### PR TITLE
QuantumESPRESSO-6.1.0 on daint-mc software stack

### DIFF
--- a/jenkins-builds/6.0.UP02-2016.11-mc
+++ b/jenkins-builds/6.0.UP02-2016.11-mc
@@ -29,7 +29,8 @@
  perftools-base-cscs-645-nogpu.eb
  perftools-cscs-645-nogpu.eb
  perftools-base-cscs-645-loops.eb
- perftools-cscs-645-loops.eb     
+ perftools-cscs-645-loops.eb
+ QuantumESPRESSO-6.1.0-CrayIntel-2016.11.eb
  QuantumESPRESSO-5.4.0-CrayIntel-2016.11.eb
  R-3.3.2-CrayGNU-2016.11.eb
  Scalasca-2.3.1-CrayGNU-2016.11.eb


### PR DESCRIPTION
QuantumESPRESSO 5.4.0 is relatively old and shows bugs (e.g.: https://webrt.cscs.ch/Ticket/Display.html?id=27467), therefore I propose to build the more recent release 6.1.0 in the software stack: not yet as default, but that would be the next step to be properly announced to the users in the News section of the User Portal.

Requires #158 