### PR TITLE
EasyBuild configuration file for CP2K-4.1 with perftools-lite/6.4.3

### DIFF
--- a/easybuild/easyconfigs/c/CP2K/CP2K-4.1-CrayGNU-2016.11-pat-6.4.3.eb
+++ b/easybuild/easyconfigs/c/CP2K/CP2K-4.1-CrayGNU-2016.11-pat-6.4.3.eb
@@ -1,0 +1,55 @@
+# contributed by Luca Marsella (CSCS)
+easyblock = 'MakeCp'
+
+name = 'CP2K'
+version = "4.1"
+patversion = "6.4.3"
+
+versionsuffix = '-pat-%s' %patversion
+
+homepage = 'http://www.cp2k.org/'
+description = """CP2K is a freely available (GPL) program, written in Fortran 95, to perform atomistic and molecular
+ simulations of solid state, liquid, molecular and biological systems. It provides a general framework for different
+ methods such as e.g. density functional theory (DFT) using a mixed Gaussian and plane waves approach (GPW), and
+ classical pair and many-body potentials. """
+
+toolchain = {'name': 'CrayGNU', 'version': '2016.11'}
+toolchainopts = { 'usempi': True, 'openmp': True }
+
+sources = [SOURCELOWER_TAR_BZ2]
+source_urls = [SOURCEFORGE_SOURCE]
+
+dependencies = [
+    ('Libint', '1.1.4'),
+    ('libxc', '3.0.0'),
+]
+
+builddependencies = [
+    ('perftools-lite/%s' %patversion, EXTERNAL_MODULE),
+    ('fftw/3.3.4.10', EXTERNAL_MODULE),
+    ('Python', '2.7.12'),
+    ('flex', '2.6.0'),
+    ('Bison', '3.0.4'),
+]
+
+# add define flags
+prebuildopts = " sed -i -e 's/^DFLAGS .*/& -D__FFTSG -D__LIBINT -D__LIBXC -D__GFORTRAN/' ./arch/CRAY-XC30-gfortran.psmp && "
+# add includes
+prebuildopts += " sed -i -e 's#-ffree-form .*#& -I$(EBROOTLIBINT)/include -I$(EBROOTLIBXC)/include#' ./arch/CRAY-XC30-gfortran.psmp && "
+# add libraries 
+prebuildopts += " sed -i -e '/LIBS    +=/a LIBS    += $(EBROOTLIBINT)/lib/libderiv.a $(EBROOTLIBINT)/lib/libint.a $(EBROOTLIBINT)/lib/libr12.a -lstdc++ -L$(EBROOTLIBXC)/lib -lxcf90 -lxc' ./arch/CRAY-XC30-gfortran.psmp && "
+# correct link to libsmm to match Intel Haswell architecture (no Broadwell architecture available right now)
+prebuildopts += " sed -i -e 's/sandybridge_gcc_4.9.0/haswell/' ./arch/CRAY-XC30-gfortran.psmp && "
+prebuildopts += " pushd makefiles && "
+
+# build type
+buildopts = 'ARCH=CRAY-XC30-gfortran VERSION=psmp'
+ 
+files_to_copy = [(['./exe/CRAY-XC30-gfortran/cp2k.psmp'],'bin')]
+
+sanity_check_paths = {
+    'files': ['bin/cp2k.psmp'],
+    'dirs': [],
+}
+
+moduleclass = 'chem'


### PR DESCRIPTION
perftools-lite/6.4.3 produces an instrumented executable that gives a report on the multicore portion of the system only (report on the gpu portion of the system is work in progress, see Cray bug #845303/case #150425 - perftools6.4.2 Segmentation fault)