### PR TITLE
Add QuantumESPRESSO-6.1.0 to daint-gpu software stack

### DIFF
--- a/jenkins-builds/6.0.UP02-2016.11-gpu
+++ b/jenkins-builds/6.0.UP02-2016.11-gpu
@@ -40,8 +40,8 @@
  perftools-cscs-645-loops.eb
  pycuda-2016.1.2-CrayGNU-2016.11-Python-2.7.12-cuda-8.0.54.eb
  pycuda-2016.1.2-CrayGNU-2016.11-Python-3.5.2-cuda-8.0.54.eb
+ QuantumESPRESSO-6.1.0-CrayIntel-2016.11.eb
  QuantumESPRESSO-5.4.0-CrayIntel-2016.11.eb
- QuantumESPRESSO-5.4.0-CrayIntel-2016.11-cuda-8.0.54.eb
  R-3.3.2-CrayGNU-2016.11.eb
  Scalasca-2.3.1-CrayGNU-2016.11.eb
  Scalasca-2.3.1-CrayIntel-2016.11.eb


### PR DESCRIPTION
QuantumESPRESSO 5.4.0 is relatively old and shows bugs (e.g.: https://webrt.cscs.ch/Ticket/Display.html?id=27467), therefore I propose to build the more recent release 6.1.0 in the software stack: not yet as default, but that would be the next step to be properly announced to the users in the News section of the User Portal. 
At the same time, I propose to remove the cuda build of release 5.4.0, which is not working.

Requires #158 