### PR TITLE
[daint] Fix VisIt build on compute nodes

### DIFF
--- a/easybuild/easyconfigs/v/Visit/Visit-2.12.0-CrayGNU-2016.11.eb
+++ b/easybuild/easyconfigs/v/Visit/Visit-2.12.0-CrayGNU-2016.11.eb
@@ -64,8 +64,8 @@ preconfigopts += ' --system-cmake --h5part --no-pyside --system-python --alt-boo
 preconfigopts += ' --vtk --mesa --parallel --hdf5 --silo --szip --makeflags -j20 '
 preconfigopts += ' --xdmf '
 preconfigopts += ' --netcdf --qt <<< "yes" && '
-preconfigopts += ' sed -i /VISIT_MPI_COMPILER/d $HOSTNAME.cmake; '
-preconfigopts += ' cp $HOSTNAME.cmake ../visit%(version)s/src/config-site; '
+preconfigopts += ' sed -i /VISIT_MPI_COMPILER/d $(hostname).cmake; '
+preconfigopts += ' cp $(hostname).cmake ../visit%(version)s/src/config-site; '
 preconfigopts += ' mkdir build; '
 preconfigopts += ' cd build; '
 


### PR DESCRIPTION
The build of `VisIt` would fail on compute nodes as its configuration calls the environment variable `$HOSTNAME`, which is defined with the $SLURM_SUBMIT_HOST and not with the real host. 
The fix makes use instead of the command `hostname`: other variables hold the name of the compute host, e.g. `SLURMD_NODENAME`; for a full list, please have a look at the output pasted below.
```
$ srun --constraint=gpu --nodes=1 --time=01:00:00 --pty /bin/bash -l
srun: job 3444144 queued and waiting for resources
srun: job 3444144 has been allocated resources

$ echo $HOSTNAME
daint103

$ echo $SLURM_SUBMIT_HOST 
daint103

$ echo $(hostname)
nid04027

$ env | grep nid
SLURM_NODELIST=nid04027
SLURMD_NODENAME=nid04027
SLURM_TOPOLOGY_ADDR=s19.s9.nid04027
SLURM_JOB_NODELIST=nid04027
SLURM_STEP_NODELIST=nid04027
```