### PR TITLE
[kesch] Changing matlab's path

### DIFF
--- a/easybuild/easyconfigs/m/matlab/matlab-r2016a.eb
+++ b/easybuild/easyconfigs/m/matlab/matlab-r2016a.eb
@@ -10,5 +10,5 @@ toolchain = {'name': 'dummy', 'version': 'dummy'}
 
 modtclfooter = """
 set             MATLABVersion   "r2016a"
-prepend-path    PATH            " /apps/common/matlab/r2016a/bin/"
+prepend-path    PATH            "/apps/common/matlab/r2016a/bin/"
 """

--- a/easybuild/easyconfigs/m/matlab/matlab-r2016a.eb
+++ b/easybuild/easyconfigs/m/matlab/matlab-r2016a.eb
@@ -10,5 +10,5 @@ toolchain = {'name': 'dummy', 'version': 'dummy'}
 
 modtclfooter = """
 set             MATLABVersion   "r2016a"
-prepend-path    PATH            "/apps/common/UES/matlab/r2016a/bin"
+prepend-path    PATH            " /apps/common/matlab/r2016a/bin/"
 """


### PR DESCRIPTION
Since this package is only used for kesch, I am replacing it to point to
the escha matlab folder, which does not require users to be added to the
matlab group.