### PR TITLE
WIP: Perftools-lite with Amber, GROMACS and LAMMPS

### DIFF
--- a/easybuild/easyconfigs/a/Amber/Amber-16-2016.11-CrayGNU-2016.11-cuda-8.0-craypat-6.4.3.eb
+++ b/easybuild/easyconfigs/a/Amber/Amber-16-2016.11-CrayGNU-2016.11-cuda-8.0-craypat-6.4.3.eb
@@ -9,7 +9,7 @@ easyblock = 'MakeCp'
 name = 'Amber'
 version = '16-2016.11'
 cudaversion = '8.0'
-craypatversion = '6.4.3'
+craypatversion = '643'
 versionsuffix = '-cuda-%s-craypat-%s' % (cudaversion, craypatversion)
 amberversion = '16'
 
@@ -25,7 +25,7 @@ dependencies = [ ('bzip2', '1.0.6'),
                  ('zlib', '1.2.8') ]
 
 builddependencies = [
-    ('perftools-cscs', '643cuda'),
+    ('perftools-cscs', '%scuda' %craypatversion, '', True),
     ('cudatoolkit/8.0.44_GA_2.2.7_g4a6c213-2.1', EXTERNAL_MODULE),
     ('cray-hdf5/1.10.0', EXTERNAL_MODULE),
     ('cray-netcdf/4.4.1', EXTERNAL_MODULE),

--- a/easybuild/easyconfigs/a/Amber/Amber-16-2016.11-CrayGNU-2016.11-cuda-8.0-craypat-6.4.3.eb
+++ b/easybuild/easyconfigs/a/Amber/Amber-16-2016.11-CrayGNU-2016.11-cuda-8.0-craypat-6.4.3.eb
@@ -1,0 +1,81 @@
+# Contributed by
+# Vasileios Karakasisi - karakasv (CSCS)
+# Guilherme Peretti-Pezzi - gppezzi(CSCS)
+# Victor Holanda Rusu - victorusu (CSCS)
+# @author: karakasv gppezzi victorusu
+
+easyblock = 'MakeCp'
+
+name = 'Amber'
+version = '16-2016.11'
+cudaversion = '8.0'
+craypatversion = '6.4.3'
+versionsuffix = '-cuda-%s-craypat-%s' % (cudaversion, craypatversion)
+amberversion = '16'
+
+homepage = 'http://ambermd.org/'
+description = 'Assisted Model Building with Energy Refinement'
+
+toolchain = {'name': 'CrayGNU', 'version': '2016.11'}
+toolchainopts = { 'verbose' : False }
+#sources = ['Amber%(version)s.tar.bz2', 'AmberTools%(version)s.tar.bz2']
+sources = ['Amber%(version)s.tar.bz2']
+
+dependencies = [ ('bzip2', '1.0.6'),
+                 ('zlib', '1.2.8') ]
+
+builddependencies = [
+    ('perftools-cscs', '643cuda'),
+    ('cudatoolkit/8.0.44_GA_2.2.7_g4a6c213-2.1', EXTERNAL_MODULE),
+    ('cray-hdf5/1.10.0', EXTERNAL_MODULE),
+    ('cray-netcdf/4.4.1', EXTERNAL_MODULE),
+    ('flex', '2.6.0'),
+]
+
+buildininstalldir = True
+
+configopts = 'gnu'
+
+prebuildopts = 'cd .. && mv amber%s/* . && ' % amberversion
+prebuildopts += 'export AMBERHOME=%(builddir)s; export CUDA_HOME=$CUDATOOLKIT_HOME;'
+#
+# Disabling perftools-lite
+#
+prebuildopts += "export PE_PRODUCT_LIST=$(echo $PE_PRODUCT_LIST | sed -e 's/:PERFTOOLS//'); "
+prebuildopts += "export PE_PRODUCT_LIST=$(echo $PE_PRODUCT_LIST | sed -e 's/:CRAYPAT//'); "
+prebuildopts += "unset CRAYPAT_COMPILER_OPTIONS; "
+prebuildopts += "unset CRAYPAT_LITE; "
+#
+# Patching from David Case should be applied after updating
+# updating
+#prebuildopts += './update_amber --update && '
+# applying patch to Amber
+#prebuildopts += 'patch -p0 < update.6 && '
+# applying patch to AmberTools
+#prebuildopts += 'patch -p0 < update.20 && '
+prebuildopts += './configure -mpi -cuda -noX11 -crayxt5 --skip-python --with-netcdf $EBROOTNETCDF gnu;'
+#
+# Enabling perftools-lite
+#
+prebuildopts += "export PE_PRODUCT_LIST=$PE_PRODUCT_LIST:PERFTOOLS:CRAYPAT ; "
+prebuildopts += "export CRAYPAT_COMPILER_OPTIONS=1 ; "
+prebuildopts += "export CRAYPAT_LITE=sample_profile ; "
+#
+# Ready to continue
+#
+prebuildopts += "echo 'PMEMD_CU_INCLUDES += -I$(MPICH_DIR)/include' >> config.h;"
+
+buildopts = 'install'
+
+files_to_copy = []
+
+sanity_check_paths = {
+    'files' : [ 'bin/pmemd.cuda.MPI' ],
+    'dirs'  : [],
+}
+
+modextravars = {
+    'AMBERHOME' : '%(builddir)s',
+}
+
+moduleclass = 'bio'

--- a/easybuild/easyconfigs/a/Amber/Amber-16-2016.11-CrayGNU-2016.11-parallel-craypat-6.4.3.eb
+++ b/easybuild/easyconfigs/a/Amber/Amber-16-2016.11-CrayGNU-2016.11-parallel-craypat-6.4.3.eb
@@ -8,7 +8,7 @@ easyblock = 'MakeCp'
 
 name = 'Amber'
 version = '16-2016.11'
-craypatversion = '6.4.3'
+craypatversion = '643'
 versionsuffix = '-parallel-craypat-%s' % craypatversion
 amberversion = '16'
 
@@ -24,7 +24,7 @@ dependencies = [ ('bzip2', '1.0.6'),
                  ('zlib', '1.2.8') ]
 
 builddependencies = [
-    ('perftools-cscs', '643nogpu'),
+    ('perftools-cscs', '%snogpu' %craypatversion, '', True),
     ('cray-hdf5/1.10.0', EXTERNAL_MODULE),
     ('cray-netcdf/4.4.1', EXTERNAL_MODULE),
     ('flex', '2.6.0'),

--- a/easybuild/easyconfigs/a/Amber/Amber-16-2016.11-CrayGNU-2016.11-parallel-craypat-6.4.3.eb
+++ b/easybuild/easyconfigs/a/Amber/Amber-16-2016.11-CrayGNU-2016.11-parallel-craypat-6.4.3.eb
@@ -1,0 +1,71 @@
+# @author: karakasv gppezzi victorusu
+
+easyblock = 'MakeCp'
+
+name = 'Amber'
+version = '16-2016.11'
+craypatversion = '6.4.3'
+versionsuffix = '-parallel-craypat-%s' % craypatversion
+amberversion = '16'
+
+homepage = 'http://ambermd.org/'
+description = 'Assisted Model Building with Energy Refinement'
+
+toolchain = {'name': 'CrayGNU', 'version': '2016.11'}
+toolchainopts = { 'verbose' : False }
+#sources = ['Amber%(version)s.tar.bz2', 'AmberTools%(version)s.tar.bz2']
+sources = ['Amber%(version)s.tar.bz2']
+
+dependencies = [ ('bzip2', '1.0.6'),
+                 ('zlib', '1.2.8') ]
+
+builddependencies = [
+    ('perftools-cscs', '643nogpu'),
+    ('cray-hdf5/1.10.0', EXTERNAL_MODULE),
+    ('cray-netcdf/4.4.1', EXTERNAL_MODULE),
+    ('flex', '2.6.0'),
+]
+
+buildininstalldir = True
+
+configopts = 'gnu'
+
+prebuildopts = 'cd .. && mv amber%s/* . && ' % amberversion
+prebuildopts += 'export AMBERHOME=%(builddir)s; '
+#
+# Disabling perftools-lite
+#
+prebuildopts += "export PE_PRODUCT_LIST=$(echo $PE_PRODUCT_LIST | sed -e 's/:PERFTOOLS//'); "
+prebuildopts += "export PE_PRODUCT_LIST=$(echo $PE_PRODUCT_LIST | sed -e 's/:CRAYPAT//'); "
+prebuildopts += "unset CRAYPAT_COMPILER_OPTIONS; "
+prebuildopts += "unset CRAYPAT_LITE; "
+# Patching from David Case should be applied after updating
+# updating
+#prebuildopts += './update_amber --update && '
+# applying patch to Amber
+#prebuildopts += 'patch -p0 < update.6 && '
+# applying patch to AmberTools
+#prebuildopts += 'patch -p0 < update.20 && '
+prebuildopts += './configure -mpi -noX11 -crayxt5 --skip-python --with-netcdf $EBROOTNETCDF gnu;'
+#
+# Enabling perftools-lite
+#
+prebuildopts += "export PE_PRODUCT_LIST=$PE_PRODUCT_LIST:PERFTOOLS:CRAYPAT ; "
+prebuildopts += "export CRAYPAT_COMPILER_OPTIONS=1 ; "
+prebuildopts += "export CRAYPAT_LITE=sample_profile ; "
+prebuildopts += "echo 'PMEMD_CU_INCLUDES += -I$(MPICH_DIR)/include' >> config.h;"
+
+buildopts = 'install'
+
+files_to_copy = []
+
+sanity_check_paths = {
+    'files' : [ 'bin/pmemd.MPI' ],
+    'dirs'  : [],
+}
+
+modextravars = {
+    'AMBERHOME' : '%(builddir)s',
+}
+
+moduleclass = 'bio'

--- a/easybuild/easyconfigs/a/Amber/Amber-16-2016.11-CrayGNU-2016.11-parallel-craypat-6.4.3.eb
+++ b/easybuild/easyconfigs/a/Amber/Amber-16-2016.11-CrayGNU-2016.11-parallel-craypat-6.4.3.eb
@@ -1,3 +1,7 @@
+# Contributed by
+# Vasileios Karakasisi - karakasv (CSCS)
+# Guilherme Peretti-Pezzi - gppezzi(CSCS)
+# Victor Holanda Rusu - victorusu (CSCS)
 # @author: karakasv gppezzi victorusu
 
 easyblock = 'MakeCp'

--- a/easybuild/easyconfigs/g/GROMACS/GROMACS-5.1.4-CrayGNU-2016.11-craypat-6.4.3.eb
+++ b/easybuild/easyconfigs/g/GROMACS/GROMACS-5.1.4-CrayGNU-2016.11-craypat-6.4.3.eb
@@ -15,7 +15,7 @@
 #
 name = 'GROMACS'
 version = "5.1.4"
-craypatversion = '6.4.3'
+craypatversion = '643'
 versionsuffix = "-craypat-%s" % craypatversion
 
 homepage = 'http://www.gromacs.org'
@@ -35,7 +35,7 @@ skipsteps = ['test']
 # CMake and libxml2 dependencies with dummy toolchain
 builddependencies = [
     ('CMake', '3.6.0'),
-    ('perftools-cscs','643nogpu'),
+    ('perftools-cscs', '%snogpu' %craypatversion, '', True),
     ('fftw/3.3.4.10', EXTERNAL_MODULE),
     ('Boost', '1.61.0', '-Python-2.7.12'),
     ('libxml2', '2.9.3'),

--- a/easybuild/easyconfigs/g/GROMACS/GROMACS-5.1.4-CrayGNU-2016.11-craypat-6.4.3.eb
+++ b/easybuild/easyconfigs/g/GROMACS/GROMACS-5.1.4-CrayGNU-2016.11-craypat-6.4.3.eb
@@ -1,0 +1,44 @@
+# contributed by
+# Luca Marsella (CSCS)
+# Victor Holanda Rusu (CSCS)
+#
+# This file is an EasyBuild reciPY as per https://github.com/hpcugent/easybuild
+#
+# Copyright:: Copyright 2012-2013 University of Luxembourg / LCSB, Cyprus Institute / CaSToRC, Ghent University
+# Authors::   Wiktor Jurkowski <wiktor.jurkowski@uni.lu>, Fotis Georgatos <fotis.georgatos@uni.lu>, \
+#             George Tsouloupas <g.tsouloupas@cyi.ac.cy>, Kenneth Hoste
+# License::   MIT/GPL
+# $Id$
+#
+# This work implements a part of the HPCBIOS project and is a component of the policy:
+# http://hpcbios.readthedocs.org/en/latest/HPCBIOS_2012-93.html
+#
+name = 'GROMACS'
+version = "5.1.4"
+craypatversion = '6.4.3'
+versionsuffix = "-craypat-%s" % craypatversion
+
+homepage = 'http://www.gromacs.org'
+description = """GROMACS is a versatile package to perform molecular dynamics,
+ i.e. simulate the Newtonian equations of motion for systems with hundreds to millions of particles."""
+
+toolchain = {'name': 'CrayGNU', 'version': '2016.11'}
+toolchainopts = {'usempi': 'True', 'openmp': 'True'}
+
+source_urls = ['ftp://ftp.gromacs.org/pub/gromacs/']
+sources = [SOURCELOWER_TAR_GZ]
+
+configopts = ' -DCMAKE_C_FLAGS="-g -fopenmp" -DCMAKE_CXX_FLAGS="-g -fopenmp" '
+
+skipsteps = ['test']
+
+# CMake and libxml2 dependencies with dummy toolchain
+builddependencies = [
+    ('CMake', '3.6.0'),
+    ('perftools-cscs','643nogpu'),
+    ('fftw/3.3.4.10', EXTERNAL_MODULE),
+    ('Boost', '1.61.0', '-Python-2.7.12'),
+    ('libxml2', '2.9.3'),
+]
+
+moduleclass = 'bio'

--- a/easybuild/easyconfigs/g/GROMACS/GROMACS-5.1.4-CrayGNU-2016.11-cuda-8.0-craypat-6.4.3.eb
+++ b/easybuild/easyconfigs/g/GROMACS/GROMACS-5.1.4-CrayGNU-2016.11-cuda-8.0-craypat-6.4.3.eb
@@ -15,7 +15,7 @@
 name = 'GROMACS'
 version = "5.1.4"
 cudaversion = '8.0'
-craypatversion = '6.4.3'
+craypatversion = '643'
 versionsuffix = '-cuda-%s-craypat-%s' % (cudaversion, craypatversion)
 
 homepage = 'http://www.gromacs.org'
@@ -29,7 +29,7 @@ source_urls = ['ftp://ftp.gromacs.org/pub/gromacs/']
 sources = [SOURCELOWER_TAR_GZ]
 
 builddependencies = [
-    ('perftools-cscs', '643cuda'),
+    ('perftools-cscs', '%scuda' %craypatversion, '', True),
     ('CMake', '3.6.0'),
     ('cudatoolkit/%s.44_GA_2.2.7_g4a6c213-2.1' %cudaversion, EXTERNAL_MODULE),
     ('fftw/3.3.4.10', EXTERNAL_MODULE),

--- a/easybuild/easyconfigs/g/GROMACS/GROMACS-5.1.4-CrayGNU-2016.11-cuda-8.0-craypat-6.4.3.eb
+++ b/easybuild/easyconfigs/g/GROMACS/GROMACS-5.1.4-CrayGNU-2016.11-cuda-8.0-craypat-6.4.3.eb
@@ -1,0 +1,45 @@
+# Contributed by
+# Luca Marsella (CSCS)
+# Guilherme Peretti-Pezzi (CSCS)
+# Victor Holanda Rusu (CSCS)
+#
+# Copyright:: Copyright 2012-2013 University of Luxembourg / LCSB, Cyprus Institute / CaSToRC, Ghent University
+# Authors::   Wiktor Jurkowski <wiktor.jurkowski@uni.lu>, Fotis Georgatos <fotis.georgatos@uni.lu>, \
+#             George Tsouloupas <g.tsouloupas@cyi.ac.cy>, Kenneth Hoste
+# License::   MIT/GPL
+# $Id$
+#
+# This work implements a part of the HPCBIOS project and is a component of the policy:
+# http://hpcbios.readthedocs.org/en/latest/HPCBIOS_2012-93.html
+
+name = 'GROMACS'
+version = "5.1.4"
+cudaversion = '8.0'
+craypatversion = '6.4.3'
+versionsuffix = '-cuda-%s-craypat-%s' % (cudaversion, craypatversion)
+
+homepage = 'http://www.gromacs.org'
+description = """GROMACS is a versatile package to perform molecular dynamics,
+ i.e. simulate the Newtonian equations of motion for systems with hundreds to millions of particles."""
+
+toolchain = {'name': 'CrayGNU', 'version': '2016.11'}
+toolchainopts = {'usempi': True, 'openmp': True, 'pic': True, 'verbose': False}
+
+source_urls = ['ftp://ftp.gromacs.org/pub/gromacs/']
+sources = [SOURCELOWER_TAR_GZ]
+
+builddependencies = [
+    ('perftools-cscs', '643cuda'),
+    ('CMake', '3.6.0'),
+    ('cudatoolkit/%s.44_GA_2.2.7_g4a6c213-2.1' %cudaversion, EXTERNAL_MODULE),
+    ('fftw/3.3.4.10', EXTERNAL_MODULE),
+    ('Boost', '1.61.0', '-Python-2.7.12'),
+    ('libxml2', '2.9.3'),
+]
+
+installopts = " -j16"
+
+# skip tests as they call the MPI executable gmx_mpi and would fail on the login nodes
+runtest = False
+
+moduleclass = 'bio'

--- a/easybuild/easyconfigs/l/LAMMPS/LAMMPS-30Jul16-CrayGNU-2016.11-craypat-6.4.3.eb
+++ b/easybuild/easyconfigs/l/LAMMPS/LAMMPS-30Jul16-CrayGNU-2016.11-craypat-6.4.3.eb
@@ -6,7 +6,7 @@ easyblock = 'MakeCp'
 name = 'LAMMPS'
 version = "30Jul16"
 release = 'r15407'
-craypatversion = '6.4.3'
+craypatversion = '643'
 versionsuffix = "-craypat-%s" % craypatversion
 
 homepage = 'http://lammps.sandia.gov/'
@@ -28,7 +28,7 @@ prebuildopts += ' sed -i -e \'s/mpicxx/CC/\' ./MAKE/Makefile.mpi && '
 buildopts = [ ' mpi ', ' omp ' ]
 
 builddependencies = [
-    ('perftools-cscs', '643nogpu'),
+    ('perftools-cscs', '%snogpu' %craypatversion, '', True),
     ('fftw/3.3.4.10', EXTERNAL_MODULE),
     ('Python', '2.7.12'),
 ]

--- a/easybuild/easyconfigs/l/LAMMPS/LAMMPS-30Jul16-CrayGNU-2016.11-craypat-6.4.3.eb
+++ b/easybuild/easyconfigs/l/LAMMPS/LAMMPS-30Jul16-CrayGNU-2016.11-craypat-6.4.3.eb
@@ -1,0 +1,43 @@
+# Contributed by
+# Luca Marsella (CSCS)
+# Victor Holanda Rusu (CSCS)
+easyblock = 'MakeCp'
+
+name = 'LAMMPS'
+version = "30Jul16"
+release = 'r15407'
+craypatversion = '6.4.3'
+versionsuffix = "-craypat-%s" % craypatversion
+
+homepage = 'http://lammps.sandia.gov/'
+description = "LAMMPS (Large-scale Atomic/Molecular Massively Parallel Simulator) is a classical molecular dynamics simulation code designed to run efficiently on parallel computers."
+
+toolchain = {'name': 'CrayGNU', 'version': '2016.11'}
+toolchainopts = { 'usempi': True, 'openmp': True , 'dynamic': True }
+
+source_urls = ['https://github.com/lammps/lammps/archive']
+sources = ['%s.tar.gz' % (release)]
+
+prebuildopts = ' cd ./src && '
+prebuildopts += ' make yes-standard yes-user-reaxc yes-user-omp yes-kspace yes-misc yes-molecule yes-rigid yes-user-misc && '
+prebuildopts += ' make no-voronoi no-poems no-meam no-kim no-gpu && '
+prebuildopts += ' make package-update && '
+prebuildopts += ' pushd ../lib/reax && make -f Makefile.gfortran && popd && '
+prebuildopts += ' sed -e \'s/mpicxx/CC -fopenmp/\' ./MAKE/Makefile.mpi > ./MAKE/Makefile.omp && '
+prebuildopts += ' sed -i -e \'s/mpicxx/CC/\' ./MAKE/Makefile.mpi && '
+buildopts = [ ' mpi ', ' omp ' ]
+
+builddependencies = [
+    ('perftools-cscs', '643nogpu'),
+    ('fftw/3.3.4.10', EXTERNAL_MODULE),
+    ('Python', '2.7.12'),
+]
+
+files_to_copy = [(['src/lmp*'], "bin")]
+
+sanity_check_paths = {
+    'files': ['bin/lmp_mpi','bin/lmp_omp'],
+    'dirs': [],
+}
+
+moduleclass = 'chem'

--- a/easybuild/easyconfigs/l/LAMMPS/LAMMPS-30Jul16-CrayGNU-2016.11-cuda-8.0-craypat-6.4.3.eb
+++ b/easybuild/easyconfigs/l/LAMMPS/LAMMPS-30Jul16-CrayGNU-2016.11-cuda-8.0-craypat-6.4.3.eb
@@ -1,0 +1,50 @@
+# Contributed by
+# Luca Marsella (CSCS)
+# Victor Holanda Rusu (CSCS)
+easyblock = 'MakeCp'
+
+name = 'LAMMPS'
+version = '30Jul16'
+release = 'r15407'
+cudaversion =  '8.0'
+craypatversion = '6.4.3'
+versionsuffix = '-cuda-%s-craypat-%s' % (cudaversion, craypatversion)
+
+homepage = 'http://lammps.sandia.gov/'
+description = "LAMMPS (Large-scale Atomic/Molecular Massively Parallel Simulator) is a classical molecular dynamics simulation code designed to run efficiently on parallel computers."
+
+toolchain = {'name': 'CrayGNU', 'version': '2016.11'}
+toolchainopts = { 'usempi': True, 'openmp': True }
+
+source_urls = ['https://github.com/lammps/lammps/archive']
+sources = ['%s.tar.gz' % (release)]
+
+prebuildopts = ' cd ./src && '
+prebuildopts += ' make yes-standard yes-user-cg-cmm yes-user-omp yes-user-reaxc yes-gpu yes-kspace yes-misc yes-molecule yes-rigid yes-user-misc && '
+prebuildopts += ' make no-voronoi no-reax no-poems no-meam no-kim && '
+prebuildopts += ' make package-update && '
+# go to folder ./lib/reax and make package reax
+prebuildopts += ' pushd ../lib/reax && make -f Makefile.gfortran && popd && '
+# go to folder ./lib/gpu and create Makefile.gpu for sm_60 (the executable was failing on Pascal GPU without that)
+prebuildopts += ' pushd ../lib/gpu && sed -e "s/-march=bdver1//g" -e "s/sm_[0-9]*/sm_60/g" Makefile.xk7 > Makefile.gpu && '
+prebuildopts += ' make -f Makefile.gpu && popd && '
+# create Makefile.omp and correct Makefile.mpi
+prebuildopts += ' sed -e \'s/mpicxx/CC -fopenmp/\' ./MAKE/Makefile.mpi > ./MAKE/Makefile.omp && '
+prebuildopts += ' sed -i -e \'s/mpicxx/CC/\' ./MAKE/Makefile.mpi && '
+buildopts = [ ' mpi ', ' omp ' ]
+
+builddependencies = [
+    ('perftools-cscs', '643cuda'),
+    ('cudatoolkit/%s.44_GA_2.2.7_g4a6c213-2.1' %cudaversion, EXTERNAL_MODULE),
+    ('fftw/3.3.4.10', EXTERNAL_MODULE),
+    ('Python', '2.7.12'),
+]
+
+files_to_copy = [(['src/lmp*'], "bin")]
+
+sanity_check_paths = {
+    'files': ['bin/lmp_mpi','bin/lmp_omp'],
+    'dirs': [],
+}
+
+moduleclass = 'chem'

--- a/easybuild/easyconfigs/l/LAMMPS/LAMMPS-30Jul16-CrayGNU-2016.11-cuda-8.0-craypat-6.4.3.eb
+++ b/easybuild/easyconfigs/l/LAMMPS/LAMMPS-30Jul16-CrayGNU-2016.11-cuda-8.0-craypat-6.4.3.eb
@@ -7,7 +7,7 @@ name = 'LAMMPS'
 version = '30Jul16'
 release = 'r15407'
 cudaversion =  '8.0'
-craypatversion = '6.4.3'
+craypatversion = '643'
 versionsuffix = '-cuda-%s-craypat-%s' % (cudaversion, craypatversion)
 
 homepage = 'http://lammps.sandia.gov/'
@@ -34,7 +34,7 @@ prebuildopts += ' sed -i -e \'s/mpicxx/CC/\' ./MAKE/Makefile.mpi && '
 buildopts = [ ' mpi ', ' omp ' ]
 
 builddependencies = [
-    ('perftools-cscs', '643cuda'),
+    ('perftools-cscs', '%scuda' %craypatversion, '', True),
     ('cudatoolkit/%s.44_GA_2.2.7_g4a6c213-2.1' %cudaversion, EXTERNAL_MODULE),
     ('fftw/3.3.4.10', EXTERNAL_MODULE),
     ('Python', '2.7.12'),


### PR DESCRIPTION
This commit adds the CUDA and non-CUDA versions. Even though
not all of these options are working prorpely. GROMACS and LAMMPS
non-CUDA versions are able to produce performance analysis.
While the rest no.