### PR TITLE
adding keras (TF + Theano) and deps

### DIFF
--- a/easybuild/easyconfigs/k/Keras/Keras-2.0.3-CrayGNU-2016.11-Python-3.5.2.eb
+++ b/easybuild/easyconfigs/k/Keras/Keras-2.0.3-CrayGNU-2016.11-Python-3.5.2.eb
@@ -1,0 +1,29 @@
+easyblock = "PythonPackage"
+
+name = 'Keras'
+version = '2.0.3'
+versionsuffix = '-Python-%(pyver)s'
+
+homepage = 'https://keras.io/'
+description = """Keras is a minimalist, highly modular neural networks library, written in Python and
+capable of running on top of either TensorFlow or Theano."""
+
+toolchain = {'name': 'CrayGNU', 'version': '2016.11'}
+
+source_urls = [PYPI_SOURCE]
+sources = [SOURCE_TAR_GZ]
+
+dependencies = [
+    ('Python', '3.5.2'),
+    ('Theano', '0.8.2', versionsuffix),
+    ('TensorFlow', '1.0.0', '-cuda-8.0%(versionsuffix)s'),
+    ('h5py', '2.6.0', '%(versionsuffix)s-serial'),
+    ('PyYAML', '3.12', versionsuffix),
+]
+
+sanity_check_paths = {
+    'files': [],
+    'dirs': ['lib/python%(pyshortver)s/site-packages'],
+}
+
+moduleclass = 'math'

--- a/easybuild/easyconfigs/l/libyaml/libyaml-0.1.6-CrayGNU-2016.11.eb
+++ b/easybuild/easyconfigs/l/libyaml/libyaml-0.1.6-CrayGNU-2016.11.eb
@@ -1,0 +1,28 @@
+##
+# This file is an EasyBuild reciPY as per https://github.com/hpcugent/easybuild
+#
+# Copyright:: Copyright 2012-2014 Uni.Lu/LCSB, NTUA
+# Authors::   Nils Christian <nils.christian@uni.lu>
+# License::   MIT/GPL
+# $Id$
+##
+
+easyblock = 'ConfigureMake'
+
+name = 'libyaml'
+version = '0.1.6'
+
+homepage = 'http://pyyaml.org/wiki/LibYAML'
+description = """LibYAML is a YAML 1.1 parser and emitter written in C."""
+
+toolchain = {'name': 'CrayGNU', 'version': '2016.11'}
+
+sources = ['yaml-%(version)s.tar.gz']
+source_urls = ['http://pyyaml.org/download/libyaml/']
+
+sanity_check_paths = {
+    'files': ["include/yaml.h", "lib/libyaml.a", "lib/libyaml.%s" % SHLIB_EXT],
+    'dirs': ["lib/pkgconfig"]
+}
+
+moduleclass = 'lib'

--- a/easybuild/easyconfigs/p/PyYAML/PyYAML-3.12-CrayGNU-2016.11-Python-3.5.2.eb
+++ b/easybuild/easyconfigs/p/PyYAML/PyYAML-3.12-CrayGNU-2016.11-Python-3.5.2.eb
@@ -1,0 +1,27 @@
+easyblock = 'PythonPackage'
+
+name = 'PyYAML'
+version = '3.12'
+versionsuffix = '-Python-%(pyver)s'
+
+homepage = "https://pypi.python.org/pypi/PyYAML/"
+description = """PyYAML is a YAML parser and emitter for the Python programming language."""
+
+toolchain = {'name': 'CrayGNU', 'version': '2016.11'}
+
+source_urls = [PYPI_SOURCE]
+sources = [SOURCE_TAR_GZ]
+
+dependencies = [
+    ('Python', '3.5.2'),
+    ('libyaml', '0.1.6'),
+]
+
+options = {'modulename': 'yaml'}
+
+sanity_check_paths = {
+    'files': [],
+    'dirs': ['lib/python%(pyshortver)s/site-packages'],
+}
+
+moduleclass = 'lib'


### PR DESCRIPTION
Test (TF backend) on Daint:
```
perettig@daint102:/scratch/snx3000/perettig> wget https://github.com/fchollet/keras/raw/master/examples/mnist_mlp.py
perettig@daint102:/scratch/snx3000/perettig> srun python mnist_mlp.py
I tensorflow/stream_executor/dso_loader.cc:135] successfully opened CUDA library libcublas.so.8.0 locally
I tensorflow/stream_executor/dso_loader.cc:135] successfully opened CUDA library libcudnn.so.5 locally
I tensorflow/stream_executor/dso_loader.cc:135] successfully opened CUDA library libcufft.so.8.0 locally
I tensorflow/stream_executor/dso_loader.cc:135] successfully opened CUDA library libcuda.so.1 locally
I tensorflow/stream_executor/dso_loader.cc:135] successfully opened CUDA library libcurand.so.8.0 locally
I tensorflow/core/common_runtime/gpu/gpu_device.cc:885] Found device 0 with properties:
name: Tesla P100-PCIE-16GB
major: 6 minor: 0 memoryClockRate (GHz) 1.3285
pciBusID 0000:02:00.0
Total memory: 15.89GiB
Free memory: 15.61GiB
I tensorflow/core/common_runtime/gpu/gpu_device.cc:906] DMA: 0
I tensorflow/core/common_runtime/gpu/gpu_device.cc:916] 0:   Y
I tensorflow/core/common_runtime/gpu/gpu_device.cc:975] Creating TensorFlow device (/gpu:0) -> (device: 0, name: Tesla P100-PCIE-16GB, pci bus id: 0000:02:00.0)
60000 train samples
10000 test samples
_________________________________________________________________
Layer (type)                 Output Shape              Param #
=================================================================
dense_1 (Dense)              (None, 512)               401920
_________________________________________________________________
dropout_1 (Dropout)          (None, 512)               0
_________________________________________________________________
dense_2 (Dense)              (None, 512)               262656
_________________________________________________________________
dropout_2 (Dropout)          (None, 512)               0
_________________________________________________________________
dense_3 (Dense)              (None, 10)                5130
=================================================================
Total params: 669,706
Trainable params: 669,706
Non-trainable params: 0
_________________________________________________________________
Train on 60000 samples, validate on 10000 samples
Epoch 1/20
60000/60000 [==============================] - 3s - loss: 0.2466 - acc: 0.9248 - val_loss: 0.1020 - val_acc: 0.9690
Epoch 2/20
60000/60000 [==============================] - 1s - loss: 0.1020 - acc: 0.9689 - val_loss: 0.0833 - val_acc: 0.9760
Epoch 3/20
60000/60000 [==============================] - 1s - loss: 0.0743 - acc: 0.9772 - val_loss: 0.0795 - val_acc: 0.9769
Epoch 4/20
60000/60000 [==============================] - 1s - loss: 0.0592 - acc: 0.9821 - val_loss: 0.0817 - val_acc: 0.9773
Epoch 5/20
60000/60000 [==============================] - 1s - loss: 0.0498 - acc: 0.9848 - val_loss: 0.0706 - val_acc: 0.9819
Epoch 6/20
60000/60000 [==============================] - 1s - loss: 0.0421 - acc: 0.9875 - val_loss: 0.0848 - val_acc: 0.9801
Epoch 7/20
60000/60000 [==============================] - 1s - loss: 0.0373 - acc: 0.9890 - val_loss: 0.0886 - val_acc: 0.9813
Epoch 8/20
60000/60000 [==============================] - 1s - loss: 0.0352 - acc: 0.9899 - val_loss: 0.0820 - val_acc: 0.9833
Epoch 9/20
60000/60000 [==============================] - 1s - loss: 0.0311 - acc: 0.9910 - val_loss: 0.0818 - val_acc: 0.9849
Epoch 10/20
60000/60000 [==============================] - 1s - loss: 0.0270 - acc: 0.9921 - val_loss: 0.0898 - val_acc: 0.9826
Epoch 11/20
60000/60000 [==============================] - 1s - loss: 0.0259 - acc: 0.9924 - val_loss: 0.1025 - val_acc: 0.9798
Epoch 12/20
60000/60000 [==============================] - 1s - loss: 0.0264 - acc: 0.9927 - val_loss: 0.1108 - val_acc: 0.9813
Epoch 13/20
60000/60000 [==============================] - 1s - loss: 0.0228 - acc: 0.9939 - val_loss: 0.1021 - val_acc: 0.9823
Epoch 14/20
60000/60000 [==============================] - 1s - loss: 0.0230 - acc: 0.9934 - val_loss: 0.0862 - val_acc: 0.9856
Epoch 15/20
60000/60000 [==============================] - 1s - loss: 0.0210 - acc: 0.9942 - val_loss: 0.0967 - val_acc: 0.9840
Epoch 16/20
60000/60000 [==============================] - 1s - loss: 0.0210 - acc: 0.9945 - val_loss: 0.0915 - val_acc: 0.9840
Epoch 17/20
60000/60000 [==============================] - 1s - loss: 0.0205 - acc: 0.9949 - val_loss: 0.0992 - val_acc: 0.9843
Epoch 18/20
60000/60000 [==============================] - 1s - loss: 0.0190 - acc: 0.9954 - val_loss: 0.1051 - val_acc: 0.9845
Epoch 19/20
60000/60000 [==============================] - 1s - loss: 0.0175 - acc: 0.9956 - val_loss: 0.1215 - val_acc: 0.9819
Epoch 20/20
60000/60000 [==============================] - 1s - loss: 0.0156 - acc: 0.9959 - val_loss: 0.1203 - val_acc: 0.9839Using TensorFlow backend.

Test loss: 0.120316589033
Test accuracy: 0.9839
```