### PR TITLE
Removing Scalasca and Score-P

### DIFF
--- a/jenkins-builds/6.0.UP02-2016.11-gpu
+++ b/jenkins-builds/6.0.UP02-2016.11-gpu
@@ -52,14 +52,6 @@
  QuantumESPRESSO-6.1.0-CrayIntel-2016.11.eb
  QuantumESPRESSO-5.4.0-CrayIntel-2016.11.eb
  R-3.3.2-CrayGNU-2016.11.eb
- Scalasca-2.3.1-CrayGNU-2016.11.eb
- Scalasca-2.3.1-CrayIntel-2016.11.eb
- Scalasca-2.3.1-CrayPGI-2016.11.eb
- Score-P-3.0-CrayCCE-2016.11.eb
- Score-P-3.0-CrayGNU-2016.11.eb
- Score-P-3.0-CrayIntel-2016.11.eb
- Score-P-3.0-CrayPGI-2016.11.eb
- Score-P-3.0-CrayGNU-2016.11-cuda-8.0.54.eb
  Spark-1.6.0.eb
  TensorFlow-1.0.0-CrayGNU-2016.11-cuda-8.0-Python-2.7.12.eb
  TensorFlow-1.0.0-CrayGNU-2016.11-cuda-8.0-Python-3.5.2.eb

--- a/jenkins-builds/6.0.UP02-2016.11-mc
+++ b/jenkins-builds/6.0.UP02-2016.11-mc
@@ -40,13 +40,6 @@
  QuantumESPRESSO-6.1.0-CrayIntel-2016.11.eb
  QuantumESPRESSO-5.4.0-CrayIntel-2016.11.eb
  R-3.3.2-CrayGNU-2016.11.eb
- Scalasca-2.3.1-CrayGNU-2016.11.eb
- Scalasca-2.3.1-CrayIntel-2016.11.eb
- Scalasca-2.3.1-CrayPGI-2016.11.eb
- Score-P-3.0-CrayCCE-2016.11.eb
- Score-P-3.0-CrayGNU-2016.11.eb
- Score-P-3.0-CrayIntel-2016.11.eb
- Score-P-3.0-CrayPGI-2016.11.eb
  Spark-1.6.0.eb
  vampir-9.3.0.eb --set-default-module
  VASP-5.4.1-CrayIntel-2016.11.eb


### PR DESCRIPTION
Their builds fail on Piz Daint compute nodes. However the build of Scalasca with `17.08` is successful on Dom compute nodes.