### PR TITLE
Revert "Improved Kesch suport on Easybuild module"

### DIFF
--- a/easybuild/easybuild.d/system_wide.cfg
+++ b/easybuild/easybuild.d/system_wide.cfg
@@ -1,4 +1,4 @@
 [override]
 # Comma separated list of dependencies that you want automatically hidden, (e.g. --hide-deps=zlib,ncurses) (type comma-separated list)
 hide-deps="Bison,Doxygen,JasPer,NASM,SQLite,Szip,Tcl,bzip2,cURL,flex,freetype,libjpeg-turbo,libpng,libreadline,libtool,libxml2,ncurses,zlib,M4,Serf,APR,APR-util,expat,SCons,binutils,Coreutils,GLib,Qt,SCOTCH,Tk,hwloc,libffi,libunwind,make,numactl,pkg-config,gettext,Autotools,Automake,Autoconf,OPARI2,OTF2,UDUNITS,ZeroMQ,OpenPGM,util-linux,libsodium,libQGLViewer,Eigen,GTS,GL2PS,PyGTS,PyQt,IPython,Python-Xlib,LOKI,SIP,NASM,PIL,libjpeg-turbo,libxcb,libX11,libXau,xproto,kbproto,inputproto,libpthread-stubs,xextproto,libXdmcp,xcb-proto,xtrans,LibTIFF,byacc,guile,libunistring,CMake,PCRE,XZ,PROJ,libutempter,libevent,libiberty,SIONlib,PDT,Cube,Python-bare,"
-module-syntax=Tcl
+module-syntax=Tcl 

--- a/easybuild/easyconfigs/e/EasyBuild-custom/EasyBuild-custom-cscs.eb
+++ b/easybuild/easyconfigs/e/EasyBuild-custom/EasyBuild-custom-cscs.eb
@@ -55,19 +55,15 @@ set host_machine [regsub -all {[0-9]} $::env(HOSTNAME) ""]
 # removing any possible '-' at the end of the $host_machine
 set host_machine [regsub -all {[-]$} $host_machine ""]
 
-# CRAY specific configurations
-if { [ info exists ::env(CRAYPE_VERSION) ] } {
-    if { [ info exists ::env(CRAY_CPU_TARGET) ] } {
-        setenv EASYBUILD_OPTARCH                    $::env(CRAY_CPU_TARGET)
-    }
+# Specific cray configurations
+if { [ info exists ::env(CRAY_CPU_TARGET) ] } {
+    setenv EASYBUILD_EXTERNAL_MODULES_METADATA  $::env(EB_CUSTOM_REPOSITORY)/cray_external_modules_metadata.cfg
+    setenv EASYBUILD_OPTARCH                    $::env(CRAY_CPU_TARGET)
 
     setenv EASYBUILD_RECURSIVE_MODULE_UNLOAD    0
 } else {
     setenv EASYBUILD_RECURSIVE_MODULE_UNLOAD    1
 }
-
-# Map to system modules
-setenv EASYBUILD_EXTERNAL_MODULES_METADATA  $::env(EB_CUSTOM_REPOSITORY)/cray_external_modules_metadata.cfg
 
 #
 # EASYBUILD_PREFIX

--- a/easybuild/module/Easybuild
+++ b/easybuild/module/Easybuild
@@ -62,19 +62,15 @@ set host_machine [regsub -all {[0-9]} $::env(HOSTNAME) ""]
 # removing any possible '-' at the end of the $host_machine
 set host_machine [regsub -all {[-]$} $host_machine ""]
 
-# CRAY specific configurations
-if { [ info exists ::env(CRAYPE_VERSION) ] } {
-    if { [ info exists ::env(CRAY_CPU_TARGET) ] } {
-        setenv EASYBUILD_OPTARCH                    $::env(CRAY_CPU_TARGET)
-    }
+# Specific cray configurations
+if { [ info exists ::env(CRAY_CPU_TARGET) ] } {
+    setenv EASYBUILD_EXTERNAL_MODULES_METADATA  $::env(EB_CUSTOM_REPOSITORY)/cray_external_modules_metadata.cfg
+    setenv EASYBUILD_OPTARCH                    $::env(CRAY_CPU_TARGET)
 
     setenv EASYBUILD_RECURSIVE_MODULE_UNLOAD    0
 } else {
     setenv EASYBUILD_RECURSIVE_MODULE_UNLOAD    1
 }
-
-# Map to system modules
-setenv EASYBUILD_EXTERNAL_MODULES_METADATA  $::env(EB_CUSTOM_REPOSITORY)/cray_external_modules_metadata.cfg
 
 #
 # EASYBUILD_PREFIX


### PR DESCRIPTION
This broke our setup on daint, since we unload PrgEnv-cray before our builds. 

@victorusu maybe we should use the hostname for testing if we're on kesch/escha.