### PR TITLE
Change from $CRAYPE_NETWORK_TARGET to $PE_ENV

### DIFF
--- a/easybuild/module/Easybuild
+++ b/easybuild/module/Easybuild
@@ -64,7 +64,7 @@ set host_machine [regsub -all {[0-9]} $::env(HOSTNAME) ""]
 set host_machine [regsub -all {[-]$} $host_machine ""]
 
 # Specific cray configurations
-if { [ info exists ::env(CRAYPE_NETWORK_TARGET) ] } {
+if { [ info exists ::env(PE_ENV) ] } {
     setenv EASYBUILD_OPTARCH                    $::env(CRAY_CPU_TARGET)
 
     setenv EASYBUILD_RECURSIVE_MODULE_UNLOAD    0

--- a/easybuild/module/Easybuild
+++ b/easybuild/module/Easybuild
@@ -80,7 +80,7 @@ if { [ info exists ::env(PE_ENV) ] } {
 #
 if { ! [ info exists ::env(EASYBUILD_PREFIX) ] } {
     # cray systems directory change
-    if { [ info exists ::env(CRAYPE_NETWORK_TARGET) ] } {
+    if { [ info exists ::env(PE_ENV) ] } {
         setenv EASYBUILD_PREFIX                 $::env(HOME)/easybuild/$host_machine/$::env(CRAY_CPU_TARGET)
     } else {
         setenv EASYBUILD_PREFIX                 $::env(HOME)/easybuild/$host_machine


### PR DESCRIPTION
This PR is about changing the variable we use to separate from CRAY system from non-Cray ones.