### PR TITLE
Adding PyRegression-2.0.2

### DIFF
--- a/jenkins-builds/common-RH6.7-2016.10
+++ b/jenkins-builds/common-RH6.7-2016.10
@@ -7,6 +7,7 @@ Autoconf-2.69.eb
 Automake-1.15.eb
 libtool-2.4.6.eb
 numactl-2.0.11.eb
+PyRegression-2.0.2.eb
 hwloc-1.11.4.eb
 likwid-4.1.2.eb
 ctags-5.8.eb


### PR DESCRIPTION
This commit adds `PyRegression-2.0.2.eb` to the list of installable packages