### PR TITLE
[dom-gpu] VASP 5.4.4 recipes using 17.08 and perftools/6.5.1

### DIFF
--- a/easybuild/easyconfigs/v/VASP/VASP-5.4.4-CrayIntel-17.08-cuda-8.0-pat-6.5.1.eb
+++ b/easybuild/easyconfigs/v/VASP/VASP-5.4.4-CrayIntel-17.08-cuda-8.0-pat-6.5.1.eb
@@ -1,0 +1,40 @@
+# contributed by Luca Marsella (CSCS)
+easyblock = 'MakeCp'
+
+name = 'VASP'
+version = '5.4.4'
+cudaversion = '8.0'
+patversion = '6.5.1'
+versionsuffix = '-cuda-%s-pat-%s' % (cudaversion, patversion)
+
+homepage = 'http://www.vasp.at'
+description = """The Vienna Ab initio Simulation Package (VASP) is a computer program for atomic scale materials modelling, e.g. electronic structure calculations and quantum-mechanical molecular dynamics, from first principles. """
+
+toolchain = {'name': 'CrayIntel', 'version': '17.08'}
+toolchainopts = { 'usempi': True }
+
+patches = [('%(name)s-%(version)s-%(toolchain_name)s-%(toolchain_version)s-cuda-{0}.makefile.include'.format(cudaversion), '%(builddir)s/%(namelower)s-%(version)s')]
+
+sources = ['/apps/common/UES/easybuild/sources/%(nameletterlower)s/%(name)s/' + SOURCELOWER_TAR_BZ2]
+
+builddependencies = [
+    ('cudatoolkit/%s.61_2.4.3-6.0.4.0_3.1__gb475d12' %cudaversion, EXTERNAL_MODULE),
+    ('cray-fftw/3.3.6.2', EXTERNAL_MODULE),
+]
+
+prebuildopts = ' mv %(name)s-%(version)s-%(toolchain_name)s-%(toolchain_version)s-cuda-{0}.makefile.include makefile.include && '.format(cudaversion) 
+
+# don't use parallel make, results in compilation failure
+parallel = 1
+
+# build type
+buildopts = ' gpu gpu_ncl '
+ 
+files_to_copy = [(['./bin/vasp_*'],'bin')]
+
+sanity_check_paths = {
+    'files': ['bin/vasp_gpu','bin/vasp_gpu_ncl'],
+    'dirs': [],
+}
+
+moduleclass = 'phys'

--- a/easybuild/easyconfigs/v/VASP/VASP-5.4.4-CrayIntel-17.08-pat-6.5.1.eb
+++ b/easybuild/easyconfigs/v/VASP/VASP-5.4.4-CrayIntel-17.08-pat-6.5.1.eb
@@ -1,0 +1,37 @@
+# contributed by Luca Marsella (CSCS)
+easyblock = 'MakeCp'
+
+name = 'VASP'
+version = '5.4.4'
+patversion = '6.5.1'
+versionsuffix = '-pat-%s' % patversion
+
+homepage = 'http://www.vasp.at'
+description = """The Vienna Ab initio Simulation Package (VASP) is a computer program for atomic scale materials modelling, e.g. electronic structure calculations and quantum-mechanical molecular dynamics, from first principles. """
+
+toolchain = {'name': 'CrayIntel', 'version': '17.08'}
+toolchainopts = { 'usempi': True }
+
+patches = [('%(name)s-%(version)s-%(toolchain_name)s-%(toolchain_version)s.makefile.include', '%(builddir)s/%(namelower)s-%(version)s')]
+sources = ['/apps/common/UES/easybuild/sources/%(nameletterlower)s/%(name)s/' + SOURCELOWER_TAR_BZ2]
+
+builddependencies = [
+    ('cray-fftw/3.3.6.2', EXTERNAL_MODULE),
+    ('perftools-lite/%s' % patversion, EXTERNAL_MODULE)
+]
+
+prebuildopts = ' mv %(name)s-%(version)s-%(toolchain_name)s-%(toolchain_version)s.makefile.include makefile.include && '
+# don't use parallel make, results in compilation failure
+parallel = 1
+
+# build type
+buildopts = ' all '
+ 
+files_to_copy = [(['./bin/vasp_*'],'bin')]
+
+sanity_check_paths = {
+    'files': ['bin/vasp_gam','bin/vasp_ncl','bin/vasp_std'],
+    'dirs': [],
+}
+
+moduleclass = 'phys'


### PR DESCRIPTION
New EasyBuild configuration files for `VASP` release `5.4.4` using `perftools/6.5.1'.