### PR TITLE
[dom-gpu] CMake in 6.0.UP04-17.08-gpu

### DIFF
--- a/jenkins-builds/6.0.UP04-17.08-gpu
+++ b/jenkins-builds/6.0.UP04-17.08-gpu
@@ -8,6 +8,7 @@
  Charm++-6.8.0-CrayIntel-17.08.eb                   --hidden
  Charm++-6.8.0-CrayGNU-17.08-cuda-8.0.eb            --hidden --set-default-module
  Charm++-6.8.0-CrayIntel-17.08-cuda-8.0.eb          --hidden
+ CMake-3.9.1.eb
  CP2K-5.0r18043-CrayGNU-17.08-cuda-8.0.eb           --set-default-module
  CDO-1.9.0-CrayGNU-17.08.eb                         --set-default-module
  CPMD-4.1-CrayIntel-17.08.eb                        --set-default-module


### PR DESCRIPTION
Inserting `CMake-3.9.1.eb` (dummy) to make it visible in the software stack
