### PR TITLE
[daint dom] QuantumESPRESSO: remove cray-libsci from linked libraries

### DIFF
--- a/easybuild/easyconfigs/q/QuantumESPRESSO/QuantumESPRESSO-6.1.0-CrayIntel-17.08.eb
+++ b/easybuild/easyconfigs/q/QuantumESPRESSO/QuantumESPRESSO-6.1.0-CrayIntel-17.08.eb
@@ -20,7 +20,8 @@ builddependencies = [
     ('cray-fftw/3.3.6.2', EXTERNAL_MODULE),
 ]
 
-preconfigopts = ' CC=cc LDFLAGS+="$LDFLAGS -qopenmp" && ' 
+preconfigopts = ' module unload cray-libsci && module list && ' 
+preconfigopts += ' CC=cc LDFLAGS+="$LDFLAGS -qopenmp" && ' 
 preconfigopts += ' BLAS_LIBS="$MKLROOT/lib/intel64/libmkl_blas95_lp64.a" && ' 
 preconfigopts += ' LAPACK_LIBS="$MKLROOT/lib/intel64/libmkl_lapack95_lp64.a" && ' 
 preconfigopts += ' SCALAPACK_LIBS="-L$MKLROOT/lib/intel64 -lmkl_scalapack_lp64 -lmkl_intel_lp64 -lmkl_sequential -lmkl_core -lmkl_blacs_intelmpi_lp64" && '


### PR DESCRIPTION
The current executable `pw.x` links `cray-libsci` for linear algebra routines, which cause the code to fail during `CG style diagonalization` within the QuantumESPRESSO testcase reported by CSCS ticket 29516.

The configuration file should link `MKL` libraries for linear algebra routines, therefore I unload `cray-libsci` and let EasyBuild print a `module list` in the build log for cross-checking.