### PR TITLE
[daint-gpu] Fixing path to libsmm in architecture file

### DIFF
--- a/easybuild/easyconfigs/c/CP2K/CP2K-5.0r17753-CrayGNU-2016.11-cuda-8.0.54.eb
+++ b/easybuild/easyconfigs/c/CP2K/CP2K-5.0r17753-CrayGNU-2016.11-cuda-8.0.54.eb
@@ -37,11 +37,11 @@ prebuildopts = " sed -i -e 's/^DFLAGS .*/& -D__FFTSG -D__LIBINT -D__LIBXC -D__GF
 # add includes
 prebuildopts += " sed -i -e 's#-ffree-form .*#& -I$(EBROOTLIBINT)/include -I$(EBROOTLIBXC)/include#' ./arch/CRAY-XC30-gfortran-cuda.psmp && "
 # add libraries 
-prebuildopts += " sed -i -e '/LIBS     +=/a LIBS     += -lcudart -lcublas -lcufft -lrt $(EBROOTLIBINT)/lib/libderiv.a $(EBROOTLIBINT)/lib/libint.a $(EBROOTLIBINT)/lib/libr12.a -lstdc++ -L$(EBROOTLIBXC)/lib -lxcf90 -lxc ' ./arch/CRAY-XC30-gfortran-cuda.psmp && "
+prebuildopts += " sed -i -e '/LIBS     +=/a LIBS     += -lcudart -lcublas -lcufft -lrt $(EBROOTLIBINT)/lib/libderiv.a $(EBROOTLIBINT)/lib/libint.a $(EBROOTLIBINT)/lib/libr12.a -lstdc++ -L$(EBROOTLIBXC)/lib -lxcf90 -lxc /apps/common/UES/easybuild/sources/c/CP2K/libsmm_dnn_cray.gnu.a' ./arch/CRAY-XC30-gfortran-cuda.psmp && "
 # correct reference to specific GPU architecture (sm_60)
 prebuildopts += " sed -i -e 's/-arch sm_35/-arch sm_60/' ./arch/CRAY-XC30-gfortran-cuda.psmp && "
-# correct link to libsmm to match Intel Haswell architecture
-prebuildopts += " sed -i -e 's/sandybridge_gcc_4.9.0/haswell/' ./arch/CRAY-XC30-gfortran-cuda.psmp && "
+# removes wrong link to libsmm
+prebuildopts += " sed -i -e '/alazzaro/d' ./arch/CRAY-XC30-gfortran-cuda.psmp && "
 prebuildopts += " cat ./arch/CRAY-XC30-gfortran-cuda.psmp && pushd makefiles && "
 
 # build type


### PR DESCRIPTION
I have copied the library file that we link for Broadwell and Haswell architectures to: 
`/apps/common/UES/easybuild/sources/c/CP2K/libsmm_dnn_cray.gnu.a`