### PR TITLE
Removing VMD from mc partition

### DIFF
--- a/jenkins-builds/6.0.UP02-2016.11-mc
+++ b/jenkins-builds/6.0.UP02-2016.11-mc
@@ -47,5 +47,3 @@
  Spark-1.6.0.eb
  VASP-5.4.1-CrayIntel-2016.11.eb
  Visit-2.12.0-CrayGNU-2016.11.eb
- VMD-1.9.3.eb
-


### PR DESCRIPTION
VMD should only be available on the GPU partition (either OGL or EGL version).

I'm deleting as well the existing module as agreed with @jfavre.