### PR TITLE
[dom] Update cray-python name

### DIFF
--- a/easybuild/cray_external_modules_metadata.cfg
+++ b/easybuild/cray_external_modules_metadata.cfg
@@ -142,7 +142,7 @@ version = 3.7.6.0
 prefix = PETSC_DIR
 
 [cray-python/17.06.1]
-name = CrayPython
+name = Python
 version = 17.06.1
 prefix = PYTHON_PATH
 


### PR DESCRIPTION
the name for cray-python should be Python, so that easyblocks can find it.