### PR TITLE
[daint dom kesch leone monch] zlib with fPIC and dummy

### DIFF
--- a/easybuild/easyconfigs/z/zlib/zlib-1.2.11.eb
+++ b/easybuild/easyconfigs/z/zlib/zlib-1.2.11.eb
@@ -9,7 +9,7 @@ description = """zlib is designed to be a free, general-purpose, legally unencum
  not covered by any patents -- lossless data-compression library for use on virtually any
  computer hardware and operating system."""
 
-toolchain = {'name': 'dummy', 'version': 'dummy'}
+toolchain = {'name': 'dummy', 'version': ''}
 toolchainopts = {'pic': True}
 
 sources = [SOURCELOWER_TAR_GZ]

--- a/easybuild/easyconfigs/z/zlib/zlib-1.2.11.eb
+++ b/easybuild/easyconfigs/z/zlib/zlib-1.2.11.eb
@@ -10,9 +10,14 @@ description = """zlib is designed to be a free, general-purpose, legally unencum
  computer hardware and operating system."""
 
 toolchain = {'name': 'dummy', 'version': 'dummy'}
+toolchainopts = {'pic': True}
 
 sources = [SOURCELOWER_TAR_GZ]
 source_urls = [('http://sourceforge.net/projects/libpng/files/zlib/%(version)s', 'download')]
+
+# need to take care of $CFLAGS ourselves with dummy toolchain
+# we need to add -fPIC, but should also include -O* option to avoid compiling with -O0 (default for GCC)
+buildopts = 'CFLAGS="-O2 -fPIC"'
 
 sanity_check_paths = {
     'files': ['include/zconf.h', 'include/zlib.h', 'lib/libz.a', 'lib/libz.so'],


### PR DESCRIPTION
Insert `-fPIC` in GCC `CFLAGS` for `zlib`: it may be required when linking other libraries (e.g.: `binutils-2.28.eb`)