### PR TITLE
Improved EasyBuild-custom and production scripts

### DIFF
--- a/easybuild/easyconfigs/e/EasyBuild-custom/EasyBuild-custom-cscs.eb
+++ b/easybuild/easyconfigs/e/EasyBuild-custom/EasyBuild-custom-cscs.eb
@@ -66,19 +66,24 @@ set host_machine [regsub -all {[-]$} $host_machine ""]
 # the following variables should depend on it
 #
 # EASYBUILD_PREFIX    
-# EASYBUILD_BUILDPATH 
-# EASYBUILD_TMPDIR    
-# EASYBUILD_TMP_LOGDIR
 # EASYBUILD_INSTALLPATH
 #
 if { ! [info exists ::env(EB_CUSTOM_PREFIX) ] } {
-    setenv EB_CUSTOM_PREFIX $::env(HOME)/easybuild/$host_machine
+    setenv EB_CUSTOM_PREFIX $::env(HOME)/easybuild/$host_machine/$::env(CRAY_CPU_TARGET)
+    setenv EASYBUILD_INSTALLPATH       $::env(EB_CUSTOM_PREFIX)
+} else {
+    setenv EASYBUILD_INSTALLPATH       $::env(EB_CUSTOM_PREFIX)/easybuild
 }
 setenv EASYBUILD_PREFIX            $::env(EB_CUSTOM_PREFIX)
-setenv EASYBUILD_BUILDPATH         $::env(EB_CUSTOM_PREFIX)/build
-setenv EASYBUILD_TMPDIR            $::env(EB_CUSTOM_PREFIX)/tmp
-setenv EASYBUILD_TMP_LOGDIR        $::env(EB_CUSTOM_PREFIX)/log
-setenv EASYBUILD_INSTALLPATH       $::env(EB_CUSTOM_PREFIX)
+
+#
+# These variables are set to /dev/shm/$USER/easbuild/stage
+#
+# EASYBUILD_BUILDPATH 
+# EASYBUILD_TMPDIR    
+#
+setenv EASYBUILD_TMPDIR            /dev/shm/$::env(USER)/easybuild/stage/tmp
+setenv EASYBUILD_BUILDPATH         /dev/shm/$::env(USER)/easybuild/stage/build
 
 ###############
 # FINAL TOUCH #
@@ -96,7 +101,7 @@ if { [file writable "/apps/common/easybuild/sources" ] } {
 }
 
 # Adding easybuild installed softwares to the list of modules
-prepend-path MODULEPATH                     $::env(EB_CUSTOM_PREFIX)/modules/all
+prepend-path MODULEPATH                     $::env(EASYBUILD_INSTALLPATH)/modules/all
 
 # Loading easybuild module
 module load /apps/common/UES/easybuild/modules/all/EasyBuild/latest

--- a/easybuild/module/Easybuild
+++ b/easybuild/module/Easybuild
@@ -75,17 +75,23 @@ set host_machine [regsub -all {[-]$} $host_machine ""]
 # EASYBUILD_PREFIX    
 # EASYBUILD_BUILDPATH 
 # EASYBUILD_TMPDIR    
-# EASYBUILD_TMP_LOGDIR
 # EASYBUILD_INSTALLPATH
 #
 if { ! [info exists ::env(EB_CUSTOM_PREFIX) ] } {
-    setenv EB_CUSTOM_PREFIX $::env(HOME)/easybuild/$host_machine
+    setenv EB_CUSTOM_PREFIX $::env(HOME)/easybuild/$host_machine/$::env(CRAY_CPU_TARGET)
+    setenv EASYBUILD_INSTALLPATH       $::env(EB_CUSTOM_PREFIX)
+} else {
+    setenv EASYBUILD_INSTALLPATH       $::env(EB_CUSTOM_PREFIX)/easybuild
 }
 setenv EASYBUILD_PREFIX            $::env(EB_CUSTOM_PREFIX)
-setenv EASYBUILD_BUILDPATH         $::env(EB_CUSTOM_PREFIX)/build
-setenv EASYBUILD_TMPDIR            $::env(EB_CUSTOM_PREFIX)/tmp
-setenv EASYBUILD_TMP_LOGDIR        $::env(EB_CUSTOM_PREFIX)/log
-setenv EASYBUILD_INSTALLPATH       $::env(EB_CUSTOM_PREFIX)
+
+#
+# These variables are set to /dev/shm/$USER/easbuild/stage
+#
+# EASYBUILD_BUILDPATH 
+# EASYBUILD_TMPDIR    
+setenv EASYBUILD_TMPDIR            /dev/shm/$::env(USER)/easybuild/stage/tmp
+setenv EASYBUILD_BUILDPATH         /dev/shm/$::env(USER)/easybuild/stage/build
 
 ###############
 # FINAL TOUCH #
@@ -103,7 +109,7 @@ if { [file writable "/apps/common/easybuild/sources" ] } {
 }
 
 # Adding easybuild installed softwares to the list of modules
-prepend-path MODULEPATH                     $::env(EB_CUSTOM_PREFIX)/modules/all
+prepend-path MODULEPATH                     $::env(EASYBUILD_INSTALLPATH)/modules/all
 
 # Loading easybuild module
 module load /apps/common/UES/easybuild/modules/all/EasyBuild/latest

--- a/jenkins-builds/production_builds-dom.sh
+++ b/jenkins-builds/production_builds-dom.sh
@@ -22,8 +22,18 @@ module load daint-$ARCH
 echo -e "\n Loading modules: \n - module load daint-$ARCH"
 
 # EasyBuild setup
-echo -e "\n EasyBuild setup: \n source $PWD/easybuild/setup.sh $APPS/UES/jenkins/$OS/$ARCH $PWD"
-source $PWD/easybuild/setup.sh $APPS/UES/jenkins/$OS/$ARCH $PWD
+export EB_CUSTOM_PREFIX=$APPS/UES/jenkins/$OS/$ARCH
+export EB_CUSTOM_REPOSITORY=$PWD/easybuild
+module use easybuild/module
+module load EasyBuild
+echo -e "\n Easybuild setup:"
+echo -e " - EB_CUSTOM_PREFIX=$EB_CUSTOM_PREFIX"
+echo -e " - EB_CUSTOM_REPOSITORY=$EB_CUSTOM_REPOSITORY"
+echo -e " - module load EasyBuild-custom/cscs"
+
+echo -e "\n Easybuild configuration:"
+echo -e " - eb --show-config"
+eb --show-config
 
 # start time
 echo -e "\n Builds started on $(date)"

--- a/jenkins-builds/production_builds.sh
+++ b/jenkins-builds/production_builds.sh
@@ -22,8 +22,18 @@ module load daint-$ARCH
 echo -e "\n Loading modules: \n - module load daint-$ARCH"
 
 # EasyBuild setup
-echo -e "\n EasyBuild setup: \n source $PWD/easybuild/setup.sh $APPS/UES/jenkins/$OS/$ARCH $PWD"
-source $PWD/easybuild/setup.sh $APPS/UES/jenkins/$OS/$ARCH $PWD
+export EB_CUSTOM_PREFIX=$APPS/UES/jenkins/$OS/$ARCH
+export EB_CUSTOM_REPOSITORY=$PWD/easybuild
+module use easybuild/module
+module load EasyBuild
+echo -e "\n Easybuild setup:"
+echo -e " - EB_CUSTOM_PREFIX=$EB_CUSTOM_PREFIX"
+echo -e " - EB_CUSTOM_REPOSITORY=$EB_CUSTOM_REPOSITORY"
+echo -e " - module load EasyBuild-custom/cscs"
+
+echo -e "\n Easybuild configuration:"
+echo -e " - eb --show-config"
+eb --show-config
 
 # start time
 echo -e "\n Builds started on $(date)"


### PR DESCRIPTION
Changes to EasyBuild-Custom and EasyBuild modules

- The following variables were set to use the /dev/shm folders (improving performance)
EASYBUILD_TMPDIR            /dev/shm/$USER/easybuild/stage/tmp
EASYBUILD_BUILDPATH         /dev/shm/$USER/easybuild/stage/build

- $CRAY_CPU_TARGET added to the default user EASYBUILD installation folder.
This allows the user to know for which system he installed his own EB configfiles.
This change only affects CRAY systems.

- Removed the definition of EASYBUILD_TMP_LOGDIR. This flag definition was unnecessary.

BUGFIX:
- The MODULEPATH now depends on the EASYBUILD_INSTALLPATH variable, as it should be.

- Updated the jenkins production scripts to use the module EasyBuild.
This removes the need of `setup.sh`. Which is incompatible with the EasyBuild modules.
Now one only needs to maintain a single language to perform the EasyBuild installation.