### PR TITLE
Update matplotlib-1.4.3 with Python-3.5.0 and dependencies

### DIFF
--- a/easybuild/easyconfigs/f/freetype/freetype-2.7.1-gmvolf-15.11.eb
+++ b/easybuild/easyconfigs/f/freetype/freetype-2.7.1-gmvolf-15.11.eb
@@ -1,0 +1,22 @@
+# contributed by Luca Marsella (CSCS)
+name = 'freetype'
+version = "2.7.1"
+
+homepage = 'http://freetype.org'
+description = """FreeType 2 is a software font engine that is designed to be small, efficient, highly customizable, and
+ portable while capable of producing high-quality output (glyph images). It can be used in graphics libraries, display
+ servers, font conversion tools, text image generation tools, and many other products as well."""
+
+toolchain = {'name': 'gmvolf', 'version': '15.11'}
+
+source_urls = [GNU_SAVANNAH_SOURCE]
+sources = [SOURCE_TAR_GZ]
+
+dependencies = [('libpng', '1.6.28')]
+
+sanity_check_paths = {
+    'files': ['bin/freetype-config', 'lib/libfreetype.a', 'lib/libfreetype.so', 'lib/pkgconfig/freetype2.pc'],
+    'dirs': ['include/freetype2'],
+}
+
+moduleclass = 'vis'

--- a/easybuild/easyconfigs/l/libpng/libpng-1.6.28-gmvolf-15.11.eb
+++ b/easybuild/easyconfigs/l/libpng/libpng-1.6.28-gmvolf-15.11.eb
@@ -1,0 +1,20 @@
+# contributed by Luca Marsella (CSCS)
+easyblock = 'ConfigureMake'
+
+name = 'libpng'
+version = '1.6.28'
+
+homepage = 'http://www.libpng.org/pub/png/libpng.html'
+description = "libpng is the official PNG reference library"
+
+toolchain = {'name': 'gmvolf', 'version': '15.11'}
+toolchainopts = {'pic': True}
+
+source_urls = [SOURCEFORGE_SOURCE]
+sources = [SOURCELOWER_TAR_GZ]
+
+dependencies = [('zlib', '1.2.8')]
+
+configopts = "--with-pic"
+
+moduleclass = 'lib'

--- a/easybuild/easyconfigs/m/matplotlib/matplotlib-1.4.3-gmvolf-15.11-Python-3.5.0.eb
+++ b/easybuild/easyconfigs/m/matplotlib/matplotlib-1.4.3-gmvolf-15.11-Python-3.5.0.eb
@@ -1,0 +1,38 @@
+# contributed by Luca Marsella (CSCS)
+easyblock = "PythonPackage"
+
+name = 'matplotlib'
+version = '1.4.3'
+
+homepage = 'http://matplotlib.org'
+description = """matplotlib is a python 2D plotting library which produces publication quality figures in a variety of
+ hardcopy formats and interactive environments across platforms. matplotlib can be used in python scripts, the python
+ and ipython shell, web application servers, and six graphical user interface toolkits."""
+
+toolchain = {'name': 'gmvolf', 'version': '15.11'}
+
+source_urls = [SOURCEFORGE_SOURCE]
+sources = [SOURCELOWER_TAR_GZ]
+
+patches = [('matplotlib-%(version)s_Qhull-intel-fix.patch')]
+
+python = "Python"
+pythonversion = '3.5.0'
+pyshortver = ".".join(pythonversion.split(".")[:-1])
+
+versionsuffix = "-%s-%s" % (python, pythonversion)
+
+dependencies = [
+    (python, pythonversion),
+    ('freetype', '2.7.1'),
+    ('libpng', '1.6.28'),
+]
+
+pyprefix = 'lib/python%s/site-packages' % pyshortver
+eggname = 'matplotlib-%%(version)s-py%s-linux-x86_64.egg' % pyshortver
+sanity_check_paths = {
+    'files': [],
+    'dirs': [('%s/%%(name)s' % pyprefix, '%s/%s' % (pyprefix, eggname))],
+}
+
+moduleclass = 'vis'

--- a/easybuild/easyconfigs/z/zlib/zlib-1.2.11-gmvolf-15.11.eb
+++ b/easybuild/easyconfigs/z/zlib/zlib-1.2.11-gmvolf-15.11.eb
@@ -1,0 +1,22 @@
+# # contributed by Luca Marsella (CSCS)
+easyblock = 'ConfigureMake'
+
+name = 'zlib'
+version = "1.2.11"
+
+homepage = 'http://www.zlib.net/'
+description = """zlib is designed to be a free, general-purpose, legally unencumbered -- that is,
+ not covered by any patents -- lossless data-compression library for use on virtually any
+ computer hardware and operating system."""
+
+toolchain = {'name': 'gmvolf', 'version': '15.11'}
+
+sources = [SOURCELOWER_TAR_GZ]
+source_urls = [('http://sourceforge.net/projects/libpng/files/zlib/%(version)s', 'download')]
+
+sanity_check_paths = {
+    'files': ['include/zconf.h', 'include/zlib.h', 'lib/libz.a', 'lib/libz.so'],
+    'dirs': [],
+}
+
+moduleclass = 'lib'


### PR DESCRIPTION
The request includes the easyconfig files for matplotlib-1.4.3, freetype-2.7.1 and libpng-1.6.28 and zlib-1.2.11 with the toolchain gmvolf-15.11.
The latter is updated but not used to build libpng-1.6.28, keeping instead the old dependency zlib-1.2.8 for compatibility with the other modules built using the toolchain gmvolf-15.11.