### PR TITLE
[dom-gpu] Fixing VASP gpu recipe with perftools-lite

### DIFF
--- a/easybuild/easyconfigs/v/VASP/VASP-5.4.4-CrayIntel-17.08-cuda-8.0-pat-6.5.1.eb
+++ b/easybuild/easyconfigs/v/VASP/VASP-5.4.4-CrayIntel-17.08-cuda-8.0-pat-6.5.1.eb
@@ -20,6 +20,7 @@ sources = ['/apps/common/UES/easybuild/sources/%(nameletterlower)s/%(name)s/' + 
 builddependencies = [
     ('cudatoolkit/%s.61_2.4.3-6.0.4.0_3.1__gb475d12' %cudaversion, EXTERNAL_MODULE),
     ('cray-fftw/3.3.6.2', EXTERNAL_MODULE),
+    ('perftools-lite/%s' % patversion, EXTERNAL_MODULE)
 ]
 
 prebuildopts = ' mv %(name)s-%(version)s-%(toolchain_name)s-%(toolchain_version)s-cuda-{0}.makefile.include makefile.include && '.format(cudaversion) 


### PR DESCRIPTION
I had forgotten to load `perftools-lite` as a `builddependency`.