### PR TITLE
[kesch leone monch] CMake 3.10.0 rc5

### DIFF
--- a/easybuild/easyconfigs/c/CMake/CMake-3.10.0-rc5-GCC-5.4.0-2.26.eb
+++ b/easybuild/easyconfigs/c/CMake/CMake-3.10.0-rc5-GCC-5.4.0-2.26.eb
@@ -8,7 +8,7 @@ homepage = 'http://www.cmake.org'
 description = """CMake, the cross-platform, open-source build system.
  CMake is a family of tools designed to build, test and package software."""
 
-toolchain = {'name': 'dummy', 'version': ''}
+toolchain = {'name': 'GCC', 'version': '5.4.0-2.26'}
 
 source_urls = ['http://www.cmake.org/files/v%(version_major_minor)s']
 sources = [SOURCELOWER_TAR_GZ]

--- a/easybuild/easyconfigs/c/CMake/CMake-3.10.0-rc5.eb
+++ b/easybuild/easyconfigs/c/CMake/CMake-3.10.0-rc5.eb
@@ -1,0 +1,21 @@
+# Contributed by Jean-Guillaume Piccinali and Luca Marsella (CSCS)
+easyblock = 'ConfigureMake'
+
+name = 'CMake'
+version = "3.10.0-rc5"
+
+homepage = 'http://www.cmake.org'
+description = """CMake, the cross-platform, open-source build system.
+ CMake is a family of tools designed to build, test and package software."""
+
+toolchain = {'name': 'dummy', 'version': ''}
+
+source_urls = ['http://www.cmake.org/files/v%(version_major_minor)s']
+sources = [SOURCELOWER_TAR_GZ]
+
+sanity_check_paths = {
+    'files': ["bin/%s" % x for x in ['cmake', 'cpack', 'ctest']],
+    'dirs': [],
+}
+
+moduleclass = 'devel'


### PR DESCRIPTION
Building CMake now requires `-std=c++11`, that is not provided by `GCC 4.4.7` available on the operating system of Kesch, Leone and Monch: therefore on these systems we are forced to build `CMake` using a toolchain providing a more recent version of `GCC` with respect to the `dummy` toolchain.