### PR TITLE
[daint, dom, kesch, monch, leone] Fixing forcelist for non matching items

### DIFF
--- a/jenkins-builds/production.sh
+++ b/jenkins-builds/production.sh
@@ -69,17 +69,16 @@ done
 
 # checks force_list
 if [ -n "${force_list}" ]; then
-# match force_list items with production lists: 
-# 'grep -n' returns the 1-based line number of the matching pattern within its file
- idx=();
+# match force_list items with production lists: only macthing items will be built using the EasyBuild flag '-f'
  nidx=0; 
  for item in ${force_list}; do 
-     idx[$nidx]=$(cat ${eb_lists[@]} | grep -n $item | awk -F ':' '{print $(NF-1)-1}') 
-     ((nidx++)) 
- done
-# append force flag '-f' to matching items in production lists
- for ((i=0; i<$nidx; i++)); do
-     eb_files[${idx[$i]}]+=" -f"
+     force_match=$(grep $item ${eb_lists[@]})
+     if [ -n "${force_match}" ]; then
+# 'grep -n' returns the 1-based line number of the matching pattern within its file
+         idx=$(cat ${eb_lists[@]} | grep -n $item | awk -F ':' '{print $(NF-1)-1}') 
+# append the force flag '-f' to matching items within the selected production lists
+         eb_files[$idx]+=" -f"
+     fi
  done
 fi
 

--- a/jenkins-builds/production.sh
+++ b/jenkins-builds/production.sh
@@ -70,7 +70,7 @@ done
 # checks force_list
 if [ -n "${force_list}" ]; then
 # match force_list items with production lists: only macthing items will be built using the EasyBuild flag '-f'
- nidx=0; 
+ echo -e "\n Items matching production list and forcelist (\"${force_list}\")"
  for item in ${force_list}; do 
      force_match=$(grep $item ${eb_lists[@]})
      if [ -n "${force_match}" ]; then
@@ -78,6 +78,7 @@ if [ -n "${force_list}" ]; then
          idx=$(cat ${eb_lists[@]} | grep -n $item | awk -F ':' '{print $(NF-1)-1}') 
 # append the force flag '-f' to matching items within the selected production lists
          eb_files[$idx]+=" -f"
+         echo -e "${eb_files[$idx]}"
      fi
  done
 fi


### PR DESCRIPTION
The EasyBuild force flag `-f` is appended only after testing the match with the production list 