### PR TITLE
[daint, dom] Update JenkinsfileTestingEB

### DIFF
--- a/jenkins/JenkinsfileTestingEB
+++ b/jenkins/JenkinsfileTestingEB
@@ -96,8 +96,10 @@ stage('Build Stage') {
 
                                        $commandComplete
                                        status=\$[status+\$?]
-                                       chmod -R o+r \$EASYBUILD_TMPDIR
-                                       find \$EASYBUILD_TMPDIR -type d -exec chmod o+x '{}' \\;
+                                       if [ -d \"\$EASYBUILD_TMPDIR\" ]; then
+                                        chmod -R o+r \$EASYBUILD_TMPDIR
+                                        find \$EASYBUILD_TMPDIR -type d -exec chmod o+x '{}' \\;
+                                       fi
                                        exit \$status""")
                     }
                 }


### PR DESCRIPTION
Insert a check on `EASYBUILD_TMPDIR` after a successful build to avoid exit code 1