### PR TITLE
ray tracing libraries used by ParaView (5.3 and above)

### DIFF
--- a/easybuild/easyconfigs/e/embree/embree-2.14.0-CrayGNU-2016.11.eb
+++ b/easybuild/easyconfigs/e/embree/embree-2.14.0-CrayGNU-2016.11.eb
@@ -1,0 +1,19 @@
+easyblock = "Tarball"
+
+name = 'embree'
+version = '2.14.0'
+
+homepage = 'https://embree.github.io/'
+description = "Embree is a collection of high-performance ray tracing kernels, developed at Intel."
+
+toolchain = {'name': 'CrayGNU', 'version': '2016.11'}
+
+sources = ['embree-2.14.0.x86_64.linux.tar.gz']
+source_urls = ['https://github.com/embree/embree/releases/download/v2.14.0/']
+
+sanity_check_paths={
+    'files': [],
+    'dirs': ['include', 'lib']
+}
+
+moduleclass = 'devel'

--- a/easybuild/easyconfigs/o/ospray/ospray-1.2.0-CrayGNU-2016.11.eb
+++ b/easybuild/easyconfigs/o/ospray/ospray-1.2.0-CrayGNU-2016.11.eb
@@ -1,0 +1,19 @@
+easyblock = "Tarball"
+
+name = 'ospray'
+version = '1.2.0'
+
+homepage = 'https://github.com/ospray'
+description = "An Open, Scalable, Parallel, Ray Tracing Based Rendering Engine for High-Fidelity Visualization"
+
+toolchain = {'name': 'CrayGNU', 'version': '2016.11'}
+
+sources = ['ospray-1.2.0.x86_64.linux.tar.gz']
+source_urls = ['https://github.com/ospray/ospray/releases/download/v1.2.0/']
+
+sanity_check_paths={
+    'files': [],
+    'dirs': ['include', 'lib']
+}
+
+moduleclass = 'devel'


### PR DESCRIPTION
These two libraries provided by Intel are used by ParaView for real-time raytracing. This will be the first version on daint (v5.3) to support it.