### PR TITLE
[kesch] Adding geeqie for MCH generic modules

### DIFF
--- a/easybuild/easyconfigs/g/geeqie/geeqie-1.3.eb
+++ b/easybuild/easyconfigs/g/geeqie/geeqie-1.3.eb
@@ -1,0 +1,24 @@
+# contributed by Luca Marsella (CSCS)
+easyblock = 'ConfigureMake'
+
+name = 'geeqie'
+version = '1.3'
+
+homepage = 'http://geeqie.sourceforge.net/'
+description = """Geeqie is a lightweight Gtk+ based image viewer for Unix like operating system"""
+
+toolchain = {'name': 'dummy', 'version': 'dummy'}
+
+sources = ['v%(version)s.tar.gz']
+source_urls = ['https://github.com/BestImageViewer/geeqie/archive/']
+
+builddependencies = [('Autotools', '201602')]
+
+preconfigopts = './autogen.sh'
+
+sanity_check_paths = {
+    'files': ['bin/geeqie'],
+    'dirs': ['bin', 'lib', 'share'],
+}
+
+moduleclass = 'vis'


### PR DESCRIPTION
I use a `dummy`toolchain as the module should be in the `generic` path.