### PR TITLE
[dom daint kesch monch leone] Check for empty unuse path

### DIFF
--- a/jenkins/JenkinsfileRegressionEB
+++ b/jenkins/JenkinsfileRegressionEB
@@ -54,7 +54,13 @@ stage('Build Stage') {
                                      script: """$loginBash
                                                 echo \$SCRATCH""").trim()
                     def prefix = "$scratch/$project_name/$machineLabel"
-                    def unuseFlag = "--unuse=${machine.unusePath}".replace('ARCH', arch)                    
+                    def unuseFlag
+                    if (machine.unusePath != '') {
+                        unuseFlag = arch == '' ?  "--unuse=${machine.unusePath}" : "--unuse=${machine.unusePath}".replace('ARCH', arch) 
+                    }
+                    else {
+                        unuseFlag = ''
+                    }                   
                     def listFlag = "--list=$workingDir/jenkins-builds/$machineLabel"
                     def command = "$workingDir/jenkins-builds/production.sh $listFlag --prefix=$prefix $unuseFlag"
                     if (arch != '') 

--- a/jenkins/JenkinsfileRegressionEB
+++ b/jenkins/JenkinsfileRegressionEB
@@ -56,9 +56,11 @@ stage('Build Stage') {
                     def prefix = "$scratch/$project_name/$machineLabel"
                     def unuseFlag
                     if (machine.unusePath != '') {
+                        println("The unuse path is: $machine.unusePath")
                         unuseFlag = arch == '' ?  "--unuse=${machine.unusePath}" : "--unuse=${machine.unusePath}".replace('ARCH', arch) 
                     }
                     else {
+                        println("The unuse path is empty")
                         unuseFlag = ''
                     }                   
                     def listFlag = "--list=$workingDir/jenkins-builds/$machineLabel"


### PR DESCRIPTION
* If the unusePath is empty then do not use the corresponding option.

* If the unusePath is not empty then use the unusePath option making
  the necessary replacements if architectures are defined.