### PR TITLE
Cp2k fix

### DIFF
--- a/easybuild/easyconfigs/c/CP2K/CP2K-svn-CrayGNU-2016.11-cuda-8.0.54.eb
+++ b/easybuild/easyconfigs/c/CP2K/CP2K-svn-CrayGNU-2016.11-cuda-8.0.54.eb
@@ -2,7 +2,7 @@
 easyblock = 'MakeCp'
 
 name = 'CP2K'
-version = "trunk"
+version = "svn"
 
 homepage = 'http://www.cp2k.org/'
 description = """CP2K is a freely available (GPL) program, written in Fortran 95, to perform atomistic and molecular

--- a/easybuild/easyconfigs/c/CP2K/CP2K-svn-CrayGNU-2016.11-cuda-8.0.54.eb
+++ b/easybuild/easyconfigs/c/CP2K/CP2K-svn-CrayGNU-2016.11-cuda-8.0.54.eb
@@ -13,7 +13,7 @@ description = """CP2K is a freely available (GPL) program, written in Fortran 95
 toolchain = {'name': 'CrayGNU', 'version': '2016.11'}
 toolchainopts = { 'usempi': True, 'openmp': True }
 
-# source file packaged from CP2K SVN trunk
+# source file packaged from: CP2K SVN trunk of Feb 09 2017
 sources = [SOURCELOWER_TAR_BZ2]
 
 cudaversion = '8.0.54'

--- a/easybuild/easyconfigs/c/CP2K/CP2K-trunk-CrayGNU-2016.11-cuda-8.0.54.eb
+++ b/easybuild/easyconfigs/c/CP2K/CP2K-trunk-CrayGNU-2016.11-cuda-8.0.54.eb
@@ -13,6 +13,7 @@ description = """CP2K is a freely available (GPL) program, written in Fortran 95
 toolchain = {'name': 'CrayGNU', 'version': '2016.11'}
 toolchainopts = { 'usempi': True, 'openmp': True }
 
+# source file packaged from CP2K SVN trunk
 sources = [SOURCELOWER_TAR_BZ2]
 
 cudaversion = '8.0.54'

--- a/easybuild/easyconfigs/c/CP2K/CP2K-trunk-CrayGNU-2016.11-cuda-8.0.54.eb
+++ b/easybuild/easyconfigs/c/CP2K/CP2K-trunk-CrayGNU-2016.11-cuda-8.0.54.eb
@@ -1,0 +1,58 @@
+# contributed by Luca Marsella (CSCS)
+easyblock = 'MakeCp'
+
+name = 'CP2K'
+version = "trunk"
+
+homepage = 'http://www.cp2k.org/'
+description = """CP2K is a freely available (GPL) program, written in Fortran 95, to perform atomistic and molecular
+ simulations of solid state, liquid, molecular and biological systems. It provides a general framework for different
+ methods such as e.g. density functional theory (DFT) using a mixed Gaussian and plane waves approach (GPW), and
+ classical pair and many-body potentials. """
+
+toolchain = {'name': 'CrayGNU', 'version': '2016.11'}
+toolchainopts = { 'usempi': True, 'openmp': True }
+
+sources = [SOURCELOWER_TAR_BZ2]
+
+cudaversion = '8.0.54'
+versionsuffix = '-cuda-%s' % cudaversion
+
+dependencies = [
+    ('Libint', '1.1.4'),
+    ('libxc', '3.0.0'),
+]
+
+builddependencies = [
+    ('cudatoolkit/%s_2.2.8_ga620558-2.1' %cudaversion, EXTERNAL_MODULE),
+    ('fftw/3.3.4.10', EXTERNAL_MODULE),
+    ('Python', '2.7.12'),
+    ('flex', '2.6.0'),
+    ('Bison', '3.0.4'),
+]
+
+# add define flags
+prebuildopts = " sed -i -e 's/^DFLAGS .*/& -D__FFTSG -D__LIBINT -D__LIBXC -D__GFORTRAN/' ./arch/CRAY-XC30-gfortran-cuda.psmp && "
+# add includes
+prebuildopts += " sed -i -e 's#-ffree-form .*#& -I$(EBROOTLIBINT)/include -I$(EBROOTLIBXC)/include#' ./arch/CRAY-XC30-gfortran-cuda.psmp && "
+# add libraries 
+prebuildopts += " sed -i -e '/LIBS     +=/a LIBS     += -lcudart -lcublas -lcufft -lrt $(EBROOTLIBINT)/lib/libderiv.a $(EBROOTLIBINT)/lib/libint.a $(EBROOTLIBINT)/lib/libr12.a -lstdc++ -L$(EBROOTLIBXC)/lib -lxcf90 -lxc ' ./arch/CRAY-XC30-gfortran-cuda.psmp && "
+# correct reference to specific GPU architecture (sm_60)
+prebuildopts += " sed -i -e 's/-arch sm_35/-arch sm_60/' ./arch/CRAY-XC30-gfortran-cuda.psmp && "
+# correct link to libsmm to match Intel Haswell architecture
+prebuildopts += " sed -i -e 's/sandybridge_gcc_4.9.0/haswell/' ./arch/CRAY-XC30-gfortran-cuda.psmp && "
+prebuildopts += " cat ./arch/CRAY-XC30-gfortran-cuda.psmp && pushd makefiles && "
+
+# build type
+buildopts = 'ARCH=CRAY-XC30-gfortran-cuda VERSION=psmp'
+ 
+files_to_copy = [(['./exe/CRAY-XC30-gfortran-cuda/cp2k.psmp'],'bin')]
+
+sanity_check_paths = {
+    'files': ['bin/cp2k.psmp'],
+    'dirs': [],
+}
+
+modextravars = { 'LD_LIBRARY_PATH':'$::env(CRAY_LD_LIBRARY_PATH):$::env(LD_LIBRARY_PATH)'}
+
+moduleclass = 'chem'


### PR DESCRIPTION
Adding CP2K-trunk-CrayGNU-2016.11-cuda-8.0.54 to fix a bug in CP2K release 4.1: the fix is available only in the trunk SVN, therefore I needed to package the source tarball separately.