### PR TITLE
[monch] Adding PrgEnv-gnu module wrappers

### DIFF
--- a/easybuild/easyconfigs/p/PrgEnv-gnu/PrgEnv-gnu-17.06-gmvolf.eb
+++ b/easybuild/easyconfigs/p/PrgEnv-gnu/PrgEnv-gnu-17.06-gmvolf.eb
@@ -1,0 +1,13 @@
+# @author: gppezzi
+
+easyblock = 'Bundle'
+
+name = 'PrgEnv-gnu'
+version = '17.06-gmvolf'
+
+homepage = 'http://user.cscs.ch'
+description = """This bundle provides a meta module for the Programming Environment on monch"""
+
+toolchain = {'name': 'gmvolf', 'version': '17.06'}
+
+moduleclass = 'devel'

--- a/jenkins-builds/monch-RH6.9-17.06
+++ b/jenkins-builds/monch-RH6.9-17.06
@@ -1,6 +1,7 @@
  Boost-1.63.0-gmvolf-17.06-Python-3.5.3.eb
  HDF5-1.8.18-gmvolf-17.06-serial.eb
  HDF5-1.8.18-gmvolf-17.06.eb
+ PrgEnv-gnu-17.06-gmvolf.eb
  Python-2.7.12-gmvolf-17.06.eb
  Python-3.5.3-gmvolf-17.06.eb 
  reframe-2.4.eb


### PR DESCRIPTION
Since gmvolf is now hidden, we could provide this PrgEnv-gnu module (standard name at CSCS).