### PR TITLE
Gmp crayintel

### DIFF
--- a/easybuild/easyconfigs/g/GMP/GMP-6.1.2-CrayIntel-2016.11.eb
+++ b/easybuild/easyconfigs/g/GMP/GMP-6.1.2-CrayIntel-2016.11.eb
@@ -1,0 +1,29 @@
+# contributed by Guilherme Peretti Pezzi and Luca Marsella (CSCS)
+easyblock = 'ConfigureMake'
+
+name = 'GMP'
+version = "6.1.2"
+
+homepage = 'http://gmplib.org/'
+description = """GMP is a free library for arbitrary precision arithmetic, 
+operating on signed integers, rational numbers, and floating point numbers. """
+
+toolchain = {'name': 'CrayIntel', 'version': '2016.11'}
+toolchainopts = {'lowopt': True}
+
+sources = [SOURCELOWER_TAR_BZ2]
+source_urls = [GNU_SOURCE]
+
+preconfigopts = 'export CFLAGS="$CFLAGS -mcmodel=large" && '
+
+# the output of config.guess is used by default and can be changed with --build
+# configopts = ' --build=haswell-pc-linux-gnu'
+
+#runtest = 'check'
+
+sanity_check_paths = {
+    'files': ['lib/libgmp.%s' % SHLIB_EXT, 'include/gmp.h'],
+    'dirs': [],
+}
+
+moduleclass = 'math'


### PR DESCRIPTION
The output of config.guess is used by default and can be changed with --build. E.g:
`configopts = ' --build=haswell-pc-linux-gnu' `
