### PR TITLE
[dom-gpu] QuantumESPRESSO with perftools-lite/6.5.1

### DIFF
--- a/easybuild/easyconfigs/q/QuantumESPRESSO/QuantumESPRESSO-6.1.0-CrayIntel-17.08-pat-6.5.1.eb
+++ b/easybuild/easyconfigs/q/QuantumESPRESSO/QuantumESPRESSO-6.1.0-CrayIntel-17.08-pat-6.5.1.eb
@@ -1,0 +1,42 @@
+# contributed by Guilherme Peretti Pezzi and Luca Marsella (CSCS)
+easyblock = "ConfigureMake"
+
+name = 'QuantumESPRESSO'
+version = '6.1.0'
+patversion = '6.5.1'
+versionsuffix = '-pat-%s' % patversion
+
+homepage = 'http://www.quantum-espresso.org/'
+description = """Quantum ESPRESSO  is an integrated suite of computer codes
+ for electronic-structure calculations and materials modeling at the nanoscale.
+ It is based on density-functional theory, plane waves, and pseudopotentials
+  (both norm-conserving and ultrasoft)."""
+
+toolchain = {'name': 'CrayIntel', 'version': '17.08'}
+toolchainopts = {'usempi': True, 'openmp': True}
+
+sources = ['qe-%(version_major_minor)s.tar.gz']
+source_urls = ['http://qe-forge.org/gf/download/frsrelease/240/1075/']
+
+builddependencies = [
+    ('cray-fftw/3.3.6.2', EXTERNAL_MODULE),
+    ('perftools-lite/%s' % patversion, EXTERNAL_MODULE)
+]
+
+preconfigopts = ' CC=cc LDFLAGS+="$LDFLAGS -qopenmp" && ' 
+preconfigopts += ' BLAS_LIBS="$MKLROOT/lib/intel64/libmkl_blas95_lp64.a" && ' 
+preconfigopts += ' LAPACK_LIBS="$MKLROOT/lib/intel64/libmkl_lapack95_lp64.a" && ' 
+preconfigopts += ' SCALAPACK_LIBS="-L$MKLROOT/lib/intel64 -lmkl_scalapack_lp64 -lmkl_intel_lp64 -lmkl_sequential -lmkl_core -lmkl_blacs_intelmpi_lp64" && '
+configopts = ' ARCH=crayxt --enable-openmp --enable-parallel --with-scalapack '
+
+prebuildopts = ' cat make.inc && '
+buildopts = 'all'
+# a single make process is required, since parallel builds fail
+maxparallel = 1
+
+sanity_check_paths = {
+      'files': ['bin/pw.x', 'bin/cp.x'],
+      'dirs': ['']
+}
+
+moduleclass = 'chem'

--- a/easybuild/easyconfigs/v/VASP/VASP-5.4.4-CrayIntel-17.08-cuda-8.0.eb
+++ b/easybuild/easyconfigs/v/VASP/VASP-5.4.4-CrayIntel-17.08-cuda-8.0.eb
@@ -2,7 +2,7 @@
 easyblock = 'MakeCp'
 
 name = 'VASP'
-version = "5.4.4"
+version = '5.4.4'
 cudaversion = '8.0'
 versionsuffix = '-cuda-%s' % cudaversion
 

--- a/easybuild/easyconfigs/v/VASP/VASP-5.4.4-CrayIntel-17.08.eb
+++ b/easybuild/easyconfigs/v/VASP/VASP-5.4.4-CrayIntel-17.08.eb
@@ -2,7 +2,7 @@
 easyblock = 'MakeCp'
 
 name = 'VASP'
-version = "5.4.4"
+version = '5.4.4'
 
 homepage = 'http://www.vasp.at'
 description = """The Vienna Ab initio Simulation Package (VASP) is a computer program for atomic scale materials modelling, e.g. electronic structure calculations and quantum-mechanical molecular dynamics, from first principles. """
@@ -10,14 +10,14 @@ description = """The Vienna Ab initio Simulation Package (VASP) is a computer pr
 toolchain = {'name': 'CrayIntel', 'version': '17.08'}
 toolchainopts = { 'usempi': True }
 
-patches = [('%(name)s-%(version)s-%(toolchain_name)s-%(toolchain_version)s%(versionsuffix)s.makefile.include', '%(builddir)s/%(namelower)s-%(version)s')]
+patches = [('%(name)s-%(version)s-%(toolchain_name)s-%(toolchain_version)s.makefile.include', '%(builddir)s/%(namelower)s-%(version)s')]
 sources = ['/apps/common/UES/easybuild/sources/%(nameletterlower)s/%(name)s/' + SOURCELOWER_TAR_BZ2]
 
 builddependencies = [
     ('cray-fftw/3.3.6.2', EXTERNAL_MODULE),
 ]
 
-prebuildopts = ' mv %(name)s-%(version)s-%(toolchain_name)s-%(toolchain_version)s%(versionsuffix)s.makefile.include makefile.include && '
+prebuildopts = ' mv %(name)s-%(version)s-%(toolchain_name)s-%(toolchain_version)s.makefile.include makefile.include && '
 # don't use parallel make, results in compilation failure
 parallel = 1
 


### PR DESCRIPTION
New EasyBuild configuration file for `QuantumESPRESSO` with `perftools-lite/6.5.1` and minor edits for two `VASP` standard recipes.