### PR TITLE
[dom-gpu] QuantumESPRESSO with perftools-lite/6.5.1

### DIFF
--- a/easybuild/easyconfigs/q/QuantumESPRESSO/QuantumESPRESSO-6.1.0-CrayIntel-17.08-pat-6.5.1.eb
+++ b/easybuild/easyconfigs/q/QuantumESPRESSO/QuantumESPRESSO-6.1.0-CrayIntel-17.08-pat-6.5.1.eb
@@ -23,13 +23,14 @@ builddependencies = [
     ('perftools-lite/%s' % patversion, EXTERNAL_MODULE)
 ]
 
-preconfigopts = ' CC=cc LDFLAGS+="$LDFLAGS -qopenmp" && ' 
+preconfigopts = ' unset CRAYPAT_COMPILER_OPTIONS && '
+preconfigopts += ' CC=cc LDFLAGS+="$LDFLAGS -qopenmp" && ' 
 preconfigopts += ' BLAS_LIBS="$MKLROOT/lib/intel64/libmkl_blas95_lp64.a" && ' 
 preconfigopts += ' LAPACK_LIBS="$MKLROOT/lib/intel64/libmkl_lapack95_lp64.a" && ' 
 preconfigopts += ' SCALAPACK_LIBS="-L$MKLROOT/lib/intel64 -lmkl_scalapack_lp64 -lmkl_intel_lp64 -lmkl_sequential -lmkl_core -lmkl_blacs_intelmpi_lp64" && '
 configopts = ' ARCH=crayxt --enable-openmp --enable-parallel --with-scalapack '
 
-prebuildopts = ' cat make.inc && '
+prebuildopts = ' export CRAYPAT_COMPILER_OPTIONS=1 && cat make.inc && '
 buildopts = 'all'
 # a single make process is required, since parallel builds fail
 maxparallel = 1

--- a/easybuild/easyconfigs/q/QuantumESPRESSO/QuantumESPRESSO-6.1.0-CrayIntel-17.08-pat-6.5.1.eb
+++ b/easybuild/easyconfigs/q/QuantumESPRESSO/QuantumESPRESSO-6.1.0-CrayIntel-17.08-pat-6.5.1.eb
@@ -23,14 +23,14 @@ builddependencies = [
     ('perftools-lite/%s' % patversion, EXTERNAL_MODULE)
 ]
 
-preconfigopts = ' unset CRAYPAT_COMPILER_OPTIONS && '
+preconfigopts = ' unset CRAYPAT_LITE && '
 preconfigopts += ' CC=cc LDFLAGS+="$LDFLAGS -qopenmp" && ' 
 preconfigopts += ' BLAS_LIBS="$MKLROOT/lib/intel64/libmkl_blas95_lp64.a" && ' 
 preconfigopts += ' LAPACK_LIBS="$MKLROOT/lib/intel64/libmkl_lapack95_lp64.a" && ' 
 preconfigopts += ' SCALAPACK_LIBS="-L$MKLROOT/lib/intel64 -lmkl_scalapack_lp64 -lmkl_intel_lp64 -lmkl_sequential -lmkl_core -lmkl_blacs_intelmpi_lp64" && '
 configopts = ' ARCH=crayxt --enable-openmp --enable-parallel --with-scalapack '
 
-prebuildopts = ' export CRAYPAT_COMPILER_OPTIONS=1 && cat make.inc && '
+prebuildopts = ' export CRAYPAT_LITE=sample_profile && cat make.inc && '
 buildopts = 'all'
 # a single make process is required, since parallel builds fail
 maxparallel = 1


### PR DESCRIPTION
Unset the following variable defined by `perftools-lite/6.5.1` is needed during configuration: `CRAYPAT_COMPILER_OPTIONS`

The build would fail otherwise with the following error on the login nodes only:
```
checking whether the Fortran compiler works... configure: error: in `/dev/shm/lucamar/easybuild/stage/build/QuantumESPRESSO/6.1.0/CrayIntel-17.08-pat-6.5.1/qe-6.1':
configure: error: cannot run Fortran compiled programs.
If you meant to cross compile, use `--host'.
```

An alternative option might be using `--host`, as suggested by the error message itself.
The variable is then exported with the value `1` before building.

The previous recipe was instead successful on the compute nodes.