### PR TITLE
[leone] adding boost for ESyS

### DIFF
--- a/jenkins-builds/leone-RHEL6.7EUS-17.06
+++ b/jenkins-builds/leone-RHEL6.7EUS-17.06
@@ -1,3 +1,4 @@
+ Boost-1.61.0-foss-2016b-Python-2.7.12.eb
  ddt-7.0.5.eb --set-default-module
  OpenFOAM-4.1-foss-2016b.eb
  OpenFOAM-Extend-4.0-foss-2016b.eb


### PR DESCRIPTION
So that the user finds all the dependencies on the modulepath when building ESyS