### PR TITLE
[daint dom kesch] New CMake version

### DIFF
--- a/easybuild/easyconfigs/c/CMake/CMake-3.10.1.eb
+++ b/easybuild/easyconfigs/c/CMake/CMake-3.10.1.eb
@@ -1,0 +1,21 @@
+# Contributed by Jean-Guillaume Piccinali and Luca Marsella (CSCS)
+easyblock = 'ConfigureMake'
+
+name = 'CMake'
+version = "3.10.1"
+
+homepage = 'http://www.cmake.org'
+description = """CMake, the cross-platform, open-source build system.
+ CMake is a family of tools designed to build, test and package software."""
+
+toolchain = {'name': 'dummy', 'version': ''}
+
+source_urls = ['http://www.cmake.org/files/v%(version_major_minor)s']
+sources = [SOURCELOWER_TAR_GZ]
+
+sanity_check_paths = {
+    'files': ["bin/%s" % x for x in ['cmake', 'cpack', 'ctest']],
+    'dirs': [],
+}
+
+moduleclass = 'devel'


### PR DESCRIPTION
Operating system gcc compilers on `Leone` and `Monch` are version `4.4.7`, too old to have `--std=c++11` which is now required to build `CMake`. Therefore we cannot use `dummy` on these systems for `CMake`.