### PR TITLE
[dom-mc] CMake in 6.0.UP04-17.08-mc

### DIFF
--- a/jenkins-builds/6.0.UP04-17.08-mc
+++ b/jenkins-builds/6.0.UP04-17.08-mc
@@ -5,6 +5,7 @@
  Boost-1.65.0-CrayGNU-17.08.eb
  Charm++-6.8.0-CrayGNU-17.08.eb                     --set-default-module --hidden
  Charm++-6.8.0-CrayIntel-17.08.eb                   --hidden
+ CMake-3.9.1.eb
  CP2K-5.0r18043-CrayGNU-17.08.eb                    --set-default-module
  CDO-1.9.0-CrayGNU-17.08.eb                         --set-default-module
  CPMD-4.1-CrayIntel-17.08.eb                        --set-default-module


### PR DESCRIPTION
Build `CMake` release `3.9.1` (dummy) to have it listed as a visible modulefile in the `mc` software stack as well.