### PR TITLE
graphviz

### DIFF
--- a/easybuild/easyconfigs/g/graphviz/graphviz-2.40.1.eb
+++ b/easybuild/easyconfigs/g/graphviz/graphviz-2.40.1.eb
@@ -1,0 +1,19 @@
+easyblock = 'ConfigureMake'
+
+name = 'graphviz'
+version = '2.40.1'
+
+homepage = 'http://www.graphviz.org/Download_source.php'
+description = """Graphviz is open source graph visualization software."""
+
+toolchain = {'name': 'dummy', 'version': ''}
+
+source_urls = ['http://www.graphviz.org/pub/graphviz/stable/SOURCES']
+sources = ['graphviz-%(version)s.tar.gz']
+
+sanity_check_paths = {
+    'files': ['bin/dot'],
+    'dirs': [],
+}
+
+moduleclass = 'vis'

--- a/jenkins-builds/common-SLES12-2016.10
+++ b/jenkins-builds/common-SLES12-2016.10
@@ -5,6 +5,7 @@
  ddt-6.1.2.eb
  ddt-7.0.eb
  git-2.11.0.eb
+ graphviz-2.40.1.eb
  HDFView-2.13.0.eb
  hwloc-1.11.5.eb
  idl-84.eb

--- a/jenkins-builds/common-SLES12-2016.10
+++ b/jenkins-builds/common-SLES12-2016.10
@@ -5,7 +5,6 @@
  ddt-6.1.2.eb
  ddt-7.0.eb
  git-2.11.0.eb
- graphviz-2.40.1.eb
  HDFView-2.13.0.eb
  hwloc-1.11.5.eb
  idl-84.eb


### PR DESCRIPTION
* mo use ~/easybuild/daint/haswell/modules/all 
* mll graphviz/2.40.1
* dot -v
```
dot - graphviz version 2.40.1 (20161225.0304)
libdir = "/apps/common/UES/sandbox/jgp/easybuild.eff/daint/haswell/software/graphviz/2.40.1/lib/graphviz"
Activated plugin library: libgvplugin_dot_layout.so.6
Using layout: dot:dot_layout
Activated plugin library: libgvplugin_core.so.6
Using render: dot:core
Using device: dot:dot:core
The plugin configuration file:
	/apps/common/UES/sandbox/jgp/easybuild.eff/daint/haswell/software/graphviz/2.40.1/lib/graphviz/config6
		was successfully loaded.
    render	:  cairo dot dot_json fig json json0 map mp pic pov ps svg tk vml xdot xdot_json
    layout	:  circo dot fdp neato nop nop1 nop2 osage patchwork sfdp twopi
    textlayout	:  textlayout
    device	:  bmp canon cmap cmapx cmapx_np dot dot_json eps fig gtk gv ico imap imap_np ismap jpe jpeg jpg json json0 mp pdf pic plain plain-ext png pov ps ps2 svg svgz tif tiff tk vml vmlz x11 xdot xdot1.2 xdot1.4 xdot_json xlib
    loadimage	:  (lib) bmp eps gif ico jpe jpeg jpg png ps svg
```