### PR TITLE
[daint-gpu] Cleaning up duplicated dependencies of CrayGNU-17.12.eb

### DIFF
--- a/easybuild/easyconfigs/c/CrayGNU/CrayGNU-17.12.eb
+++ b/easybuild/easyconfigs/c/CrayGNU/CrayGNU-17.12.eb
@@ -12,12 +12,7 @@ dependencies = [
     # PrgEnv version is not pinned, as Cray recommends to use the latest (default) version
     ('cdt/17.12', EXTERNAL_MODULE),
     ('PrgEnv-gnu', EXTERNAL_MODULE),
-    ('atp/2.1.1', EXTERNAL_MODULE),
     ('gcc/5.3.0', EXTERNAL_MODULE),
-    ('cray-libsci/17.06.1', EXTERNAL_MODULE),
-    ('cray-mpich/7.6.0', EXTERNAL_MODULE),
-    ('craype/2.5.12', EXTERNAL_MODULE),
-    ('pmi/5.0.12', EXTERNAL_MODULE),
 ]
 
 modextravars = {


### PR DESCRIPTION
Removing dependencies that are already set by cdt (only gcc is kept for compatibility with cuda 8).

Drawback of using cdt currently seems to be only the extra messages displayed:
```
Switching to atp/2.1.1.
Switching to cray-libsci/17.12.1.
Switching to cray-mpich/7.7.0.
Switching to craype/2.5.13.
Switching to gcc/7.2.0.
Switching to java/jdk1.8.0_51.
Switching to modules/3.2.10.6.
Switching to perftools-base/7.0.0.
Switching to pmi/5.0.13.
```