### PR TITLE
Removing module purge from daint and dom

### DIFF
--- a/jenkins-builds/production.sh
+++ b/jenkins-builds/production.sh
@@ -96,7 +96,7 @@ if [[ "$system" =~ "daint" || "$system" =~ "dom" ]]; then
         echo -e "\n No architecture defined. Please use the option -a,--arch to define the architecture \n"
         usage
     else
-        module purge
+        #module purge
         module load craype craype-network-aries modules ugni
         module load daint-${ARCH}
         eb_args="${eb_args} --modules-header=${scriptdir%/*}/login/daint-${ARCH}.h --modules-footer=${scriptdir%/*}/login/daint.footer"

--- a/jenkins-builds/production.sh
+++ b/jenkins-builds/production.sh
@@ -97,8 +97,7 @@ if [[ "$system" =~ "daint" || "$system" =~ "dom" ]]; then
         usage
     else
         module purge
-        module load craype craype-network-aries modules ugni
-        module use /opt/cray/pe/perftools/6.5.1/modulefiles
+        module load craype craype-network-aries modules perftools-base ugni
         module load daint-${ARCH}
         eb_args="${eb_args} --modules-header=${scriptdir%/*}/login/daint-${ARCH}.h --modules-footer=${scriptdir%/*}/login/daint.footer"
     fi

--- a/jenkins-builds/production.sh
+++ b/jenkins-builds/production.sh
@@ -96,8 +96,9 @@ if [[ "$system" =~ "daint" || "$system" =~ "dom" ]]; then
         echo -e "\n No architecture defined. Please use the option -a,--arch to define the architecture \n"
         usage
     else
-        #module purge
+        module purge
         module load craype craype-network-aries modules ugni
+        module use /opt/cray/pe/perftools/6.5.1/modulefiles
         module load daint-${ARCH}
         eb_args="${eb_args} --modules-header=${scriptdir%/*}/login/daint-${ARCH}.h --modules-footer=${scriptdir%/*}/login/daint.footer"
     fi


### PR DESCRIPTION
I do not understand why we have this module purge. 
It hurts on the builds when attempting to build with craypat support. 
See:
https://github.com/eth-cscs/production/pull/326
https://jenkins.cscs.ch/view/ProductionEB/job/TestingEB/551/label=dom/console

IMHO, there are two solutions, one is to remove the `module purge` and the other is to recover the needed folder by adding `module use ...`. I am choosing the first one if there is no other problem, that I cannot foresee.