### PR TITLE
fix dependency on cray defaults: added cray_ld_libpath to $LD_LIBRARY_PATH

### DIFF
--- a/easybuild/easyconfigs/a/Amber/Amber-16-2016.11-CrayGNU-2016.11-cuda-8.0.54.eb
+++ b/easybuild/easyconfigs/a/Amber/Amber-16-2016.11-CrayGNU-2016.11-cuda-8.0.54.eb
@@ -54,6 +54,8 @@ sanity_check_paths = {
 
 modextravars = {
     'AMBERHOME' : '%(builddir)s',
+    'LD_LIBRARY_PATH':'$::env(CRAY_LD_LIBRARY_PATH):$::env(LD_LIBRARY_PATH)',
+
 }
 
 moduleclass = 'bio'

--- a/easybuild/easyconfigs/a/Amber/Amber-16-2016.11-CrayGNU-2016.11-cuda-8.0.54.eb
+++ b/easybuild/easyconfigs/a/Amber/Amber-16-2016.11-CrayGNU-2016.11-cuda-8.0.54.eb
@@ -55,7 +55,6 @@ sanity_check_paths = {
 modextravars = {
     'AMBERHOME' : '%(builddir)s',
     'LD_LIBRARY_PATH':'$::env(CRAY_LD_LIBRARY_PATH):$::env(LD_LIBRARY_PATH)',
-
 }
 
 moduleclass = 'bio'

--- a/easybuild/easyconfigs/c/CP2K/CP2K-4.1-CrayGNU-2016.11-cuda-8.0.54.eb
+++ b/easybuild/easyconfigs/c/CP2K/CP2K-4.1-CrayGNU-2016.11-cuda-8.0.54.eb
@@ -51,6 +51,8 @@ buildopts = 'ARCH=CRAY-XC30-gfortran-cuda VERSION=psmp'
  
 files_to_copy = [(['./exe/CRAY-XC30-gfortran-cuda/cp2k.psmp'],'bin')]
 
+modextravars = { 'LD_LIBRARY_PATH':'$::env(CRAY_LD_LIBRARY_PATH):$::env(LD_LIBRARY_PATH)'}
+
 sanity_check_paths = {
     'files': ['bin/cp2k.psmp'],
     'dirs': [],

--- a/easybuild/easyconfigs/c/CP2K/CP2K-4.1-CrayGNU-2016.11-cuda-8.0.54.eb
+++ b/easybuild/easyconfigs/c/CP2K/CP2K-4.1-CrayGNU-2016.11-cuda-8.0.54.eb
@@ -51,8 +51,6 @@ buildopts = 'ARCH=CRAY-XC30-gfortran-cuda VERSION=psmp'
  
 files_to_copy = [(['./exe/CRAY-XC30-gfortran-cuda/cp2k.psmp'],'bin')]
 
-modextravars = { 'LD_LIBRARY_PATH':'$::env(CRAY_LD_LIBRARY_PATH):$::env(LD_LIBRARY_PATH)'}
-
 sanity_check_paths = {
     'files': ['bin/cp2k.psmp'],
     'dirs': [],

--- a/easybuild/easyconfigs/g/GROMACS/GROMACS-5.1.4-CrayGNU-2016.11-cuda-8.0.54.eb
+++ b/easybuild/easyconfigs/g/GROMACS/GROMACS-5.1.4-CrayGNU-2016.11-cuda-8.0.54.eb
@@ -39,4 +39,6 @@ installopts = " -j16"
 # skip tests as they call the MPI executable gmx_mpi and would fail on the login nodes
 runtest = False
 
+modextravars = { 'LD_LIBRARY_PATH':'$::env(CRAY_LD_LIBRARY_PATH):$::env(LD_LIBRARY_PATH)'}
+
 moduleclass = 'bio'

--- a/easybuild/easyconfigs/l/LAMMPS/LAMMPS-30Jul16-CrayGNU-2016.11-cuda-8.0.54.eb
+++ b/easybuild/easyconfigs/l/LAMMPS/LAMMPS-30Jul16-CrayGNU-2016.11-cuda-8.0.54.eb
@@ -38,6 +38,8 @@ builddependencies = [
 
 files_to_copy = [(['src/lmp*'], "bin")]
 
+modextravars = { 'LD_LIBRARY_PATH':'$::env(CRAY_LD_LIBRARY_PATH):$::env(LD_LIBRARY_PATH)'}
+
 sanity_check_paths = {
     'files': ['bin/lmp_mpi','bin/lmp_omp'],
     'dirs': [],

--- a/easybuild/easyconfigs/n/NAMD/NAMD-2.11-CrayIntel-2016.11-cuda-8.0.54.eb
+++ b/easybuild/easyconfigs/n/NAMD/NAMD-2.11-CrayIntel-2016.11-cuda-8.0.54.eb
@@ -27,6 +27,8 @@ builddependencies = [
 
 files_to_copy = [(['./CRAY-XC-intel.cuda/namd2'], 'bin')]
 
+modextravars = { 'LD_LIBRARY_PATH':'$::env(CRAY_LD_LIBRARY_PATH):$::env(LD_LIBRARY_PATH)'}
+
 sanity_check_paths = {
     'files': ['bin/namd2'],
     'dirs': [],

--- a/easybuild/easyconfigs/p/pycuda/pycuda-2016.1.2-CrayGNU-2016.11-Python-2.7.12-cuda-8.0.54.eb
+++ b/easybuild/easyconfigs/p/pycuda/pycuda-2016.1.2-CrayGNU-2016.11-Python-2.7.12-cuda-8.0.54.eb
@@ -1,4 +1,4 @@
-#easyblock = "PythonPackage"
+# @author: gppezzi
 easyblock = "pycuda"
 
 name = 'pycuda'
@@ -23,9 +23,11 @@ dependencies = [
     ('cudatoolkit/8.0.54_2.2.8_ga620558-2.1', EXTERNAL_MODULE),
 ]
 
-#sanity_check_paths = {
-#    'files': ['lib/python%(pv)s/site-packages/%%(name)s-%%(version)s-py%(pv)s-linux-x86_64.egg' % {'pv': pyshortver}],
-#    'dirs': [],
-#}
+modextravars = { 'LD_LIBRARY_PATH':'$::env(CRAY_LD_LIBRARY_PATH):$::env(LD_LIBRARY_PATH)'}
+
+sanity_check_paths = {
+    'files': [],
+    'dirs': ['lib/python%(pv)s/site-packages/%%(name)s-%%(version)s-py%(pv)s-linux-x86_64.egg' % {'pv': pyshortver}],
+}
 
 moduleclass = 'data'

--- a/easybuild/easyconfigs/p/pycuda/pycuda-2016.1.2-CrayGNU-2016.11-Python-3.5.2-cuda-8.0.54.eb
+++ b/easybuild/easyconfigs/p/pycuda/pycuda-2016.1.2-CrayGNU-2016.11-Python-3.5.2-cuda-8.0.54.eb
@@ -23,10 +23,12 @@ dependencies = [
     ('cudatoolkit/8.0.54_2.2.8_ga620558-2.1', EXTERNAL_MODULE),
 ]
 
-#sanity_check_paths = {
-#    'files': ['lib/python%(pv)s/site-packages/%%(name)s-%%(version)s-py%(pv)s-linux-x86_64.egg' % {'pv': pyshortver}],
-#    'dirs': [],
-#}
+modextravars = { 'LD_LIBRARY_PATH':'$::env(CRAY_LD_LIBRARY_PATH):$::env(LD_LIBRARY_PATH)'}
+
+sanity_check_paths = {
+    'files': [],
+    'dirs': ['lib/python%(pv)s/site-packages/%%(name)s-%%(version)s-py%(pv)s-linux-x86_64.egg' % {'pv': pyshortver}],
+}
 
 moduleclass = 'data'
 

--- a/easybuild/easyconfigs/q/QuantumESPRESSO/QuantumESPRESSO-5.4.0-CrayIntel-2016.11-cuda-8.0.54.eb
+++ b/easybuild/easyconfigs/q/QuantumESPRESSO/QuantumESPRESSO-5.4.0-CrayIntel-2016.11-cuda-8.0.54.eb
@@ -49,6 +49,8 @@ maxparallel = 1
 # set PREFIX for make install, since configure option --prefix does not set the PREFIX variable
 preinstallopts = ' PREFIX=%(installdir)s/bin '
 
+modextravars = { 'LD_LIBRARY_PATH':'$::env(CRAY_LD_LIBRARY_PATH):$::env(LD_LIBRARY_PATH)'}
+
 sanity_check_paths = {
       'files': ['bin/cp-gpu.x', 'bin/neb-gpu.x', 'bin/ph-gpu.x', 'bin/pw-gpu.x'],
       'dirs': ['bin']

--- a/easybuild/easyconfigs/v/VASP/VASP-5.4.1-CrayIntel-2016.11-cuda-8.0.54.eb
+++ b/easybuild/easyconfigs/v/VASP/VASP-5.4.1-CrayIntel-2016.11-cuda-8.0.54.eb
@@ -36,6 +36,8 @@ buildopts = ' gpu gpu_ncl '
  
 files_to_copy = [(['./bin/vasp_*'],'bin')]
 
+modextravars = { 'LD_LIBRARY_PATH':'$::env(CRAY_LD_LIBRARY_PATH):$::env(LD_LIBRARY_PATH)'}
+
 sanity_check_paths = {
     'files': ['bin/vasp_gpu','bin/vasp_gpu_ncl'],
     'dirs': [],


### PR DESCRIPTION
This removes the runtime dependency of cuda modules on the 'default' version of cudatoolkit.