### PR TITLE
[dom-gpu] NAMD with PE 17.08

### DIFF
--- a/easybuild/easyconfigs/n/NAMD/NAMD-2.12-CrayIntel-17.08-cuda-8.0.eb
+++ b/easybuild/easyconfigs/n/NAMD/NAMD-2.12-CrayIntel-17.08-cuda-8.0.eb
@@ -1,0 +1,41 @@
+# Contributed by gppezzi, Luca Marsella and Christopher Bignamini (CSCS)
+easyblock = 'MakeCp'
+
+nameletterlower = 'n'
+name = 'NAMD'
+version = '2.12'
+versionsuffix = '-cuda-8.0'
+
+homepage = 'http://www.ks.uiuc.edu/Research/namd/'
+description = """NAMD is a parallel molecular dynamics code designed for
+high-performance simulation of large biomolecular systems."""
+
+toolchain = {'name': 'CrayIntel', 'version': '17.08'}
+toolchainopts = {'dynamic': False}
+
+sources = ['/apps/common/UES/easybuild/sources/%(nameletterlower)s/%(name)s/' + 'NAMD_%(version)s_Source.tar.gz']
+patches = ['NAMD-2.12.patch']
+
+prebuildopts = ' ./config CRAY-XC-intel.cuda Eos --with-cuda --with-cray-fftw'
+prebuildopts += ' --tcl-prefix $EBROOTTCL --charm-base $EBROOTCHARMPLUSPLUS --charm-arch gni-crayxc-hugepages-smp'
+prebuildopts += ' --cxx-opts  "$CRAY_UGNI_POST_LINK_OPTS -lugni $CRAY_PMI_POST_LINK_OPTS -lpmi" && '
+prebuildopts += ' cd CRAY-XC-intel.cuda && '
+
+builddependencies = [
+    ('Charm++', '6.8.0'),
+    ('Tcl', '8.6.7'),
+    ('cray-fftw/3.3.6.2', EXTERNAL_MODULE),
+    ('craype-hugepages8M', EXTERNAL_MODULE),
+    ('cudatoolkit/8.0.61_2.4.3-6.0.4.0_3.1__gb475d12', EXTERNAL_MODULE),
+]
+
+files_to_copy = [(['./CRAY-XC-intel.cuda/namd2'], 'bin')]
+
+modextravars = { 'LD_LIBRARY_PATH':'$::env(CRAY_LD_LIBRARY_PATH):$::env(LD_LIBRARY_PATH)'}
+
+sanity_check_paths = {
+    'files': ['bin/namd2'],
+    'dirs': [],
+}
+
+moduleclass = 'chem'

--- a/easybuild/easyconfigs/n/NAMD/NAMD-2.12-CrayIntel-17.08.eb
+++ b/easybuild/easyconfigs/n/NAMD/NAMD-2.12-CrayIntel-17.08.eb
@@ -20,7 +20,6 @@ prebuildopts += ' cd CRAY-XC-intel && '
 
 builddependencies = [
     ('Charm++', '6.8.0'),
-#    ('Tcl', '8.5.9', '-namd',  True),
     ('Tcl', '8.6.7'),
     ('cray-fftw/3.3.6.2', EXTERNAL_MODULE),
     ('craype-hugepages8M', EXTERNAL_MODULE),

--- a/easybuild/easyconfigs/n/NAMD/NAMD-2.12-CrayIntel-17.08.eb
+++ b/easybuild/easyconfigs/n/NAMD/NAMD-2.12-CrayIntel-17.08.eb
@@ -1,0 +1,36 @@
+# Contributed by gppezzi, Luca Marsella and Christopher Bignamini (CSCS)
+easyblock = 'MakeCp'
+
+name = 'NAMD'
+version = '2.12'
+
+homepage = 'http://www.ks.uiuc.edu/Research/namd/'
+description = """NAMD is a parallel molecular dynamics code designed for
+high-performance simulation of large biomolecular systems."""
+
+toolchain = {'name': 'CrayIntel', 'version': '17.08'}
+
+sources = ['/apps/common/UES/easybuild/sources/%(nameletterlower)s/%(name)s/' + 'NAMD_%(version)s_Source.tar.gz']
+patches = ['NAMD-2.12.patch']
+
+prebuildopts = ' ./config CRAY-XC-intel Eos --with-cray-fftw'
+prebuildopts += ' --tcl-prefix $EBROOTTCL --charm-base $EBROOTCHARMPLUSPLUS --charm-arch gni-crayxc-hugepages-smp'
+prebuildopts += ' --cxx-opts  "$CRAY_UGNI_POST_LINK_OPTS -lugni $CRAY_PMI_POST_LINK_OPTS -lpmi" && '
+prebuildopts += ' cd CRAY-XC-intel && '
+
+builddependencies = [
+    ('Charm++', '6.8.0'),
+#    ('Tcl', '8.5.9', '-namd',  True),
+    ('Tcl', '8.6.7'),
+    ('cray-fftw/3.3.6.2', EXTERNAL_MODULE),
+    ('craype-hugepages8M', EXTERNAL_MODULE),
+]
+
+files_to_copy = [(['./CRAY-XC-intel/namd2'], 'bin')]
+
+sanity_check_paths = {
+    'files': ['bin/namd2'],
+    'dirs': [],
+}
+
+moduleclass = 'chem'

--- a/easybuild/easyconfigs/n/NAMD/NAMD-2.12.patch
+++ b/easybuild/easyconfigs/n/NAMD/NAMD-2.12.patch
@@ -1,0 +1,85 @@
+-diff -Naur NAMD_2.12_Source.ori/arch/CRAY-XC.cray_fftw NAMD_2.12_Source/arch/CRAY-XC.cray_fftw
+---- NAMD_2.12_Source.ori/arch/CRAY-XC.cray_fftw        1970-01-01 01:00:00.000000000 +0100
+-+++ NAMD_2.12_Source/arch/CRAY-XC.cray_fftw    2017-08-25 15:26:55.560496000 +0200
+-@@ -0,0 +1,16 @@
+-+#works on Eos with module load fftw/3.3.0.4
+-+FFTDIR=$(FFTW_DIR)
+-+FFTINCL=-I$(FFTW_INC)
+-+FFTLIB=-L$(FFTW_DIR)/lib -lfftw3f
+-+FFTFLAGS=-DNAMD_FFTW -DNAMD_FFTW_3
+-+FFT=$(FFTINCL) $(FFTFLAGS)
+-+
+-+loaded_modules := $(subst :, ,$(LOADEDMODULES))
+-+
+-+module := $(filter cray-fftw/3%,$(loaded_modules))
+-+ifeq (,$(module))
+-+  $(error module cray-fftw/3 is not loaded)
+-+else
+-+  $(info found module $(module))
+-+endif
+-+
+-diff -Naur NAMD_2.12_Source.ori/config NAMD_2.12_Source/config
+---- NAMD_2.12_Source.ori/config        2016-10-20 22:50:56.000000000 +0200
+-+++ NAMD_2.12_Source/config    2017-08-25 15:30:17.744943000 +0200
+-@@ -132,6 +132,7 @@
+-   set use_python = 0
+-   set use_fftw = 1
+-   set use_fftw3 = 0
+-+  set use_cray_fftw = 0
+-   set use_mkl = 0
+-   set use_cuda = 0
+-   set use_memopt = 0
+-@@ -269,9 +270,13 @@
+-       case --with-fftw3:
+-         set use_fftw3 = 1
+-       breaksw
+-+      case --with-cray-fftw:
+-+        set use_cray_fftw = 1
+-+      breaksw
+-       case --without-fftw:
+-         set use_fftw = 0
+-         set use_fftw3 = 0
+-+        set use_cray_fftw = 0
+-       breaksw
+-       case --fftw-prefix:
+-         shift
+-@@ -285,6 +290,7 @@
+-         set use_mkl = 1
+-         set use_fftw = 0
+-         set use_fftw3 = 0
+-+        set use_cray_fftw = 0
+-       breaksw
+-       case --mkl-prefix:
+-         shift
+-@@ -500,6 +506,12 @@
+-         set use_fftw3 = 1
+-       endif
+-     endif
+-+    if ( $?FFTW_PREFIX && ! $use_cray_fftw ) then
+-+      if ( -e $FFTW_PREFIX/include/fftw3.h ) then
+-+        echo "Using FFTW3 build found in $FFTW_PREFIX"
+-+        set use_cray_fftw = 1
+-+      endif
+-+    endif
+-   endif
+-
+-   echo "Writing build options to $BUILD_LINK/Make.config"
+-@@ -586,6 +598,8 @@
+-     echo 'include .rootdir/arch/$(NAMD_ARCH).mkl' >> Make.config
+-   else if ( $use_fftw3 ) then
+-     echo 'include .rootdir/arch/$(NAMD_ARCH).fftw3' >> Make.config
+-+  else if ( $use_cray_fftw ) then
+-+    echo 'include .rootdir/arch/$(NAMD_ARCH).cray_fftw' >> Make.config
+-   else if ( $use_fftw ) echo 'include .rootdir/arch/$(NAMD_ARCH).fftw' >> Make.config
+-   endif
+-   if ( $use_cuda ) echo 'include .rootdir/arch/$(NAMD_ARCH).cuda' >> Make.config
+-diff -Naur NAMD_2.12_Source.ori/arch/CRAY-XC.tcl NAMD_2.12_Source/arch/CRAY-XC.tcl
+---- NAMD_2.12_Source.ori/arch/CRAY-XC.tcl    2013-10-05 00:15:44.000000000 +0200
+-+++ NAMD_2.12_Source/arch/CRAY-XC.tcl    2017-09-12 15:05:58.277396079 +0200
+-@@ -1,5 +1,5 @@
+- TCLDIR=$(HOME)/tcl
+- TCLINCL=-I$(TCLDIR)/include
+--TCLLIB=-L$(TCLDIR)/lib -ltcl8.5 -ldl
+-+TCLLIB=-L$(TCLDIR)/lib -ltcl8.6 -ldl
+- TCLFLAGS=-DNAMD_TCL
+- TCL=$(TCLINCL) $(TCLFLAGS)

--- a/easybuild/easyconfigs/n/NAMD/NAMD-2.12.patch
+++ b/easybuild/easyconfigs/n/NAMD/NAMD-2.12.patch
@@ -1,85 +1,85 @@
--diff -Naur NAMD_2.12_Source.ori/arch/CRAY-XC.cray_fftw NAMD_2.12_Source/arch/CRAY-XC.cray_fftw
----- NAMD_2.12_Source.ori/arch/CRAY-XC.cray_fftw        1970-01-01 01:00:00.000000000 +0100
--+++ NAMD_2.12_Source/arch/CRAY-XC.cray_fftw    2017-08-25 15:26:55.560496000 +0200
--@@ -0,0 +1,16 @@
--+#works on Eos with module load fftw/3.3.0.4
--+FFTDIR=$(FFTW_DIR)
--+FFTINCL=-I$(FFTW_INC)
--+FFTLIB=-L$(FFTW_DIR)/lib -lfftw3f
--+FFTFLAGS=-DNAMD_FFTW -DNAMD_FFTW_3
--+FFT=$(FFTINCL) $(FFTFLAGS)
--+
--+loaded_modules := $(subst :, ,$(LOADEDMODULES))
--+
--+module := $(filter cray-fftw/3%,$(loaded_modules))
--+ifeq (,$(module))
--+  $(error module cray-fftw/3 is not loaded)
--+else
--+  $(info found module $(module))
--+endif
--+
--diff -Naur NAMD_2.12_Source.ori/config NAMD_2.12_Source/config
----- NAMD_2.12_Source.ori/config        2016-10-20 22:50:56.000000000 +0200
--+++ NAMD_2.12_Source/config    2017-08-25 15:30:17.744943000 +0200
--@@ -132,6 +132,7 @@
--   set use_python = 0
--   set use_fftw = 1
--   set use_fftw3 = 0
--+  set use_cray_fftw = 0
--   set use_mkl = 0
--   set use_cuda = 0
--   set use_memopt = 0
--@@ -269,9 +270,13 @@
--       case --with-fftw3:
--         set use_fftw3 = 1
--       breaksw
--+      case --with-cray-fftw:
--+        set use_cray_fftw = 1
--+      breaksw
--       case --without-fftw:
--         set use_fftw = 0
--         set use_fftw3 = 0
--+        set use_cray_fftw = 0
--       breaksw
--       case --fftw-prefix:
--         shift
--@@ -285,6 +290,7 @@
--         set use_mkl = 1
--         set use_fftw = 0
--         set use_fftw3 = 0
--+        set use_cray_fftw = 0
--       breaksw
--       case --mkl-prefix:
--         shift
--@@ -500,6 +506,12 @@
--         set use_fftw3 = 1
--       endif
--     endif
--+    if ( $?FFTW_PREFIX && ! $use_cray_fftw ) then
--+      if ( -e $FFTW_PREFIX/include/fftw3.h ) then
--+        echo "Using FFTW3 build found in $FFTW_PREFIX"
--+        set use_cray_fftw = 1
--+      endif
--+    endif
--   endif
--
--   echo "Writing build options to $BUILD_LINK/Make.config"
--@@ -586,6 +598,8 @@
--     echo 'include .rootdir/arch/$(NAMD_ARCH).mkl' >> Make.config
--   else if ( $use_fftw3 ) then
--     echo 'include .rootdir/arch/$(NAMD_ARCH).fftw3' >> Make.config
--+  else if ( $use_cray_fftw ) then
--+    echo 'include .rootdir/arch/$(NAMD_ARCH).cray_fftw' >> Make.config
--   else if ( $use_fftw ) echo 'include .rootdir/arch/$(NAMD_ARCH).fftw' >> Make.config
--   endif
--   if ( $use_cuda ) echo 'include .rootdir/arch/$(NAMD_ARCH).cuda' >> Make.config
--diff -Naur NAMD_2.12_Source.ori/arch/CRAY-XC.tcl NAMD_2.12_Source/arch/CRAY-XC.tcl
----- NAMD_2.12_Source.ori/arch/CRAY-XC.tcl    2013-10-05 00:15:44.000000000 +0200
--+++ NAMD_2.12_Source/arch/CRAY-XC.tcl    2017-09-12 15:05:58.277396079 +0200
--@@ -1,5 +1,5 @@
-- TCLDIR=$(HOME)/tcl
-- TCLINCL=-I$(TCLDIR)/include
---TCLLIB=-L$(TCLDIR)/lib -ltcl8.5 -ldl
--+TCLLIB=-L$(TCLDIR)/lib -ltcl8.6 -ldl
-- TCLFLAGS=-DNAMD_TCL
-- TCL=$(TCLINCL) $(TCLFLAGS)
+diff -Naur NAMD_2.12_Source.ori/arch/CRAY-XC.cray_fftw NAMD_2.12_Source/arch/CRAY-XC.cray_fftw
+--- NAMD_2.12_Source.ori/arch/CRAY-XC.cray_fftw        1970-01-01 01:00:00.000000000 +0100
++++ NAMD_2.12_Source/arch/CRAY-XC.cray_fftw    2017-08-25 15:26:55.560496000 +0200
+@@ -0,0 +1,16 @@
++#works on Eos with module load fftw/3.3.0.4
++FFTDIR=$(FFTW_DIR)
++FFTINCL=-I$(FFTW_INC)
++FFTLIB=-L$(FFTW_DIR)/lib -lfftw3f
++FFTFLAGS=-DNAMD_FFTW -DNAMD_FFTW_3
++FFT=$(FFTINCL) $(FFTFLAGS)
++
++loaded_modules := $(subst :, ,$(LOADEDMODULES))
++
++module := $(filter cray-fftw/3%,$(loaded_modules))
++ifeq (,$(module))
++  $(error module cray-fftw/3 is not loaded)
++else
++  $(info found module $(module))
++endif
++
+diff -Naur NAMD_2.12_Source.ori/config NAMD_2.12_Source/config
+--- NAMD_2.12_Source.ori/config        2016-10-20 22:50:56.000000000 +0200
++++ NAMD_2.12_Source/config    2017-08-25 15:30:17.744943000 +0200
+@@ -132,6 +132,7 @@
+   set use_python = 0
+   set use_fftw = 1
+   set use_fftw3 = 0
++  set use_cray_fftw = 0
+   set use_mkl = 0
+   set use_cuda = 0
+   set use_memopt = 0
+@@ -269,9 +270,13 @@
+       case --with-fftw3:
+         set use_fftw3 = 1
+       breaksw
++      case --with-cray-fftw:
++        set use_cray_fftw = 1
++      breaksw
+       case --without-fftw:
+         set use_fftw = 0
+         set use_fftw3 = 0
++        set use_cray_fftw = 0
+       breaksw
+       case --fftw-prefix:
+         shift
+@@ -285,6 +290,7 @@
+         set use_mkl = 1
+         set use_fftw = 0
+         set use_fftw3 = 0
++        set use_cray_fftw = 0
+       breaksw
+       case --mkl-prefix:
+         shift
+@@ -500,6 +506,12 @@
+         set use_fftw3 = 1
+       endif
+     endif
++    if ( $?FFTW_PREFIX && ! $use_cray_fftw ) then
++      if ( -e $FFTW_PREFIX/include/fftw3.h ) then
++        echo "Using FFTW3 build found in $FFTW_PREFIX"
++        set use_cray_fftw = 1
++      endif
++    endif
+   endif
+
+   echo "Writing build options to $BUILD_LINK/Make.config"
+@@ -586,6 +598,8 @@
+     echo 'include .rootdir/arch/$(NAMD_ARCH).mkl' >> Make.config
+   else if ( $use_fftw3 ) then
+     echo 'include .rootdir/arch/$(NAMD_ARCH).fftw3' >> Make.config
++  else if ( $use_cray_fftw ) then
++    echo 'include .rootdir/arch/$(NAMD_ARCH).cray_fftw' >> Make.config
+   else if ( $use_fftw ) echo 'include .rootdir/arch/$(NAMD_ARCH).fftw' >> Make.config
+   endif
+   if ( $use_cuda ) echo 'include .rootdir/arch/$(NAMD_ARCH).cuda' >> Make.config
+diff -Naur NAMD_2.12_Source.ori/arch/CRAY-XC.tcl NAMD_2.12_Source/arch/CRAY-XC.tcl
+--- NAMD_2.12_Source.ori/arch/CRAY-XC.tcl    2013-10-05 00:15:44.000000000 +0200
++++ NAMD_2.12_Source/arch/CRAY-XC.tcl    2017-09-12 15:05:58.277396079 +0200
+@@ -1,5 +1,5 @@
+ TCLDIR=$(HOME)/tcl
+ TCLINCL=-I$(TCLDIR)/include
+-TCLLIB=-L$(TCLDIR)/lib -ltcl8.5 -ldl
++TCLLIB=-L$(TCLDIR)/lib -ltcl8.6 -ldl
+ TCLFLAGS=-DNAMD_TCL
+ TCL=$(TCLINCL) $(TCLFLAGS)

--- a/easybuild/easyconfigs/t/Tcl/Tcl-8.6.7-CrayIntel-17.08.eb
+++ b/easybuild/easyconfigs/t/Tcl/Tcl-8.6.7-CrayIntel-17.08.eb
@@ -1,0 +1,27 @@
+# contributed by Luca Marsella (CSCS)
+easyblock = 'ConfigureMake'
+
+name = 'Tcl'
+version = '8.6.7'
+
+homepage = 'http://www.tcl.tk/'
+description = """Tcl (Tool Command Language) is a very powerful but easy to learn dynamic programming language,
+suitable for a very wide range of uses, including web and desktop applications, networking, administration, testing and many more."""
+
+toolchain = {'name': 'CrayIntel', 'version': '17.08'}
+
+source_urls = ["http://prdownloads.sourceforge.net/tcl"]
+sources = ['%(namelower)s%(version)s-src.tar.gz']
+
+dependencies = [
+    ('zlib', '1.2.11'),
+]
+
+configopts = '--enable-threads EXTRA_INSTALL="install-private-headers"'
+
+# Cross compiling, so skipping tests
+#runtest = 'test'
+
+start_dir = 'unix'
+
+moduleclass = 'lang'


### PR DESCRIPTION
I have uploaded here the new recipes of `NAMD` release 2.12 with `Cray PE 17.08` that make use of the updated dependencies (`Charm++` and `Tcl`).