### PR TITLE
Adding Easybuild module

### DIFF
--- a/easybuild/easybuild.d/system_wide.cfg
+++ b/easybuild/easybuild.d/system_wide.cfg
@@ -1,0 +1,3 @@
+[override]
+# Comma separated list of dependencies that you want automatically hidden, (e.g. --hide-deps=zlib,ncurses) (type comma-separated list)
+hide-deps="Bison,Doxygen,JasPer,NASM,SQLite,Szip,Tcl,bzip2,cURL,flex,freetype,libjpeg-turbo,libpng,libreadline,libtool,libxml2,ncurses,zlib,M4,Serf,APR,APR-util,expat,SCons,binutils,Coreutils,GLib,Qt,SCOTCH,Tk,hwloc,libffi,libunwind,make,numactl,pkg-config,gettext,Autotools,Automake,Autoconf,OPARI2,OTF2,UDUNITS,ZeroMQ,OpenPGM,util-linux,libsodium,libQGLViewer,Eigen,GTS,GL2PS,PyGTS,PyQt,IPython,Python-Xlib,LOKI,SIP,NASM,PIL,libjpeg-turbo,libxcb,libX11,libXau,xproto,kbproto,inputproto,libpthread-stubs,xextproto,libXdmcp,xcb-proto,xtrans,LibTIFF,byacc,guile,libunistring,CMake,PCRE,XZ,PROJ,libutempter,libevent" 

--- a/easybuild/easyconfigs/e/EasyBuild-cscs-default.eb
+++ b/easybuild/easyconfigs/e/EasyBuild-cscs-default.eb
@@ -1,21 +1,14 @@
-#%Module
-proc ModulesHelp { } {
-    puts stderr { EasyBuild is a software build and installation framework
-written in Python that allows you to install software in a structured,
-repeatable and robust way. - Homepage: http://hpcugent.github.com/easybuild/
-    }
-}
+easyblock = 'Bundle'
 
-module-whatis {Description: EasyBuild is a software build and installation framework
-written in Python that allows you to install software in a structured,
-repeatable and robust way. - Homepage: http://hpcugent.github.com/easybuild/}
+name = 'EasyBuild-cscs'
+version = 'default'
 
+homepage = 'https://github.com/eth-cscs/production/wiki/User-instructions-for-EasyBuild'
+description = """Production EasyBuild @ CSCS """
 
-#
-# Conflicts
-#
-conflict EasyBuild-cscs
+toolchain = {'name': 'dummy', 'version': 'dummy'}
 
+modtclfooter = """
 ###############################
 # SYSTEM INDEPENDENT SETTINGS #
 ###############################
@@ -107,3 +100,8 @@ prepend-path MODULEPATH                     $::env(EB_CUSTOM_PREFIX)/modules/all
 
 # Loading easybuild module
 module load /apps/common/UES/easybuild/modules/all/EasyBuild/latest
+"""
+
+moduleclass = 'devel'
+
+

--- a/easybuild/easyconfigs/e/EasyBuild-custom/EasyBuild-custom-cscs.eb
+++ b/easybuild/easyconfigs/e/EasyBuild-custom/EasyBuild-custom-cscs.eb
@@ -1,7 +1,7 @@
 easyblock = 'Bundle'
 
-name = 'EasyBuild-cscs'
-version = 'default'
+name = 'EasyBuild-custom'
+version = 'cscs'
 
 homepage = 'https://github.com/eth-cscs/production/wiki/User-instructions-for-EasyBuild'
 description = """Production EasyBuild @ CSCS """

--- a/easybuild/module/Easybuild
+++ b/easybuild/module/Easybuild
@@ -1,0 +1,107 @@
+#%Module
+proc ModulesHelp { } {
+    puts stderr { EasyBuild is a software build and installation framework
+written in Python that allows you to install software in a structured,
+repeatable and robust way. - Homepage: http://hpcugent.github.com/easybuild/
+    }
+}
+
+module-whatis {Description: EasyBuild is a software build and installation framework
+written in Python that allows you to install software in a structured,
+repeatable and robust way. - Homepage: http://hpcugent.github.com/easybuild/}
+
+
+#
+# Conflicts
+#
+conflict EasyBuild-cscs
+
+###############################
+# SYSTEM INDEPENDENT SETTINGS #
+###############################
+
+# Local variables
+set ebmodule               /apps/common/UES/easybuild/software/EasyBuild/latest
+set eb_config_dir          /apps/daint/UES/jenkins/daint101/workspace/ProductionEBDaint-gpu/label/daint/easybuild
+
+#
+# EB_CUSTOM_REPOSITORY
+# the following variables should depend on it
+#
+# EASYBUILD_ROBOT_PATHS
+# EASYBUILD_INCLUDE_EASYBLOCKS
+# EASYBUILD_EXTERNAL_MODULES_METADATA (if on cray)
+#
+if { ! [info exists ::env(EB_CUSTOM_REPOSITORY) ] } {
+    setenv EB_CUSTOM_REPOSITORY $eb_config_dir
+}
+setenv EASYBUILD_ROBOT_PATHS                $::env(EB_CUSTOM_REPOSITORY)/easyconfigs/:
+setenv EASYBUILD_INCLUDE_EASYBLOCKS         $::env(EB_CUSTOM_REPOSITORY)/easyblocks/*.py
+
+# Specific cray configurations
+if { [info exists ::env(CRAYPE_VERSION) ] } {
+    setenv EASYBUILD_EXTERNAL_MODULES_METADATA  $::env(EB_CUSTOM_REPOSITORY)/cray_external_modules_metadata.cfg
+    setenv EASYBUILD_OPTARCH                    $::env(CRAY_CPU_TARGET)
+    setenv EASYBUILD_RECURSIVE_MODULE_UNLOAD 0
+} else {
+    setenv EASYBUILD_RECURSIVE_MODULE_UNLOAD 1
+}
+
+# Checking if we have the command modulecmd
+# If so, then module is a c version
+# if not then module is a tcl version
+set status [catch {exec which modulecmd} [list result]]
+if { $status == 0 } {
+    setenv EASYBUILD_MODULES_TOOL EnvironmentModulesC
+} else {
+    setenv EASYBUILD_MODULES_TOOL EnvironmentModulesTcl
+}
+
+#############################
+# SYSTEM DEPENDENT SETTINGS #
+#############################
+
+# hostname
+set host_machine [regsub -all {[0-9]} $::env(HOSTNAME) ""]
+# removing any possible '-' at the end of the $host_machine
+set host_machine [regsub -all {[-]$} $host_machine ""]
+
+#
+# EB_CUSTOM_PREFIX
+# the following variables should depend on it
+#
+# EASYBUILD_PREFIX    
+# EASYBUILD_BUILDPATH 
+# EASYBUILD_TMPDIR    
+# EASYBUILD_TMP_LOGDIR
+# EASYBUILD_INSTALLPATH
+#
+if { ! [info exists ::env(EB_CUSTOM_PREFIX) ] } {
+    setenv EB_CUSTOM_PREFIX $::env(HOME)/easybuild/$host_machine
+}
+setenv EASYBUILD_PREFIX            $::env(EB_CUSTOM_PREFIX)
+setenv EASYBUILD_BUILDPATH         $::env(EB_CUSTOM_PREFIX)/build
+setenv EASYBUILD_TMPDIR            $::env(EB_CUSTOM_PREFIX)/tmp
+setenv EASYBUILD_TMP_LOGDIR        $::env(EB_CUSTOM_PREFIX)/log
+setenv EASYBUILD_INSTALLPATH       $::env(EB_CUSTOM_PREFIX)
+
+###############
+# FINAL TOUCH #
+###############
+
+#
+# the following variables should depend on $HOME
+#
+# EASYBUILD_SOURCEPATH
+#
+if { [file writable "/apps/common/easybuild/sources" ] } {
+    setenv EASYBUILD_SOURCEPATH /apps/common/easybuild/sources
+} else {
+    setenv EASYBUILD_SOURCEPATH $::env(HOME)/sources
+}
+
+# Adding easybuild installed softwares to the list of modules
+prepend-path MODULEPATH                     $::env(EB_CUSTOM_PREFIX)/easybuild/modules/all
+
+# Loading easybuild module
+module load /apps/common/UES/easybuild/modules/all/EasyBuild/latest

--- a/jenkins-builds/6.0.UP02-2016.11-gpu
+++ b/jenkins-builds/6.0.UP02-2016.11-gpu
@@ -5,6 +5,7 @@
  CMake-3.6.0.eb
  CP2K-4.1-CrayGNU-2016.11-cuda-8.0.eb
  CPMD-4.1-CrayIntel-2016.11.eb
+ EasyBuild-custom-cscs.eb 
  GROMACS-5.1.4-CrayGNU-2016.11-cuda-8.0.eb
  GSL-2.1-CrayGNU-2016.11.eb
  LAMMPS-30Jul16-CrayGNU-2016.11-cuda-8.0.eb


### PR DESCRIPTION
This easybuild module should replace the setup.sh script

The module depends on two environment variables:
EB_CUSTOM_REPOSITORY
EB_CUSTOM_PREFIX

EB_CUSTOM_REPOSITORY defines the position of this repository. If
not set before module load, then by default the jenkins repository
is used. One can use this variable to point to private clones of
this repository.

The following easybuild variables depend on it
EASYBUILD_ROBOT_PATHS
EASYBUILD_INCLUDE_EASYBLOCKS
EASYBUILD_EXTERNAL_MODULES_METADATA (if on cray)

EB_CUSTOM_PREFIX defines the installation directory. This variable
sets the EASYBUILD_PREFIX variable. If not set before module load,
then by default it points to $HOME/easybuild/$host_machine, where
host_machine is filtered version of $HOSTNAME.

The following easybuild variables depend on it
EASYBUILD_PREFIX
EASYBUILD_BUILDPATH
EASYBUILD_TMPDIR
EASYBUILD_TMP_LOGDIR
EASYBUILD_INSTALLPATH

Additionaly the folder $EB_CUSTOM_PREFIX/easybuild/modules/all
is prepended to the MODULEPATH variable.

By unloading the module the EB_CUSTOM_REPOSITORY and EB_CUSTOM_PREFIX
variables are *NOT* unset.