### PR TITLE
[dom] Python extensions for cray-python

### DIFF
--- a/easybuild/easyconfigs/p/PyExtensions/PyExtensions-2.7-CrayGNU-17.08.eb
+++ b/easybuild/easyconfigs/p/PyExtensions/PyExtensions-2.7-CrayGNU-17.08.eb
@@ -1,0 +1,55 @@
+# contributed by Luca Marsella (CSCS)
+easyblock = 'Bundle'
+
+name = 'PyExtensions'
+# python version used from cray-python
+version = '2.7'
+
+homepage = 'https://pypi.python.org/pypi'
+description = """This module is a bundle of Python packages on Cray systems based on the module cray-python"""
+
+toolchain = {'name': 'CrayGNU', 'version': '17.08'}
+toolchainopts = {'pic': True, 'verbose' : False }
+
+dependencies = [
+    ('cray-python/17.06.1', EXTERNAL_MODULE),
+]
+
+# bundle of Python packages
+exts_defaultclass = 'PythonPackage'
+
+exts_list = [
+     ('Cython', '0.26.1', {
+         'source_urls': ['https://pypi.python.org/packages/source/c/cython/'],
+     }),
+     ('six', '1.10.0', {
+         'source_urls': ['https://pypi.python.org/packages/source/s/six/'],
+     }),
+     ('matplotlib', '2.0.2', {
+         'source_urls': ['https://pypi.python.org/packages/source/m/matplotlib/'],
+     }),
+     ('pandas', '0.20.3', {
+         'source_urls': ['https://pypi.python.org/packages/source/p/pandas/'],
+     }),
+     ('pygelf', '0.3.1', {
+         'source_urls': ['https://pypi.python.org/packages/source/p/pygelf/'],
+     }),
+     ('PyMySQL', '0.7.11', {
+         'source_urls': ['https://pypi.python.org/packages/source/p/PyMySQL/'],
+     }),
+     ('influxdb', '4.1.1', {
+         'source_urls': ['https://pypi.python.org/packages/source/i/influxdb/'],
+     }),
+ ]
+
+# specify that Bundle easyblock should run a full sanity check, rather than just trying to load the module
+full_sanity_check = True
+
+modextrapaths = {'PYTHONPATH': ['lib/python{0}/site-packages'.format(version)]}
+
+sanity_check_paths = {
+    'files': [],
+    'dirs': ['lib/python%s/site-packages' % version]
+}
+
+moduleclass = 'tools'

--- a/easybuild/easyconfigs/p/PyExtensions/PyExtensions-3.5-CrayGNU-17.08.eb
+++ b/easybuild/easyconfigs/p/PyExtensions/PyExtensions-3.5-CrayGNU-17.08.eb
@@ -1,0 +1,69 @@
+# contributed by Luca Marsella (CSCS)
+easyblock = 'Bundle'
+
+name = 'PyExtensions'
+# python version used from cray-python
+version = '3.5'
+
+homepage = 'https://pypi.python.org/pypi'
+description = """This module is a bundle of Python packages on Cray systems based on the module cray-python"""
+
+toolchain = {'name': 'CrayGNU', 'version': '17.08'}
+toolchainopts = {'pic': True, 'verbose' : False }
+
+dependencies = [
+    ('cray-python/17.06.1', EXTERNAL_MODULE),
+]
+
+# bundle of Python packages
+exts_defaultclass = 'PythonPackage'
+
+exts_list = [
+     ('Cython', '0.26.1', {
+         'req_py_majver' : '3',
+         'req_py_minver' : '5',
+         'source_urls': ['https://pypi.python.org/packages/source/c/cython/'],
+     }),
+     ('six', '1.10.0', {
+         'req_py_majver' : '3',
+         'req_py_minver' : '5',
+         'source_urls': ['https://pypi.python.org/packages/source/s/six/'],
+     }),
+     ('matplotlib', '2.0.2', {
+         'req_py_majver' : '3',
+         'req_py_minver' : '5',
+         'source_urls': ['https://pypi.python.org/packages/source/m/matplotlib/'],
+     }),
+     ('pandas', '0.20.3', {
+         'req_py_majver' : '3',
+         'req_py_minver' : '5',
+         'source_urls': ['https://pypi.python.org/packages/source/p/pandas/'],
+     }),
+     ('pygelf', '0.3.1', {
+         'req_py_majver' : '3',
+         'req_py_minver' : '5',
+         'source_urls': ['https://pypi.python.org/packages/source/p/pygelf/'],
+     }),
+     ('PyMySQL', '0.7.11', {
+         'req_py_majver' : '3',
+         'req_py_minver' : '5',
+         'source_urls': ['https://pypi.python.org/packages/source/p/PyMySQL/'],
+     }),
+     ('influxdb', '4.1.1', {
+         'req_py_majver' : '3',
+         'req_py_minver' : '5',
+         'source_urls': ['https://pypi.python.org/packages/source/i/influxdb/'],
+     }),
+]
+
+# specify that Bundle easyblock should run a full sanity check, rather than just trying to load the module
+full_sanity_check = True
+
+modextrapaths = {'PYTHONPATH': ['lib/python{0}/site-packages'.format(version)]}
+
+sanity_check_paths = {
+    'files': [],
+    'dirs': ['lib/python%s/site-packages' % version]
+}
+
+moduleclass = 'tools'


### PR DESCRIPTION
I propose the name `PyExtensions-%(version)s`, where `%(version)s` is the two digit Python version:
- I don't mention python in the name, the name itself suggests that it is based on Python
- the toolchain name `CrayGNU` clarifies that we are on a Cray system, hinting at `cray-python`
- the toolchain version `17.08` identifies uniquely the version of `cray-python` used as dependency

The extensions built in this recipe are the ones missing from `cray-python` with respect to Python modules built on the Cray so far: the list can be extended if needed (we already added new modules).