### PR TITLE
Updating VASP recipes with perftools

### DIFF
--- a/easybuild/easyconfigs/v/VASP/VASP-5.4.1-CrayIntel-2016.11-cuda-8.0.54-pat-645-cuda.eb
+++ b/easybuild/easyconfigs/v/VASP/VASP-5.4.1-CrayIntel-2016.11-cuda-8.0.54-pat-645-cuda.eb
@@ -16,7 +16,7 @@ toolchainopts = { 'usempi': True }
 sources = [SOURCELOWER_TAR_BZ2]
 
 builddependencies = [
-    ('perftools-cscs/%s' %patversion, EXTERNAL_MODULE),
+    ('perftools-cscs', '%s' %patversion, '', True),
     ('cudatoolkit/%s_2.2.8_ga620558-2.1' %cudaversion, EXTERNAL_MODULE),
     ('fftw/3.3.4.10', EXTERNAL_MODULE),
     ('gcc/4.9.3', EXTERNAL_MODULE),

--- a/easybuild/easyconfigs/v/VASP/VASP-5.4.1-CrayIntel-2016.11-pat-645-nogpu.eb
+++ b/easybuild/easyconfigs/v/VASP/VASP-5.4.1-CrayIntel-2016.11-pat-645-nogpu.eb
@@ -15,7 +15,7 @@ toolchainopts = { 'usempi': True }
 sources = [SOURCELOWER_TAR_BZ2]
 
 builddependencies = [
-    ('perftools-cscs/%s' %patversion, EXTERNAL_MODULE),
+    ('perftools-cscs', '%s' %patversion, '', True),
     ('fftw/3.3.4.10', EXTERNAL_MODULE),
 ]
 


### PR DESCRIPTION
Using perftools-cscs as a build dependency with variable `%patversion`