### PR TITLE
[daint] Fixing CDO sources

### DIFF
--- a/easybuild/easyconfigs/c/CDO/CDO-1.8.1-CrayGNU-2016.11.eb
+++ b/easybuild/easyconfigs/c/CDO/CDO-1.8.1-CrayGNU-2016.11.eb
@@ -1,4 +1,4 @@
-# Updated by @gppezzi @jgphpc
+# contributed by Guilherme Peretti Pezzi, Jean-Guillaume Piccinali and Luca Marsella (CSCS)
 easyblock = 'ConfigureMake'
 
 name = 'CDO'
@@ -10,8 +10,7 @@ description = """CDO is a collection of command line Operators to manipulate and
 toolchain = {'name': 'CrayGNU', 'version': '2016.11'}
 toolchainopts = {'opt': True, 'pic': True}
 
-sources = ['cdo-%(version)s.tar.gz']
-source_urls = ['https://code.zmaw.de/attachments/download/14271/']
+sources = ['/apps/common/UES/easybuild/sources/%(nameletterlower)s/%(name)s/' + SOURCELOWER_TAR_GZ]
 checksums = [ '54498438de788f245d47499efad7966c' ]
 
 # do not use cray-netcdf/4.4.1 because it is compiled with cray-hdf5/1.10


### PR DESCRIPTION
The link given in the configuration file is not valid anymore, see the error message in the output below:
https://jenkins.cscs.ch/job/RegressionEB/label=daint/25/consoleFull

The current download link https://code.mpimet.mpg.de/projects/cdo/files does not provide release `1.8.1`, therefore we need to use the absolute path for this release.