### PR TITLE
WIP [dom] Helper modules pointing to the new PE

### DIFF
--- a/login/dom-gpu
+++ b/login/dom-gpu
@@ -1,0 +1,50 @@
+#%Module
+
+# This module is for testing purposes when upgrading the PE.
+
+# set environment
+set apps "$env(APPS)"
+set path "${apps}/UES/jenkins/6.0.UP04/ARCH/easybuild/modules/all"
+# set gpupath and mcpath
+set gpupath [string map { ARCH gpu } "${path}"]
+set mcpath [string map { ARCH mc } "${path}"]
+# list of modulefiles in gpupath
+set gpulist [exec ls --color=none "${gpupath}"]
+
+# checks for conflicts
+if { [is-loaded craype-broadwell] } {
+ module unload craype-broadwell
+ module unuse "${mcpath}"
+}
+# conflicts
+conflict craype-broadwell
+conflict daint-mc
+conflict dom-mc
+
+# module remove (unload) or switch (swap): unload dependencies
+if { [module-info mode remove] || [module-info mode switch] } {
+ foreach module ${gpulist} {
+#  if { [is-loaded ${module}] } {
+   module unload ${module}
+#  }
+ }
+}
+
+# load dependency and update MODULEPATH
+module load craype-haswell
+module use "${gpupath}"
+
+# load additional modules
+#module load xalt
+
+# print help screen
+if { [module-info mode help] } {
+proc ModulesHelp { } {
+ global apps gpupath
+ puts stderr "\t Set environment for gpu haswell compute nodes:
+  \t - module load craype-haswell
+  \t - module use ${gpupath}
+ "
+ return 0
+}
+}

--- a/login/dom-mc
+++ b/login/dom-mc
@@ -1,0 +1,50 @@
+#%Module
+
+# This module is for testing purposes when upgrading the PE.
+
+# set environment
+set apps "$env(APPS)"
+set path "${apps}/UES/jenkins/6.0.UP04/ARCH/easybuild/modules/all"
+# set gpupath and mcpath
+set gpupath [ string map { ARCH gpu } "${path}" ]
+set mcpath [ string map { ARCH mc } "${path}" ]
+# list of modulefiles in mcpath
+set mclist [exec ls --color=none "${mcpath}"]
+
+# checks for conflicts
+if { [ is-loaded craype-haswell ] } {
+ module unload craype-haswell
+ module unuse "${gpupath}"
+}
+# conflicts
+conflict craype-haswell
+conflict daint-gpu
+conflict dom-gpu
+
+# module remove (unload) or switch (swap): unload dependencies
+if { [module-info mode remove] || [module-info mode switch] } {
+ foreach module ${mclist} {
+#  if { [is-loaded ${module}] } {
+   module unload ${module}
+#  }
+ }
+}
+
+# load dependency and update MODULEPATH
+module load craype-broadwell
+module use "${mcpath}"
+
+# load additional modules
+#module load xalt
+
+# print help screen
+if { [ module-info mode help ] } {
+proc ModulesHelp { } {
+ global apps mcpath
+ puts stderr "\t Set environment for mc broadwell compute nodes:
+  \t - module load craype-broadwell
+  \t - module use ${mcpath}
+ "
+ return 0
+}
+}


### PR DESCRIPTION
I am proposing the introduction of the `dom-gpu` and `dom-mc` helper login packages as helpers to the `daint-gpu` and `daint-mc`. They will be practically the same except during the transition periods to a new PE, in which case the Dom scripts will be updated first to the new paths. This has the advantage that we can automate the testing of the new PE without having to memorise every time the correct module path to use and will also help the CI of Reframe while adapting or developing tests for the new PEs.