### PR TITLE
[daint] CP2K 5.1 in 6.0.UP04-17.08

### DIFF
--- a/jenkins-builds/6.0.UP04-17.08-gpu
+++ b/jenkins-builds/6.0.UP04-17.08-gpu
@@ -7,6 +7,7 @@
  Boost-1.65.0-CrayGNU-17.08.eb
  CMake-3.10.1.eb
  CP2K-5.0r18043-CrayGNU-17.08-cuda-8.0.eb           --set-default-module
+ CP2K-5.1-CrayGNU-17.08-cuda-8.0.eb
  CDO-1.9.0-CrayGNU-17.08.eb                         --set-default-module
  CDO-1.9.0-CrayIntel-17.08.eb
  CPMD-4.1-CrayIntel-17.08.eb                        --set-default-module

--- a/jenkins-builds/6.0.UP04-17.08-mc
+++ b/jenkins-builds/6.0.UP04-17.08-mc
@@ -6,6 +6,7 @@
  Boost-1.65.0-CrayGNU-17.08.eb
  CMake-3.10.1.eb
  CP2K-5.0r18043-CrayGNU-17.08.eb                    --set-default-module
+ CP2K-5.1-CrayGNU-17.08.eb
  CDO-1.9.0-CrayGNU-17.08.eb                         --set-default-module
  CDO-1.9.0-CrayIntel-17.08.eb
  CPMD-4.1-CrayIntel-17.08.eb                        --set-default-module


### PR DESCRIPTION
CP2K 5.1 last stable version in production before changing defaults, following CSCS request #30739.