### PR TITLE
[daint-gpu] CDO update

### DIFF
--- a/jenkins-builds/6.0.UP02-2016.11-gpu
+++ b/jenkins-builds/6.0.UP02-2016.11-gpu
@@ -7,7 +7,7 @@
  Boost-1.63.0-CrayGNU-2016.11-Python-2.7.12.eb
  Boost-1.61.0-CrayGNU-2016.11-Python-2.7.12.eb
  CDO-1.7.2-CrayGNU-2016.11.eb
- CDO-1.8.0rc6-CrayGNU-2016.11.eb
+ CDO-1.8.1-CrayGNU-2016.11.eb
  CMake-3.6.0.eb
  CP2K-4.1-CrayGNU-2016.11-cuda-8.0.54.eb
  CPMD-4.1-CrayIntel-2016.11.eb

--- a/jenkins-builds/6.0.UP02-2016.11-mc
+++ b/jenkins-builds/6.0.UP02-2016.11-mc
@@ -6,7 +6,7 @@
  Boost-1.63.0-CrayGNU-2016.11-Python-2.7.12.eb
  Boost-1.61.0-CrayGNU-2016.11-Python-2.7.12.eb
  CDO-1.7.2-CrayGNU-2016.11.eb
- CDO-1.8.0rc6-CrayGNU-2016.11.eb
+ CDO-1.8.1-CrayGNU-2016.11.eb
  CMake-3.6.0.eb
  CP2K-4.1-CrayGNU-2016.11.eb
  CPMD-4.1-CrayIntel-2016.11.eb


### PR DESCRIPTION
We currently have a release candidate for CDO in production, while the EasyBuild configuration file for release 1.8.1 is already available for `CrayGNU-2016.11`. 
Furthermore, the change should make the download work automatically.