### PR TITLE
[daint] Adding login folder to production

### DIFF
--- a/jenkins-builds/production.sh
+++ b/jenkins-builds/production.sh
@@ -98,7 +98,7 @@ if [[ "$system" =~ "daint" || "$system" =~ "dom" ]]; then
         module rm PrgEnv-cray
         module use /opt/cray/pe/craype/2.5.8/modulefiles
         module load daint-${ARCH}
-        eb_args="${eb_args} --modules-header=$APPS/UES/login/daint-${ARCH}.h"
+        eb_args="${eb_args} --modules-header=../login/daint-${ARCH}.h"
     fi
 fi
 

--- a/jenkins-builds/production.sh
+++ b/jenkins-builds/production.sh
@@ -3,7 +3,16 @@
 # New modules will be added to xalt list (reversemap) at the end of this script, so one shouldn't use it as CI.
 # The xalt list will be updated only by user jenkins, therefore this script can only be used by user jenkins.
 
+# name of the script withouth the path
 scriptname=$(basename $0)
+# path to the folder containing the script
+scriptdir=$(dirname $0)
+# path of the top level folder (production directory)
+production_dir=${scriptdir%/*}
+
+echo $scriptname
+echo $scriptdir
+echo $production_dir
 
 usage() {
     echo "Usage: $0 [OPTIONS] <list-of-ebfiles>
@@ -98,7 +107,7 @@ if [[ "$system" =~ "daint" || "$system" =~ "dom" ]]; then
         module rm PrgEnv-cray
         module use /opt/cray/pe/craype/2.5.8/modulefiles
         module load daint-${ARCH}
-        eb_args="${eb_args} --modules-header=./login/daint-${ARCH}.h"
+        eb_args="${eb_args} --modules-header=${production_dir}/login/daint-${ARCH}.h"
     fi
 fi
 

--- a/jenkins-builds/production.sh
+++ b/jenkins-builds/production.sh
@@ -7,8 +7,6 @@
 scriptname=$(basename $0)
 # path to the folder containing the script
 scriptdir=$(dirname $0)
-# path of the top level folder (production directory)
-production_dir=${scriptdir%/*}
 
 usage() {
     echo "Usage: $0 [OPTIONS] <list-of-ebfiles>
@@ -103,7 +101,7 @@ if [[ "$system" =~ "daint" || "$system" =~ "dom" ]]; then
         module rm PrgEnv-cray
         module use /opt/cray/pe/craype/2.5.8/modulefiles
         module load daint-${ARCH}
-        eb_args="${eb_args} --modules-header=${production_dir}/login/daint-${ARCH}.h"
+        eb_args="${eb_args} --modules-header=${scriptdir%/*}/login/daint-${ARCH}.h"
     fi
 fi
 

--- a/jenkins-builds/production.sh
+++ b/jenkins-builds/production.sh
@@ -10,10 +10,6 @@ scriptdir=$(dirname $0)
 # path of the top level folder (production directory)
 production_dir=${scriptdir%/*}
 
-echo $scriptname
-echo $scriptdir
-echo $production_dir
-
 usage() {
     echo "Usage: $0 [OPTIONS] <list-of-ebfiles>
     -a,--arch     Architecture (gpu or mc)           (mandatory: Dom and Piz Daint only)

--- a/jenkins-builds/production.sh
+++ b/jenkins-builds/production.sh
@@ -98,7 +98,7 @@ if [[ "$system" =~ "daint" || "$system" =~ "dom" ]]; then
         module rm PrgEnv-cray
         module use /opt/cray/pe/craype/2.5.8/modulefiles
         module load daint-${ARCH}
-        eb_args="${eb_args} --modules-header=../login/daint-${ARCH}.h"
+        eb_args="${eb_args} --modules-header=./login/daint-${ARCH}.h"
     fi
 fi
 

--- a/login/daint-gpu
+++ b/login/daint-gpu
@@ -1,0 +1,47 @@
+#%Module
+
+# set environment
+set apps "$env(APPS)"
+set path "${apps}/UES/jenkins/6.0.UP02/ARCH/easybuild/modules/all"
+# set gpupath and mcpath
+set gpupath [string map { ARCH gpu } "${path}"]
+set mcpath [string map { ARCH mc } "${path}"]
+# list of modulefiles in gpupath
+set gpulist [exec ls --color=none "${gpupath}"]
+
+# checks for conflicts
+if { [is-loaded craype-broadwell] } {
+ module unload craype-broadwell
+ module unuse "${mcpath}"
+}
+# conflicts
+conflict craype-broadwell
+conflict daint-mc
+
+# module remove (unload) or switch (swap): unload dependencies
+if { [module-info mode remove] || [module-info mode switch] } {
+ foreach module ${gpulist} {
+#  if { [is-loaded ${module}] } {
+   module unload ${module}
+#  }
+ }
+}
+
+# load dependency and update MODULEPATH
+module load craype-haswell
+module use "${gpupath}"
+
+# load additional modules
+#module load xalt
+
+# print help screen
+if { [module-info mode help] } {
+proc ModulesHelp { } {
+ global apps gpupath
+ puts stderr "\t Set environment for gpu haswell compute nodes:
+  \t - module load craype-haswell
+  \t - module use ${gpupath} 
+ "
+ return 0
+}
+}

--- a/login/daint-gpu.h
+++ b/login/daint-gpu.h
@@ -1,0 +1,4 @@
+# gpu header for modulefiles created by EasyBuild
+conflict craype-broadwell
+conflict daint-mc
+prereq daint-gpu

--- a/login/daint-mc
+++ b/login/daint-mc
@@ -1,0 +1,47 @@
+#%Module
+
+# set environment
+set apps "$env(APPS)"
+set path "${apps}/UES/jenkins/6.0.UP02/ARCH/easybuild/modules/all"
+# set gpupath and mcpath
+set gpupath [ string map { ARCH gpu } "${path}" ]
+set mcpath [ string map { ARCH mc } "${path}" ]
+# list of modulefiles in mcpath
+set mclist [exec ls --color=none "${mcpath}"]
+
+# checks for conflicts
+if { [ is-loaded craype-haswell ] } {
+ module unload craype-haswell
+ module unuse "${gpupath}"
+}
+# conflicts
+conflict craype-haswell
+conflict daint-gpu
+
+# module remove (unload) or switch (swap): unload dependencies
+if { [module-info mode remove] || [module-info mode switch] } {
+ foreach module ${mclist} {
+#  if { [is-loaded ${module}] } {
+   module unload ${module}
+#  }
+ }
+}
+
+# load dependency and update MODULEPATH
+module load craype-broadwell
+module use "${mcpath}"
+
+# load additional modules
+#module load xalt
+
+# print help screen
+if { [ module-info mode help ] } {
+proc ModulesHelp { } {
+ global apps mcpath
+ puts stderr "\t Set environment for mc broadwell compute nodes:
+  \t - module load craype-broadwell
+  \t - module use ${mcpath} 
+ "
+ return 0
+}
+}

--- a/login/daint-mc.h
+++ b/login/daint-mc.h
@@ -1,0 +1,4 @@
+# mc header for modulefiles created by EasyBuild
+conflict craype-haswell
+conflict daint-gpu
+prereq daint-mc

--- a/login/xalt
+++ b/login/xalt
@@ -1,0 +1,1 @@
+/apps/daint/UES/xalt/git/cscs/xalt/


### PR DESCRIPTION
The folder contains the modules needed to load the architecture dependent software stack on Piz Daint, together with the EasyBuild headers used to build production modulefiles and a link to the xalt modulefile:
- daint-gpu
- daint-gpu.h
- daint-mc
- daint-mc.h
- xalt
