### PR TITLE
[dom daint] Removing CDT as dependency from CrayGNU/17.12

### DIFF
--- a/easybuild/easyconfigs/c/CrayGNU/CrayGNU-17.12.eb
+++ b/easybuild/easyconfigs/c/CrayGNU/CrayGNU-17.12.eb
@@ -4,16 +4,19 @@ name = 'CrayGNU'
 version = '17.12'
 
 homepage = 'https://pubs.cray.com/discover'
-description = """Toolchain using Cray compiler wrapper, using PrgEnv-gnu module (PE release: August 2017).\n"""
+description = """Toolchain using Cray compiler wrapper, using PrgEnv-gnu module (PE release: December 2017).\n"""
 
 toolchain = {'name': 'dummy', 'version': 'dummy'}
 
 dependencies = [
     # PrgEnv version is not pinned, as Cray recommends to use the latest (default) version
-    ('cdt/17.12', EXTERNAL_MODULE),
     ('PrgEnv-gnu', EXTERNAL_MODULE),
+    ('atp/2.1.1', EXTERNAL_MODULE),
     ('gcc/5.3.0', EXTERNAL_MODULE),
-]
+    ('cray-libsci/17.06.1', EXTERNAL_MODULE),
+    ('cray-mpich/7.6.0', EXTERNAL_MODULE),
+    ('craype/2.5.12', EXTERNAL_MODULE),
+    ('pmi/5.0.12', EXTERNAL_MODULE),]
 
 modextravars = {
         'LD_LIBRARY_PATH' : '$::env(CRAY_LD_LIBRARY_PATH):$::env(LD_LIBRARY_PATH)'

--- a/easybuild/easyconfigs/c/CrayGNU/CrayGNU-17.12.eb
+++ b/easybuild/easyconfigs/c/CrayGNU/CrayGNU-17.12.eb
@@ -16,7 +16,8 @@ dependencies = [
     ('cray-libsci/17.06.1', EXTERNAL_MODULE),
     ('cray-mpich/7.6.0', EXTERNAL_MODULE),
     ('craype/2.5.12', EXTERNAL_MODULE),
-    ('pmi/5.0.12', EXTERNAL_MODULE),]
+    ('pmi/5.0.12', EXTERNAL_MODULE),
+]
 
 modextravars = {
         'LD_LIBRARY_PATH' : '$::env(CRAY_LD_LIBRARY_PATH):$::env(LD_LIBRARY_PATH)'


### PR DESCRIPTION
I've managed to reproduce TF build problem from jenkins on my terminal and removing CDT seems to have solved the problem.

@victorusu's 1st version (with CDT + explicit dependencies) was working, but had redundant dependencies. 

I propose we don't add CDT until we're sure that it is working nicely (we should also test on other Cray systems).

