### PR TITLE
cleaning up bazel workspace after successful build

### DIFF
--- a/easybuild/easyconfigs/t/TensorFlow/TensorFlow-1.0.0-CrayGNU-2016.11-Python-3.5.2.eb
+++ b/easybuild/easyconfigs/t/TensorFlow/TensorFlow-1.0.0-CrayGNU-2016.11-Python-3.5.2.eb
@@ -55,7 +55,7 @@ sanity_check_paths={
     'dirs': ['%(installdir)s/lib/python%(pyshortver)s/site-packages'],
 }
 
-postinstallcmds = [ 'rm -rf $TEST_TMPDIR' ]
+postinstallcmds = [ 'rm -rf /dev/shm/$USER/bazelout/' ]
 
 modextrapaths = {                                                                  
     'PYTHONPATH' : 'lib/python%(pyshortver)s/site-packages',

--- a/easybuild/easyconfigs/t/TensorFlow/TensorFlow-1.0.0-CrayGNU-2016.11-Python-3.5.2.eb
+++ b/easybuild/easyconfigs/t/TensorFlow/TensorFlow-1.0.0-CrayGNU-2016.11-Python-3.5.2.eb
@@ -55,6 +55,8 @@ sanity_check_paths={
     'dirs': ['%(installdir)s/lib/python%(pyshortver)s/site-packages'],
 }
 
+postinstallcmds = [ 'rm -rf $TEST_TMPDIR' ]
+
 modextrapaths = {                                                                  
     'PYTHONPATH' : 'lib/python%(pyshortver)s/site-packages',
 }

--- a/easybuild/easyconfigs/t/TensorFlow/TensorFlow-1.0.0-CrayGNU-2016.11-cuda-8.0-Python-2.7.12.eb
+++ b/easybuild/easyconfigs/t/TensorFlow/TensorFlow-1.0.0-CrayGNU-2016.11-cuda-8.0-Python-2.7.12.eb
@@ -58,7 +58,7 @@ sanity_check_paths={
     'dirs': ['%(installdir)s/lib/python%(pyshortver)s/site-packages'],
 }
 
-postinstallcmds = [ 'rm -rf $TEST_TMPDIR' ] 
+postinstallcmds = [ 'rm -rf /dev/shm/$USER/bazelout/' ]
 
 modextrapaths = {                                                                  
     'PYTHONPATH' : 'lib/python%(pyshortver)s/site-packages',

--- a/easybuild/easyconfigs/t/TensorFlow/TensorFlow-1.0.0-CrayGNU-2016.11-cuda-8.0-Python-2.7.12.eb
+++ b/easybuild/easyconfigs/t/TensorFlow/TensorFlow-1.0.0-CrayGNU-2016.11-cuda-8.0-Python-2.7.12.eb
@@ -58,6 +58,8 @@ sanity_check_paths={
     'dirs': ['%(installdir)s/lib/python%(pyshortver)s/site-packages'],
 }
 
+postinstallcmds = [ 'rm -rf $TEST_TMPDIR' ] 
+
 modextrapaths = {                                                                  
     'PYTHONPATH' : 'lib/python%(pyshortver)s/site-packages',
 }

--- a/easybuild/easyconfigs/t/TensorFlow/TensorFlow-1.0.0-CrayGNU-2016.11-cuda-8.0-Python-3.5.2.eb
+++ b/easybuild/easyconfigs/t/TensorFlow/TensorFlow-1.0.0-CrayGNU-2016.11-cuda-8.0-Python-3.5.2.eb
@@ -57,7 +57,7 @@ sanity_check_paths={
     'dirs': ['%(installdir)s/lib/python%(pyshortver)s/site-packages'],
 }
 
-postinstallcmds = [ 'rm -rf $TEST_TMPDIR' ]
+postinstallcmds = [ 'rm -rf /dev/shm/$USER/bazelout/' ]
 
 modextrapaths = {                                                                  
     'PYTHONPATH' : 'lib/python%(pyshortver)s/site-packages',

--- a/easybuild/easyconfigs/t/TensorFlow/TensorFlow-1.0.0-CrayGNU-2016.11-cuda-8.0-Python-3.5.2.eb
+++ b/easybuild/easyconfigs/t/TensorFlow/TensorFlow-1.0.0-CrayGNU-2016.11-cuda-8.0-Python-3.5.2.eb
@@ -57,6 +57,8 @@ sanity_check_paths={
     'dirs': ['%(installdir)s/lib/python%(pyshortver)s/site-packages'],
 }
 
+postinstallcmds = [ 'rm -rf $TEST_TMPDIR' ]
+
 modextrapaths = {                                                                  
     'PYTHONPATH' : 'lib/python%(pyshortver)s/site-packages',
 }


### PR DESCRIPTION
Addressing ticket #27402

TensorFlow builds keep bazel workspace after successful builds and this change should fix this problem.

Failed builds will stay anyway on the temporary folder (as expected).