### PR TITLE
[daint, dom] PLUMED 2.4.0 to patch LAMMPS 11Aug2017

### DIFF
--- a/easybuild/easyconfigs/l/LAMMPS/LAMMPS-11Aug2017-CrayGNU-17.08-PLUMED-2.4.0-cuda-8.0.eb
+++ b/easybuild/easyconfigs/l/LAMMPS/LAMMPS-11Aug2017-CrayGNU-17.08-PLUMED-2.4.0-cuda-8.0.eb
@@ -1,0 +1,50 @@
+# Contributed by Luca Marsella and Victor Holanda Rusu (CSCS)
+easyblock = 'MakeCp'
+
+name = 'LAMMPS'
+version = '11Aug17'
+release = 'stable_11Aug2017'
+cudaversion =  '8.0'
+plumedversion = '2.4.0'
+versionsuffix = '-PLUMED-%s-cuda-%s' % (plumedversion, cudaversion)
+
+homepage = 'http://lammps.sandia.gov/'
+description = "LAMMPS (Large-scale Atomic/Molecular Massively Parallel Simulator) is a classical molecular dynamics simulation code designed to run efficiently on parallel computers."
+
+toolchain = {'name': 'CrayGNU', 'version': '17.08'}
+toolchainopts = { 'usempi': True, 'openmp': True }
+
+source_urls = ['https://github.com/lammps/lammps/archive']
+sources = ['%s.tar.gz' % (release)]
+
+prebuildopts = ' plumed-patch -p --runtime --shared <<< 5 && '
+prebuildopts += ' cd ./src && '
+prebuildopts += ' make yes-standard yes-user-cg-cmm yes-user-omp yes-user-reaxc yes-gpu yes-k-space yes-molecule yes-mpiio yes-rigid yes-misc yes-user-misc  && '
+prebuildopts += ' make no-voronoi no-reax no-poems no-meam no-kim no-kokkos no-mscg && '
+prebuildopts += ' make package-update && '
+# go to folder ./lib/reax and make package reax
+prebuildopts += ' pushd ../lib/reax && make -f Makefile.gfortran && popd && '
+# go to folder ./lib/gpu, create Makefile.gpu and correct file ./lib/gpu/geryon/nvd_device.h
+prebuildopts += ' pushd ../lib/gpu && sed -e "s/-march=bdver1//g" -e "s/sm_[0-9]*/sm_60/g" Makefile.xk7 > Makefile.gpu && '
+prebuildopts += ' make -f Makefile.gpu && popd && '
+#create Makefile.omp and correct Makefile.mpi
+prebuildopts += ' sed -e \'s/mpicxx/CC -fopenmp/\' ./MAKE/Makefile.mpi > ./MAKE/Makefile.omp && '
+prebuildopts += ' sed -i -e \'s/mpicxx/CC/\' ./MAKE/Makefile.mpi && '
+buildopts = [ ' mpi ', ' omp ' ]
+
+builddependencies = [
+    ('cudatoolkit/%s.61_2.4.3-6.0.4.0_3.1__gb475d12' %cudaversion, EXTERNAL_MODULE),
+    ('cray-fftw/3.3.6.2', EXTERNAL_MODULE),
+    ('cray-python/17.06.1', EXTERNAL_MODULE),
+]
+
+dependencies = [ ('PLUMED', '%s' %plumedversion) ]
+
+files_to_copy = [(['src/lmp*'], "bin")]
+
+sanity_check_paths = {
+    'files': ['bin/lmp_mpi','bin/lmp_omp'],
+    'dirs': [],
+}
+
+moduleclass = 'chem'

--- a/easybuild/easyconfigs/p/PLUMED/PLUMED-2.4.0-CrayGNU-17.08.eb
+++ b/easybuild/easyconfigs/p/PLUMED/PLUMED-2.4.0-CrayGNU-17.08.eb
@@ -1,0 +1,41 @@
+# by Ward Poelmans <wpoely86@gmail.com>
+# Modified by Luca Marsella (CSCS)
+easyblock = 'ConfigureMake'
+
+name = 'PLUMED'
+version = "2.4.0"
+
+homepage = 'http://www.plumed-code.org'
+description = """PLUMED is an open source library for free energy calculations in molecular systems which
+ works together with some of the most popular molecular dynamics engines. Free energy calculations can be
+ performed as a function of many order parameters with a particular  focus on biological problems, using
+ state of the art methods such as metadynamics, umbrella sampling and Jarzynski-equation based steered MD.
+ The software, written in C++, can be easily interfaced with both fortran and C/C++ codes.
+"""
+
+toolchain = {'name': 'CrayGNU', 'version': '17.08'}
+toolchainopts = {'usempi': 'True'}
+
+source_urls = ['https://github.com/plumed/plumed2/archive/']
+sources = ['v%(version)s.tar.gz']
+
+dependencies = [
+    ('zlib', '1.2.11'),
+    ('GSL', '2.4'),
+    ('libmatheval', '1.1.11')
+]
+
+configopts = ' --exec-prefix=%(installdir)s --enable-gsl --enable-matheval --enable-modules=all'
+prebuildopts = 'source sourceme.sh && '
+
+sanity_check_paths = {
+    'files': ['bin/plumed', 'lib/libplumedKernel.%s' % SHLIB_EXT, 'lib/libplumed.%s' % SHLIB_EXT],
+    'dirs': ['lib/plumed']
+}
+
+modextrapaths = {
+    'PLUMED_KERNEL': 'lib/libplumedKernel.%s' % SHLIB_EXT,
+    'PLUMED_ROOT': 'lib/plumed',
+}
+
+moduleclass = 'chem'


### PR DESCRIPTION
New recipes to be included in the repository, following CSCS request #30732: the flag `--enable-mpi` with PLUMED is not necessary to patch a mpi parallel code, but only to build a PLUMEd version that is mpi aware. We never used this flag, in order to to avoid the need of running PLUMED with `srun` on compute nodes even for patching the codes.