### PR TITLE
[dom] Reframe 2.6.1 patch

### DIFF
--- a/easybuild/easyconfigs/r/reframe/reframe-2.6.1-hpl_hpcg.patch
+++ b/easybuild/easyconfigs/r/reframe/reframe-2.6.1-hpl_hpcg.patch
@@ -1,0 +1,26 @@
+diff --git a/checks/cuda/hpcg_check.py b/checks/cuda/hpcg_check.py
+index c670310..80ff454 100644
+--- a/checks/cuda/hpcg_check.py
++++ b/checks/cuda/hpcg_check.py
+@@ -60,7 +60,7 @@ class HPCGCheck(RunOnlyRegressionTest):
+         }
+ 
+         self.maintainers = ['VH', 'VK']
+-        self.tags = { 'maintenance' }
++        # self.tags = { 'maintenance' }
+ 
+ def _get_checks(**kwargs):
+     return [ HPCGCheck(**kwargs) ]
+diff --git a/checks/cuda/hpl_check.py b/checks/cuda/hpl_check.py
+index 6230b98..b525e01 100644
+--- a/checks/cuda/hpl_check.py
++++ b/checks/cuda/hpl_check.py
+@@ -109,7 +109,7 @@ class HPLBigCheck(HPLBaseCheck):
+             },
+         }
+ 
+-        self.tags = {'maintenance'}
++        # self.tags = {'maintenance'}
+ 
+ 
+ def _get_checks(**kwargs):

--- a/easybuild/easyconfigs/r/reframe/reframe-2.6.1.eb
+++ b/easybuild/easyconfigs/r/reframe/reframe-2.6.1.eb
@@ -12,6 +12,7 @@ toolchain = {'name': 'dummy', 'version': 'dummy'}
 
 sources = [ ('archive.tar.gz?ref=v%(version)s', "tar xfz %s" )]
 source_urls = ['https://madra.cscs.ch/scs/reframe/repository/']
+patches = ['reframe-2.6.1-hpl_hpcg.patch']
 
 dependencies = [('Python-bare', '3.6.2')]
 


### PR DESCRIPTION
This provides an updated package for 2.6.1 that applies a patch for removing the maintenance tag from the HPL and HPCG tests.