### PR TITLE
[dom] Update cray_external_modules_metadata.cfg

### DIFF
--- a/easybuild/cray_external_modules_metadata.cfg
+++ b/easybuild/cray_external_modules_metadata.cfg
@@ -1,6 +1,11 @@
 # metadata useful to EasyBuild (hpcugent.github.io/easybuild) for modules provided by Cray on Cray systems
 # authors: Guilherme Peretti-Pezzi (CSCS), Petar Forai (IMP/IMBA), Kenneth Hoste (HPC-UGent)
 
+[cray-fftw/3.3.6.2]
+name = FFTW
+version = 3.3.6.2
+prefix = FFTW_INC/..
+
 [cray-hdf5/1.8.13]
 name = HDF5
 version = 1.8.13
@@ -101,6 +106,16 @@ name = PETSc
 version = 3.7.2.1
 prefix = PETSC_DIR
 
+[cray-python/17.06.1]
+name = Python
+version = 17.06.1
+prefix = PYTHONPATH
+
+[cray-R/3.3.3]
+name = R
+version = 3.3.3
+prefix = 
+
 [cray-tpsl/16.07.1]
 name = TPSL
 version = 16.07.1 
@@ -146,6 +161,11 @@ name = CUDA
 version = 8.0.54_2.2.8_ga620558-2.1
 prefix = CRAY_CUDATOOLKIT_DIR
 
+[cudatoolkit/8.0.61_2.4.3-6.0.4.0_3.1__gb475d12]
+name = CUDA
+version = 8.0.61_2.4.3-6.0.4.0_3.1__gb475d12
+prefix = CRAY_CUDATOOLKIT_DIR
+
 [fftw/3.3.4.3]
 name = FFTW
 version = 3.3.4.3
@@ -169,6 +189,11 @@ prefix = FFTW_INC/..
 [fftw/3.3.4.10]
 name = FFTW
 version = 3.3.4.10
+prefix = FFTW_INC/..
+
+[fftw/3.3.4.11]
+name = FFTW
+version = 3.3.4.11
 prefix = FFTW_INC/..
 
 [gcc/4.9.2]

--- a/easybuild/cray_external_modules_metadata.cfg
+++ b/easybuild/cray_external_modules_metadata.cfg
@@ -107,12 +107,12 @@ version = 3.7.2.1
 prefix = PETSC_DIR
 
 [cray-python/17.06.1]
-name = Python
+name = CrayPython
 version = 17.06.1
-prefix = PYTHONPATH
+prefix = PYTHON_PATH
 
 [cray-R/3.3.3]
-name = R
+name = CrayR
 version = 3.3.3
 prefix = 
 


### PR DESCRIPTION
New Cray modules available:
- `cray-fftw`
- `cray-python`
- `cray-R`

New versions of existing modules:
- `cudatoolkit`
- `fftw`