### PR TITLE
[kesch] Ruby mail 2.7.0 -> 2.6.3

### DIFF
--- a/easybuild/easyconfigs/r/Ruby/Ruby-2.2.2-gmvolf-17.02.eb
+++ b/easybuild/easyconfigs/r/Ruby/Ruby-2.2.2-gmvolf-17.02.eb
@@ -33,11 +33,13 @@ configopts = "--disable-install-doc --enable-shared"
 dependencies = [('GSL', '1.16')]
 
 postinstallcmds = ["%(installdir)s/bin/gem install bigdecimal io-console json "\
-                   "mail mime-types minitest more_rinda net-ssh open4 pony "   \
+                   "mime-types minitest more_rinda net-ssh open4 pony "        \
                    "power_assert psych rinruby ruby-prof test-unit xml-simple "\
                    "svn2git", "%(installdir)s/bin/gem install narray "         \
                    "--version '0.6.1.1'", "export NARRAY=1", "%(installdir)s/" \
                    "bin/gem install gsl --version '1.16.0.6'",                 \
-                   "%(installdir)s/bin/gem install rb-gsl"]
+                   "%(installdir)s/bin/gem install rb-gsl", "%(installdir)s/"  \
+                   "bin/gem install mail --version '2.6.3'", "%(installdir)s/" \
+                   "bin/gem uninstall mail --version '2.7.0'"]
 
 moduleclass = 'lang'


### PR DESCRIPTION
revert mail to 2.6.3 due to issues experienced by MCH while testing