### PR TITLE
[dom daint] Fix the source url of the archive for Understand-4.0.913

### DIFF
--- a/easybuild/easyconfigs/u/Understand/Understand-4.0.913.eb
+++ b/easybuild/easyconfigs/u/Understand/Understand-4.0.913.eb
@@ -9,7 +9,7 @@ description = """Understand provides you with pertinent informations regarding
 your code."""
 
 toolchain = {'name': 'dummy', 'version': ''}
-source_urls = ['http://latest.scitools.com/Understand/']
+source_urls = ['http://builds.scitools.com/all_builds/b913/Understand/']
 sources = [{
   'filename': '%(name)s-%(version)s-Linux-64bit.tgz',
   'extract_cmd': "tar xf %s",


### PR DESCRIPTION
* Change the source url which doesn't work since the new release `4.0.914` came out.