### PR TITLE
VASP with perftools-cscs/645-cuda and perftools-cscs/645-nogpu

### DIFF
--- a/easybuild/easyconfigs/v/VASP/VASP-5.4.1-CrayIntel-2016.11-cuda-8.0.54-pat-645-cuda.eb
+++ b/easybuild/easyconfigs/v/VASP/VASP-5.4.1-CrayIntel-2016.11-cuda-8.0.54-pat-645-cuda.eb
@@ -1,0 +1,47 @@
+# contributed by Luca Marsella (CSCS)
+easyblock = 'MakeCp'
+
+name = 'VASP'
+version = "5.4.1"
+cudaversion = '8.0.54'
+patversion = "645-cuda"
+versionsuffix = '-cuda-%s-pat-%s' %(cudaversion, patversion)
+
+homepage = 'http://www.vasp.at'
+description = """The Vienna Ab initio Simulation Package (VASP) is a computer program for atomic scale materials modelling, e.g. electronic structure calculations and quantum-mechanical molecular dynamics, from first principles. """
+
+toolchain = {'name': 'CrayIntel', 'version': '2016.11'}
+toolchainopts = { 'usempi': True }
+
+sources = [SOURCELOWER_TAR_BZ2]
+
+builddependencies = [
+    ('perftools-cscs/%s' %patversion, EXTERNAL_MODULE),
+    ('cudatoolkit/%s_2.2.8_ga620558-2.1' %cudaversion, EXTERNAL_MODULE),
+    ('fftw/3.3.4.10', EXTERNAL_MODULE),
+    ('gcc/4.9.3', EXTERNAL_MODULE),
+]
+
+# adapt ./arch/makefile.include.linux_intel_cuda and copy to ./makefile.include 
+prebuildopts = ' sed -e "s/mpif90/ftn/g" -e "s/-mkl//" -e "/mkl/Id" -e "/FFT_ROOT/d" -e "/OBJECTS /a FFT_LIB=-L\$(FFTW_DIR) -lfftw3 \\nINCS=-I\$(FFTW_INC)" -e "s#/opt/cuda/#\$(CUDATOOLKIT_HOME)#" -e "/GENCODE_ARCH/d" -e "/MAGMA_ROOT/d" -e "s#/opt/openmpi/include#\$(MPICH_DIR)/include#" ./arch/makefile.include.linux_intel_cuda > ./makefile.include && '
+# correct common.mk for Intel compiler
+prebuildopts += ' sed -i -e "s/gcc/icc/" -e "s/g++/icpc/g" src/CUDA/common.mk && '
+# correct kernels.h for CUDA 8.0
+prebuildopts += ' sed -i -e "/double atomicAdd/i #if (__CUDACC_VER_MAJOR__<8) || ( defined(__CUDA_ARCH__) && (__CUDA_ARCH__<600) )" -e "/<int is_partial>/i #endif" ./src/CUDA/kernels.h && '
+
+# don't use parallel make, results in compilation failure
+parallel = 1
+
+# build type
+buildopts = ' gpu gpu_ncl '
+ 
+files_to_copy = [(['./bin/vasp_*'],'bin')]
+
+modextravars = { 'LD_LIBRARY_PATH':'$::env(CRAY_LD_LIBRARY_PATH):$::env(LD_LIBRARY_PATH)'}
+
+sanity_check_paths = {
+    'files': ['bin/vasp_gpu','bin/vasp_gpu_ncl'],
+    'dirs': [],
+}
+
+moduleclass = 'phys'

--- a/easybuild/easyconfigs/v/VASP/VASP-5.4.1-CrayIntel-2016.11-pat-645-nogpu.eb
+++ b/easybuild/easyconfigs/v/VASP/VASP-5.4.1-CrayIntel-2016.11-pat-645-nogpu.eb
@@ -1,0 +1,40 @@
+# contributed by Luca Marsella (CSCS)
+easyblock = 'MakeCp'
+
+name = 'VASP'
+version = "5.4.1"
+patversion = "645-nogpu"
+versionsuffix = 'pat-%s' % patversion
+
+homepage = 'http://www.vasp.at'
+description = """The Vienna Ab initio Simulation Package (VASP) is a computer program for atomic scale materials modelling, e.g. electronic structure calculations and quantum-mechanical molecular dynamics, from first principles. """
+
+toolchain = {'name': 'CrayIntel', 'version': '2016.11'}
+toolchainopts = { 'usempi': True }
+
+sources = [SOURCELOWER_TAR_BZ2]
+
+builddependencies = [
+    ('perftools-cscs/%s' %patversion, EXTERNAL_MODULE),
+    ('fftw/3.3.4.10', EXTERNAL_MODULE),
+]
+
+# adapt ./arch/makefile.include.linux_intel and copy to ./makefile.include 
+prebuildopts = ' sed -e "s/_ompi/_mpich/" -e "s/mpif90/ftn/" -e "s/-mkl//" -e "/mkl/Id" -e "/OBJECTS_O2/a FFT_LIB=-L\$(FFTW_DIR) -lfftw3\\nINCS=-I\$(FFTW_INC)/include" arch/makefile.include.linux_intel > makefile.include && '
+# builds fftw3xf interface (MKL only)
+#prebuildopts += ' cp -r $MKLROOT/interfaces/fftw3xf %(builddir)s && pushd %(builddir)s/fftw3xf && make libintel64 compiler=intel fname=a_name__ && popd && '
+
+# don't use parallel make, results in compilation failure
+parallel = 1
+
+# build type
+buildopts = ' all '
+ 
+files_to_copy = [(['./bin/vasp_*'],'bin')]
+
+sanity_check_paths = {
+    'files': ['bin/vasp_gam','bin/vasp_ncl','bin/vasp_std'],
+    'dirs': [],
+}
+
+moduleclass = 'phys'


### PR DESCRIPTION
VASP recipes, CUDA and non-GPU as both are available in production on `daint-gpu`