### PR TITLE
Adding lowercase naming scheme (for kesch)

### DIFF
--- a/easybuild/__init__.py
+++ b/easybuild/__init__.py
@@ -1,0 +1,3 @@
+from pkgutil import extend_path
+# we're not the only ones in this namespace
+__path__ = extend_path(__path__, __name__)

--- a/easybuild/tools/__init__.py
+++ b/easybuild/tools/__init__.py
@@ -1,0 +1,3 @@
+from pkgutil import extend_path
+# we're not the only ones in this namespace
+__path__ = extend_path(__path__, __name__)

--- a/easybuild/tools/module_naming_scheme/__init__.py
+++ b/easybuild/tools/module_naming_scheme/__init__.py
@@ -1,0 +1,3 @@
+from pkgutil import extend_path
+# we're not the only ones in this namespace
+__path__ = extend_path(__path__, __name__)

--- a/easybuild/tools/module_naming_scheme/lowercase_module_naming_scheme.py
+++ b/easybuild/tools/module_naming_scheme/lowercase_module_naming_scheme.py
@@ -5,7 +5,7 @@ from easybuild.tools.module_naming_scheme import ModuleNamingScheme
 from easybuild.tools.module_naming_scheme.utilities import det_full_ec_version
 
 class LowercaseModuleNamingScheme(ModuleNamingScheme):
-    """Class implementing an example module naming scheme."""
+    """Class implementing a lowercase module naming scheme."""
 
     REQUIRED_KEYS = ['name', 'version', 'versionsuffix', 'toolchain']
 

--- a/easybuild/tools/module_naming_scheme/lowercase_module_naming_scheme.py
+++ b/easybuild/tools/module_naming_scheme/lowercase_module_naming_scheme.py
@@ -4,8 +4,6 @@ import re
 from easybuild.tools.module_naming_scheme import ModuleNamingScheme
 from easybuild.tools.module_naming_scheme.utilities import det_full_ec_version
 
-
-
 class LowercaseModuleNamingScheme(ModuleNamingScheme):
     """Class implementing an example module naming scheme."""
 
@@ -17,7 +15,6 @@ class LowercaseModuleNamingScheme(ModuleNamingScheme):
         :param ec: dict-like object with easyconfig parameter values (e.g. 'name', 'version', etc.)
         :return: string with full module name <name>/<installversion>, e.g.: 'gzip/1.5-goolf-1.4.10'
         """
-#        return os.path.join(ec['name'], det_full_ec_version(ec))
         return os.path.join(ec['name'], det_full_ec_version(ec)).lower()
 
     def is_short_modname_for(self, short_modname, name):

--- a/easybuild/tools/module_naming_scheme/lowercase_module_naming_scheme.py
+++ b/easybuild/tools/module_naming_scheme/lowercase_module_naming_scheme.py
@@ -1,0 +1,35 @@
+import os
+import re
+
+from easybuild.tools.module_naming_scheme import ModuleNamingScheme
+from easybuild.tools.module_naming_scheme.utilities import det_full_ec_version
+
+
+
+class LowercaseModuleNamingScheme(ModuleNamingScheme):
+    """Class implementing an example module naming scheme."""
+
+    REQUIRED_KEYS = ['name', 'version', 'versionsuffix', 'toolchain']
+
+    def det_full_module_name(self, ec):
+        """
+        Determine full module name from given easyconfig, according to the EasyBuild module naming scheme.
+        :param ec: dict-like object with easyconfig parameter values (e.g. 'name', 'version', etc.)
+        :return: string with full module name <name>/<installversion>, e.g.: 'gzip/1.5-goolf-1.4.10'
+        """
+#        return os.path.join(ec['name'], det_full_ec_version(ec))
+        return os.path.join(ec['name'], det_full_ec_version(ec)).lower()
+
+    def is_short_modname_for(self, short_modname, name):
+        """
+        Determine whether the specified (short) module name is a module for software with the specified name.
+        Default implementation checks via a strict regex pattern, and assumes short module names are of the form:
+            <name>/<version>[-<toolchain>]
+        """
+        modname_regex = re.compile('^%s(/\S+)?$' % re.escape(name.lower()))
+        res = bool(modname_regex.match(short_modname))
+
+        self.log.debug("Checking whether '%s' is a module name for software with name '%s' via regex %s: %s",
+                       short_modname, name, modname_regex.pattern, res)
+
+        return res


### PR DESCRIPTION
This is an attempt to answer the insisting MCH request to have lowercase module files. 

Here's how to test this:

```
$ export PYTHONPATH=$PYTHONPATH:/path/to/production
$ eb --avail-module-naming-schemes
List of supported module naming schemes:
	CategorizedHMNS
	CategorizedModuleNamingScheme
	HierarchicalMNS
	LowercaseModuleNamingScheme
	EasyBuildMNS
	MigrateFromEBToHMNS
$ export EASYBUILD_MODULE_NAMING_SCHEME=LowercaseModuleNamingScheme
```