### PR TITLE
Amber16+Tesla GPU and year-month version control

### DIFF
--- a/easybuild/easyconfigs/a/Amber/Amber-16-2016.11-CrayGNU-2016.11-cuda-8.0.eb
+++ b/easybuild/easyconfigs/a/Amber/Amber-16-2016.11-CrayGNU-2016.11-cuda-8.0.eb
@@ -1,0 +1,52 @@
+# @author: karakasv gppezzi
+# @author: victor holanda rusu
+
+easyblock = 'MakeCp'
+
+name = 'Amber'
+version = '16-2016.11'
+cudaversion = '8.0'
+versionsuffix = '-cuda-%s' % cudaversion
+amberversion = '16'
+
+homepage = 'http://ambermd.org/'
+description = 'Assisted Model Building with Energy Refinement'
+
+toolchain = {'name': 'CrayGNU', 'version': '2016.11'}
+toolchainopts = { 'verbose' : False }
+#sources = ['Amber%(version)s.tar.bz2', 'AmberTools%(version)s.tar.bz2']
+sources = ['Amber%(version)s.tar.bz2']
+
+dependencies = [ ('bzip2', '1.0.6'),
+                 ('zlib', '1.2.8') ]
+
+builddependencies = [
+    ('cudatoolkit/8.0.44_GA_2.2.7_g4a6c213-2.1', EXTERNAL_MODULE),
+    ('cray-hdf5/1.10.0', EXTERNAL_MODULE),
+    ('cray-netcdf/4.4.1', EXTERNAL_MODULE),
+    ('flex', '2.6.0'),
+]
+
+buildininstalldir = True
+
+configopts = 'gnu'
+
+prebuildopts = 'cd .. && mv amber%s/* . && ' % amberversion
+prebuildopts += 'export AMBERHOME=%(builddir)s; export CUDA_HOME=$CUDATOOLKIT_HOME;'
+prebuildopts += './configure -mpi -cuda -noX11 -crayxt5 --skip-python --with-netcdf $EBROOTNETCDF gnu;'
+prebuildopts += "echo 'PMEMD_CU_INCLUDES += -I$(MPICH_DIR)/include' >> config.h;"
+
+buildopts = 'install'
+
+files_to_copy = []
+
+sanity_check_paths = {
+    'files' : [ 'bin/pmemd.cuda.MPI' ],
+    'dirs'  : [],
+}
+
+modextravars = {
+    'AMBERHOME' : '%(builddir)s',
+}
+
+moduleclass = 'bio'

--- a/easybuild/easyconfigs/a/Amber/Amber-16-2016.11-CrayGNU-2016.11-cuda-8.0.eb
+++ b/easybuild/easyconfigs/a/Amber/Amber-16-2016.11-CrayGNU-2016.11-cuda-8.0.eb
@@ -33,6 +33,13 @@ configopts = 'gnu'
 
 prebuildopts = 'cd .. && mv amber%s/* . && ' % amberversion
 prebuildopts += 'export AMBERHOME=%(builddir)s; export CUDA_HOME=$CUDATOOLKIT_HOME;'
+# Patching from David Case should be applied after updating
+# updating
+#prebuildopts += './update_amber --update && '
+# applying patch to Amber
+#prebuildopts += 'patch -p0 < update.6 && '
+# applying patch to AmberTools
+#prebuildopts += 'patch -p0 < update.20 && '
 prebuildopts += './configure -mpi -cuda -noX11 -crayxt5 --skip-python --with-netcdf $EBROOTNETCDF gnu;'
 prebuildopts += "echo 'PMEMD_CU_INCLUDES += -I$(MPICH_DIR)/include' >> config.h;"
 

--- a/easybuild/easyconfigs/a/Amber/Amber-16-2016.11-CrayGNU-2016.11-parallel.eb
+++ b/easybuild/easyconfigs/a/Amber/Amber-16-2016.11-CrayGNU-2016.11-parallel.eb
@@ -1,0 +1,50 @@
+# @author: karakasv gppezzi
+# @author: victor holanda rusu
+
+easyblock = 'MakeCp'
+
+name = 'Amber'
+version = '16-2016.11'
+versionsuffix = '-parallel'
+amberversion = '16'
+
+homepage = 'http://ambermd.org/'
+description = 'Assisted Model Building with Energy Refinement'
+
+toolchain = {'name': 'CrayGNU', 'version': '2016.11'}
+toolchainopts = { 'verbose' : False }
+#sources = ['Amber%(version)s.tar.bz2', 'AmberTools%(version)s.tar.bz2']
+sources = ['Amber%(version)s.tar.bz2']
+
+dependencies = [ ('bzip2', '1.0.6'),
+                 ('zlib', '1.2.8') ]
+
+builddependencies = [
+    ('cray-hdf5/1.10.0', EXTERNAL_MODULE),
+    ('cray-netcdf/4.4.1', EXTERNAL_MODULE),
+    ('flex', '2.6.0'),
+]
+
+buildininstalldir = True
+
+configopts = 'gnu'
+
+prebuildopts = 'cd .. && mv amber%s/* . && ' % amberversion
+prebuildopts += 'export AMBERHOME=%(builddir)s;'
+prebuildopts += './configure -mpi -noX11 -crayxt5 --skip-python --with-netcdf $EBROOTNETCDF gnu;'
+prebuildopts += "echo 'PMEMD_CU_INCLUDES += -I$(MPICH_DIR)/include' >> config.h;"
+
+buildopts = 'install'
+
+files_to_copy = []
+
+sanity_check_paths = {
+    'files' : [ 'bin/pmemd.MPI' ],
+    'dirs'  : [],
+}
+
+modextravars = {
+    'AMBERHOME' : '%(builddir)s',
+}
+
+moduleclass = 'bio'

--- a/easybuild/easyconfigs/a/Amber/Amber-16-2016.11-CrayGNU-2016.11-parallel.eb
+++ b/easybuild/easyconfigs/a/Amber/Amber-16-2016.11-CrayGNU-2016.11-parallel.eb
@@ -31,6 +31,13 @@ configopts = 'gnu'
 
 prebuildopts = 'cd .. && mv amber%s/* . && ' % amberversion
 prebuildopts += 'export AMBERHOME=%(builddir)s;'
+# Patching from David Case should be applied after updating
+# updating
+#prebuildopts += './update_amber --update && '
+# applying patch to Amber
+#prebuildopts += 'patch -p0 < update.6 && '
+# applying patch to AmberTools
+#prebuildopts += 'patch -p0 < update.20 && '
 prebuildopts += './configure -mpi -noX11 -crayxt5 --skip-python --with-netcdf $EBROOTNETCDF gnu;'
 prebuildopts += "echo 'PMEMD_CU_INCLUDES += -I$(MPICH_DIR)/include' >> config.h;"
 

--- a/easybuild/easyconfigs/a/Amber/Amber-16-2016.11-CrayGNU-2016.11-serial.eb
+++ b/easybuild/easyconfigs/a/Amber/Amber-16-2016.11-CrayGNU-2016.11-serial.eb
@@ -33,6 +33,13 @@ configopts = 'gnu'
 
 prebuildopts = 'cd .. && mv amber%s/* . && ' % amberversion
 prebuildopts += 'export AMBERHOME=%(builddir)s;'
+# Patching from David Case should be applied after updating
+# updating
+#prebuildopts += './update_amber --update && '
+# applying patch to Amber
+#prebuildopts += 'patch -p0 < update.6 && '
+# applying patch to AmberTools
+#prebuildopts += 'patch -p0 < update.20 && '
 prebuildopts += './configure -noX11 -crayxt5 --with-netcdf $EBROOTNETCDF gnu;'
 
 buildopts = 'install'

--- a/easybuild/easyconfigs/a/Amber/Amber-16-2016.11-CrayGNU-2016.11-serial.eb
+++ b/easybuild/easyconfigs/a/Amber/Amber-16-2016.11-CrayGNU-2016.11-serial.eb
@@ -1,0 +1,51 @@
+# @author: karakasv gppezzi
+# @author: victor holanda rusu
+
+easyblock = 'MakeCp'
+
+name = 'Amber'
+version = '16-2016.11'
+versionsuffix = '-serial'
+amberversion = '16'
+
+homepage = 'http://ambermd.org/'
+description = 'Assisted Model Building with Energy Refinement'
+
+toolchain = {'name': 'CrayGNU', 'version': '2016.11'}
+toolchainopts = { 'verbose' : False }
+#sources = ['Amber%(version)s.tar.bz2', 'AmberTools%(version)s.tar.bz2']
+sources = ['Amber%(version)s.tar.bz2']
+
+dependencies = [ ('bzip2', '1.0.6'),
+                 ('zlib', '1.2.8'),
+                 ('Python', '2.7.12') ]
+
+builddependencies = [
+    ('cray-hdf5/1.10.0', EXTERNAL_MODULE),
+    ('cray-netcdf/4.4.1', EXTERNAL_MODULE),
+    ('Python', '2.7.12'),
+    ('flex', '2.6.0'),
+]
+
+buildininstalldir = True
+
+configopts = 'gnu'
+
+prebuildopts = 'cd .. && mv amber%s/* . && ' % amberversion
+prebuildopts += 'export AMBERHOME=%(builddir)s;'
+prebuildopts += './configure -noX11 -crayxt5 --with-netcdf $EBROOTNETCDF gnu;'
+
+buildopts = 'install'
+
+files_to_copy = []
+
+sanity_check_paths = {
+    'files' : [ 'bin/pmemd' ],
+    'dirs'  : [],
+}
+
+modextravars = {
+    'AMBERHOME' : '%(builddir)s',
+}
+
+moduleclass = 'bio'

--- a/jenkins-builds/6.0.UP02-2016.11-gpu
+++ b/jenkins-builds/6.0.UP02-2016.11-gpu
@@ -1,5 +1,5 @@
- Amber-14-CrayGNU-2016.11-serial.eb
- Amber-14-CrayGNU-2016.11-parallel.eb
+ Amber-16-2016.11-CrayGNU-2016.11-serial.eb
+ Amber-16-2016.11-CrayGNU-2016.11-cuda-8.0.eb
  Boost-1.61.0-CrayGNU-2016.11-Python-2.7.12.eb
  CDO-1.7.2-CrayGNU-2016.11.eb
  CMake-3.6.0.eb

--- a/jenkins-builds/6.0.UP02-2016.11-mc
+++ b/jenkins-builds/6.0.UP02-2016.11-mc
@@ -1,5 +1,7 @@
  Amber-14-CrayGNU-2016.11-serial.eb
  Amber-14-CrayGNU-2016.11-parallel.eb
+ Amber-16-2016.11-CrayGNU-2016.11-serial.eb
+ Amber-16-2016.11-CrayGNU-2016.11-parallel.eb
  Boost-1.61.0-CrayGNU-2016.11-Python-2.7.12.eb
  CDO-1.7.2-CrayGNU-2016.11.eb
  CMake-3.6.0.eb


### PR DESCRIPTION
This version contains two specific patches provided by David Case
in order to run Amber16 using Tesla Pascal GPUs.

In order to guarantee consistency among the GPU and CPU versions
the year-month was added to all versions. In the future Amber16
will contain these patches and this specific build should no
longer be needed.

Probably a year-month version control won't be needed as well.
Still it is hard to know which Amber and AmberTools patches were
applied.