### PR TITLE
[dom] QuantumESPRESSO 6.1.0 with updated production lists

### DIFF
--- a/easybuild/easyconfigs/q/QuantumESPRESSO/QuantumESPRESSO-6.1.0-CrayIntel-17.08.eb
+++ b/easybuild/easyconfigs/q/QuantumESPRESSO/QuantumESPRESSO-6.1.0-CrayIntel-17.08.eb
@@ -1,0 +1,39 @@
+# contributed by Guilherme Peretti Pezzi and Luca Marsella (CSCS)
+easyblock = "ConfigureMake"
+
+name = 'QuantumESPRESSO'
+version = '6.1.0'
+
+homepage = 'http://www.quantum-espresso.org/'
+description = """Quantum ESPRESSO  is an integrated suite of computer codes
+ for electronic-structure calculations and materials modeling at the nanoscale.
+ It is based on density-functional theory, plane waves, and pseudopotentials
+  (both norm-conserving and ultrasoft)."""
+
+toolchain = {'name': 'CrayIntel', 'version': '17.08'}
+toolchainopts = {'usempi': True, 'openmp': True}
+
+sources = ['qe-%(version_major_minor)s.tar.gz']
+source_urls = ['http://qe-forge.org/gf/download/frsrelease/240/1075/']
+
+builddependencies = [
+    ('cray-fftw/3.3.6.2', EXTERNAL_MODULE),
+]
+
+preconfigopts = ' CC=cc LDFLAGS+="$LDFLAGS -qopenmp" && ' 
+preconfigopts += ' BLAS_LIBS="$MKLROOT/lib/intel64/libmkl_blas95_lp64.a" && ' 
+preconfigopts += ' LAPACK_LIBS="$MKLROOT/lib/intel64/libmkl_lapack95_lp64.a" && ' 
+preconfigopts += ' SCALAPACK_LIBS="-L$MKLROOT/lib/intel64 -lmkl_scalapack_lp64 -lmkl_intel_lp64 -lmkl_sequential -lmkl_core -lmkl_blacs_intelmpi_lp64" && '
+configopts = ' ARCH=crayxt --enable-openmp --enable-parallel --with-scalapack '
+
+prebuildopts = ' cat make.inc && '
+buildopts = 'all'
+# a single make process is required, since parallel builds fail
+maxparallel = 1
+
+sanity_check_paths = {
+      'files': ['bin/pw.x', 'bin/cp.x'],
+      'dirs': ['']
+}
+
+moduleclass = 'chem'

--- a/jenkins-builds/6.0.UP04-17.08-gpu
+++ b/jenkins-builds/6.0.UP04-17.08-gpu
@@ -24,6 +24,7 @@
  papi-wrap-1.0-CrayCCE-17.08.eb
  papi-wrap-1.0-CrayIntel-17.08.eb
  Python-bare-3.6.2.eb                               --hidden
+ QuantumESPRESSO-6.1.0-CrayIntel-17.08.eb --set-default-module
  reframe-2.6.eb                                     --set-default-module
  Scalasca-2.3.1-CrayGNU-17.08.eb                    --set-default-module
  Scalasca-2.3.1-CrayIntel-17.08.eb

--- a/jenkins-builds/6.0.UP04-17.08-mc
+++ b/jenkins-builds/6.0.UP04-17.08-mc
@@ -20,6 +20,7 @@
  papi-wrap-1.0-CrayCCE-17.08.eb
  papi-wrap-1.0-CrayIntel-17.08.eb
  Python-bare-3.6.2.eb                               --hidden
+ QuantumESPRESSO-6.1.0-CrayIntel-17.08.eb --set-default-module
  reframe-2.6.eb                                     --set-default-module
  Scalasca-2.3.1-CrayGNU-17.08.eb                    --set-default-module
  Scalasca-2.3.1-CrayIntel-17.08.eb


### PR DESCRIPTION
EasyBuild configuration file for QuantumESPRESSO and updated production lists: version 6.1.0 does not have a GPU port, so the same module will be built on both software stacks `gpu` and `mc`.