### PR TITLE
Updated Qt files: easyconfis and easyblock

### DIFF
--- a/easybuild/easyblocks/qt.py
+++ b/easybuild/easyblocks/qt.py
@@ -80,6 +80,8 @@ class EB_Qt(ConfigureMake):
 
         if self.cfg['prefix_opt']:
            cmd = "%s ./configure %s%s %s" % (self.cfg['preconfigopts'], self.cfg['prefix_opt'], self.installdir, self.cfg['configopts'])
+        elif LooseVersion(self.version) >= LooseVersion('5.8'):
+           cmd = "%s ./configure -prefix %s %s" % (self.cfg['preconfigopts'], self.installdir, self.cfg['configopts'])
         else:
            cmd = "%s ./configure --prefix=%s %s" % (self.cfg['preconfigopts'], self.installdir, self.cfg['configopts'])
 

--- a/easybuild/easyconfigs/q/Qt/Qt-5.7.0-debug.eb
+++ b/easybuild/easyconfigs/q/Qt/Qt-5.7.0-debug.eb
@@ -1,3 +1,4 @@
+# debug version: -debug in configopts
 name = 'Qt'
 version = '5.7.0'
 versionsuffix = '-debug'

--- a/easybuild/easyconfigs/q/Qt/Qt-5.8.0-CrayGNU-2016.11.eb
+++ b/easybuild/easyconfigs/q/Qt/Qt-5.8.0-CrayGNU-2016.11.eb
@@ -13,7 +13,7 @@ source_urls = [
 ]
 sources = ['%(namelower)s-everywhere-opensource-src-%(version)s.tar.gz']
 
-prefix_opt = ' -prefix '
+#prefix_opt = ' -prefix '
 
 dependencies = [
     ('SQLite', '3.9.2'),

--- a/easybuild/easyconfigs/q/Qt/Qt-5.8.0.eb
+++ b/easybuild/easyconfigs/q/Qt/Qt-5.8.0.eb
@@ -1,3 +1,4 @@
+# contributed by Luca Marsella (CSCS)
 name = 'Qt'
 version = '5.8.0'
 
@@ -9,7 +10,7 @@ toolchain = {'name': 'dummy', 'version': 'dummy'}
 source_urls = [ 'http://master.qt-project.org/archive/qt/%(version_major_minor)s/%(version)s/' ]
 sources = [ '%(namelower)s-everywhere-opensource-src-%(version)s.tar.gz' ]
 
-prefix_opt = ' -prefix '
+#prefix_opt = ' -prefix '
 configopts  = ' -opensource -nomake tests -nomake examples -confirm-license'
 configopts += ' -shared -no-accessibility -no-sql-mysql -no-sql-sqlite'
 configopts += ' -no-pulseaudio -no-alsa -no-cups'


### PR DESCRIPTION
I have inserted the following version check in the easyblock `qt.py`:
`LooseVersion(self.version) >= LooseVersion('5.8')`
It will make the configuration straightforward and avoid the error prone definitition of `prefix_opt`, which I left in the easyblock though, to comply with the help screen `eb -a -e EB_Qt` (as in ConfigureMake):
`prefix_opt*             Prefix command line option for configure script ('--prefix=' if None) [default: None]`