### PR TITLE
[monch] Fixing download link for libreadline-7.0

### DIFF
--- a/easybuild/easyconfigs/l/libreadline/libreadline-7.0.eb
+++ b/easybuild/easyconfigs/l/libreadline/libreadline-7.0.eb
@@ -1,3 +1,4 @@
+# contributed by Luca Marsella (CSCS)
 easyblock = 'ConfigureMake'
 
 name = 'libreadline'
@@ -13,8 +14,7 @@ description = """The GNU Readline library provides a set of functions for use by
 toolchain = {'name': 'dummy', 'version': ''}
 toolchainopts = {'pic': True}
 
-# source_urls = ['http://ftp.gnu.org/gnu/readline']
-source_urls = ['http://ftp.gnu.org/gnu/bash']
+source_urls = ['http://ftp.gnu.org/gnu/readline']
 sources = ['readline-%(version)s.tar.gz']
 # unset EBROOTLIBREADLINE
 


### PR DESCRIPTION
Jenkins project `RegressionEB` returned a download error: 
https://jenkins.cscs.ch/view/RegressionEB/job/RegressionEB/label=monch04/25/console
As a matter of fact, release 7.0 was not available for download in the link given in the configuration file.