### PR TITLE
[daint dom kesch leone monch] Define BUILDPATH and TMPDIR only if not set

### DIFF
--- a/easybuild/easyconfigs/e/EasyBuild-custom/EasyBuild-custom-cscs.eb
+++ b/easybuild/easyconfigs/e/EasyBuild-custom/EasyBuild-custom-cscs.eb
@@ -83,11 +83,15 @@ setenv EASYBUILD_INSTALLPATH                    $::env(EASYBUILD_PREFIX)
 #
 # If not set, EASYBUILD_BUILDPATH and EASYBUILD_TMPDIR will point to /dev/shm/$USER/easbuild/stage
 #
-if { ! [ info exists ::env(EASYBUILD_TMPDIR) ] } {
-    setenv EASYBUILD_TMPDIR                         /dev/shm/$::env(USER)/easybuild/stage/tmp
+if { [ info exists ::env(EASYBUILD_TMPDIR) ] } {
+    setenv EASYBUILD_TMPDIR                     $::env(EASYBUILD_TMPDIR)
+} else {
+    setenv EASYBUILD_TMPDIR                     /dev/shm/$::env(USER)/easybuild/stage/tmp
 }
-if { ! [ info exists ::env(EASYBUILD_BUILDPATH) ] } {
-    setenv EASYBUILD_BUILDPATH                      /dev/shm/$::env(USER)/easybuild/stage/build
+if { [ info exists ::env(EASYBUILD_BUILDPATH) ] } {
+    setenv EASYBUILD_BUILDPATH                  $::env(EASYBUILD_BUILDPATH)
+} else {
+    setenv EASYBUILD_BUILDPATH                  /dev/shm/$::env(USER)/easybuild/stage/build
 }
 ###############
 # FINAL TOUCH #

--- a/easybuild/easyconfigs/e/EasyBuild-custom/EasyBuild-custom-cscs.eb
+++ b/easybuild/easyconfigs/e/EasyBuild-custom/EasyBuild-custom-cscs.eb
@@ -81,12 +81,14 @@ if { ! [ info exists ::env(EASYBUILD_PREFIX) ] } {
 }
 setenv EASYBUILD_INSTALLPATH                    $::env(EASYBUILD_PREFIX)
 #
-# These variables are set to /dev/shm/$USER/easbuild/stage
-# EASYBUILD_BUILDPATH
-# EASYBUILD_TMPDIR
+# If not set, EASYBUILD_BUILDPATH and EASYBUILD_TMPDIR will point to /dev/shm/$USER/easbuild/stage
 #
-setenv EASYBUILD_TMPDIR                         /dev/shm/$::env(USER)/easybuild/stage/tmp
-setenv EASYBUILD_BUILDPATH                      /dev/shm/$::env(USER)/easybuild/stage/build
+if { ! [ info exists ::env(EASYBUILD_TMPDIR) ] } {
+    setenv EASYBUILD_TMPDIR                         /dev/shm/$::env(USER)/easybuild/stage/tmp
+}
+if { ! [ info exists ::env(EASYBUILD_BUILDPATH) ] } {
+    setenv EASYBUILD_BUILDPATH                      /dev/shm/$::env(USER)/easybuild/stage/build
+}
 ###############
 # FINAL TOUCH #
 ###############

--- a/easybuild/module/Easybuild
+++ b/easybuild/module/Easybuild
@@ -87,12 +87,14 @@ if { ! [ info exists ::env(EASYBUILD_PREFIX) ] } {
 }
 setenv EASYBUILD_INSTALLPATH                    $::env(EASYBUILD_PREFIX)
 #
-# These variables are set to /dev/shm/$USER/easbuild/stage
-# EASYBUILD_BUILDPATH
-# EASYBUILD_TMPDIR
+# If not set, EASYBUILD_BUILDPATH and EASYBUILD_TMPDIR will point to /dev/shm/$USER/easbuild/stage
 #
-setenv EASYBUILD_TMPDIR                         /dev/shm/$::env(USER)/easybuild/stage/tmp
-setenv EASYBUILD_BUILDPATH                      /dev/shm/$::env(USER)/easybuild/stage/build
+if { ! [ info exists ::env(EASYBUILD_TMPDIR) ] } {
+    setenv EASYBUILD_TMPDIR                         /dev/shm/$::env(USER)/easybuild/stage/tmp
+}
+if { ! [ info exists ::env(EASYBUILD_BUILDPATH) ] } {
+    setenv EASYBUILD_BUILDPATH                      /dev/shm/$::env(USER)/easybuild/stage/build
+}
 ###############
 # FINAL TOUCH #
 ###############


### PR DESCRIPTION
The environment variables `EASYBUILD_BUILDPATH` and `EASYBUILD_TMPDIR` will be defined only if the `$USER` has not previously set these varialbes in the environment.