### PR TITLE
[daint, dom] GPAW and ASE python packages for CrayGNU 17.08

### DIFF
--- a/easybuild/easyconfigs/a/ASE/ASE-3.15.0-CrayGNU-17.08-python2.eb
+++ b/easybuild/easyconfigs/a/ASE/ASE-3.15.0-CrayGNU-17.08-python2.eb
@@ -1,0 +1,27 @@
+# contributed by Luca Marsella (CSCS)
+easyblock = 'PythonPackage'
+
+name = 'ASE'
+version = '3.15.0'
+pyshortver = '2.7'
+versionsuffix = '-python2'
+
+homepage = 'https://wiki.fysik.dtu.dk/ase/'
+description = """ASE is a python package providing an open source Atomic Simulation Environment
+ in the Python scripting language."""
+
+toolchain = {'name': 'CrayGNU', 'version': '17.08'}
+
+source_urls = ['https://pypi.python.org/packages/source/a/ase']
+sources = ['%(namelower)s-%(version)s.tar.gz']
+
+dependencies = [
+    ('PyExtensions', pyshortver),
+]
+
+sanity_check_paths = {
+    'files': ['bin/ase-build', 'bin/ase-db', 'bin/ase-gui', 'bin/ase-info', 'bin/ase-run'],
+    'dirs': ['lib/python%s/site-packages/%%(namelower)s-%s-py%s.egg/%%(namelower)s' % (pyshortver, version, pyshortver)],
+}
+
+moduleclass = 'chem'

--- a/easybuild/easyconfigs/g/GPAW/GPAW-1.3.0-CrayGNU-17.08-python2.eb
+++ b/easybuild/easyconfigs/g/GPAW/GPAW-1.3.0-CrayGNU-17.08-python2.eb
@@ -1,0 +1,35 @@
+# contributed by Luca Marsella (CSCS) and GPPezzi (CSCS)
+easyblock = "PythonPackage"
+
+name = 'GPAW'
+version = '1.3.0'
+pyshortver = '2.7'
+versionsuffix = '-python2'
+
+homepage = 'https://wiki.fysik.dtu.dk/gpaw/'
+description = """GPAW is a density-functional theory (DFT) Python code based on the projector-augmented wave (PAW)
+ method and the atomic simulation environment (ASE). It uses real-space uniform grids and multigrid methods or 
+ atom-centered basis-functions."""
+
+toolchain = {'name': 'CrayGNU', 'version': '17.08'}
+
+source_urls = ['https://pypi.python.org/packages/source/g/gpaw/']
+sources = [SOURCELOWER_TAR_GZ]
+
+patches = ['gpaw-%(version)s-cray.patch']
+
+# Workaround for sanity check (which fails on login nodes)
+options = {'modulename': 'os'}
+
+dependencies = [
+    ('PyExtensions', pyshortver),
+    ('ASE', '3.15.0', versionsuffix),
+    ('libxc','3.0.0')
+]
+
+sanity_check_paths = {
+    'files': ['bin/%%(namelower)s%s' % x for x in ['', '-basis', '-mpisim', '-python', '-setup']],
+    'dirs': ['lib/python%s/site-packages/%%(namelower)s' % pyshortver],
+}
+
+moduleclass = 'chem'

--- a/easybuild/easyconfigs/g/GPAW/gpaw-1.3.0-cray.patch
+++ b/easybuild/easyconfigs/g/GPAW/gpaw-1.3.0-cray.patch
@@ -1,0 +1,54 @@
+diff -Nru gpaw-1.3.0.orig/config.py gpaw-1.3.0/config.py
+--- gpaw-1.3.0.orig/config.py	2017-09-12 12:49:51.000000000 +0200
++++ gpaw-1.3.0/config.py	2018-02-08 12:15:56.202042317 +0100
+@@ -150,6 +150,14 @@
+             if openblas:  # prefer openblas
+                 libraries += ['openblas']
+                 library_dirs += [libdir]
++# Cray systems: check if cray-libsci is available
++            craylibsci = False
++            if 'CRAY_LIBSCI_DIR' in os.environ:
++                craylibsci = True
++                os.environ["GPAW_MPI"] = "True"
++                os.environ["GPAW_MPI_IMPLEMENTATION"] = "cray"
++                os.environ["GPAW_MPI_COMMAND"] = "srun"
++                libraries += ['readline', 'ncurses']
+             else:
+                 if atlas:  # then atlas
+                     # http://math-atlas.sourceforge.net/errata.html#LINK
+@@ -346,6 +354,9 @@
+     elif mpi == 'poe':
+         mpicompiler = 'mpcc_r'
+ 
++    elif mpi == 'cray':
++        mpicompiler = 'cc'
++
+     else:
+         # Try to use mpicc
+         mpicompiler = 'mpicc'
+diff -Nru gpaw-1.3.0.orig/customize.py gpaw-1.3.0/customize.py
+--- gpaw-1.3.0.orig/customize.py	2017-08-14 12:26:22.000000000 +0200
++++ gpaw-1.3.0/customize.py	2018-02-08 12:17:18.494256068 +0100
+@@ -28,6 +28,7 @@
+     libraries += ['somelib', 'otherlib']
+ """
+ 
++import os
+ # compiler = 'gcc'
+ # mpicompiler = 'mpicc'  # use None if you don't want to build a gpaw-python
+ # mpilinker = 'mpicc'
+@@ -81,3 +82,14 @@
+     define_macros += [('PARALLEL', '1')]
+     mpicompiler = None
+ 
++if os.environ["GPAW_MPI"] == "True" and os.environ["GPAW_MPI_IMPLEMENTATION"] == "cray":
++   print ("Cray Libraries found on the system: building with cray wrappers, cray-libsci and cray-mpich")
++   os.environ["CRAYPE_LINK_TYPE"] = "dynamic"
++   compiler = 'cc'
++   mpicompiler = 'cc'
++   mpilinker = 'cc'
++   define_macros += [('PARALLEL', '1')]
++else:
++   compiler = 'mpicc'
++   define_macros += [('PARALLEL', '1')]
++   mpicompiler = None


### PR DESCRIPTION
I have prepared an updated recipe for `GPAW` and the dependency `ASE` using the toolchain `CrayGNU` version `17.08`, based on request number 30693: both recipes load `PyExtensions` as dependency.