### PR TITLE
[daint-gpu] new Intel ray-tracing libs for use in ParaView. They fix the blank (n…

### DIFF
--- a/easybuild/easyconfigs/e/embree/embree-2.16.3-CrayGNU-2016.11.eb
+++ b/easybuild/easyconfigs/e/embree/embree-2.16.3-CrayGNU-2016.11.eb
@@ -1,0 +1,19 @@
+easyblock = "Tarball"
+
+name = 'embree'
+version = '2.16.3'
+
+homepage = 'https://embree.github.io/'
+description = "Embree is a collection of high-performance ray tracing kernels, developed at Intel."
+
+toolchain = {'name': 'CrayGNU', 'version': '2016.11'}
+
+sources = ['embree-2.16.3.x86_64.linux.tar.gz']
+source_urls = ['https://github.com/embree/embree/releases/download/v2.16.3/']
+
+sanity_check_paths={
+    'files': [],
+    'dirs': ['include', 'lib']
+}
+
+moduleclass = 'devel'

--- a/easybuild/easyconfigs/o/ospray/ospray-1.3.0-CrayGNU-2016.11.eb
+++ b/easybuild/easyconfigs/o/ospray/ospray-1.3.0-CrayGNU-2016.11.eb
@@ -1,0 +1,19 @@
+easyblock = "Tarball"
+
+name = 'ospray'
+version = '1.3.0'
+
+homepage = 'https://github.com/ospray'
+description = "An Open, Scalable, Parallel, Ray Tracing Based Rendering Engine for High-Fidelity Visualization"
+
+toolchain = {'name': 'CrayGNU', 'version': '2016.11'}
+
+sources = ['ospray-1.3.0.x86_64.linux.tar.gz']
+source_urls = ['https://github.com/ospray/ospray/releases/download/v1.3.0/']
+
+sanity_check_paths={
+    'files': [],
+    'dirs': ['include', 'lib']
+}
+
+moduleclass = 'devel'


### PR DESCRIPTION
Testing OSPRAY-rendering of particles in ParaView was broken with the previous Intel versions. These two updates fix the problem. ParaView 5.4 will have to be re-linked as well.