### PR TITLE
 Adding helper scripts for managing eb files

### DIFF
--- a/jenkins-builds/tools/convert-all-tc.sh
+++ b/jenkins-builds/tools/convert-all-tc.sh
@@ -1,0 +1,10 @@
+#!/bin/sh
+# author: @gppezzi
+
+# Useful for bulk creating new toolchain versions based on old versions
+# New ebs are created in place in order to avoid manual copying (--try-toolchain)
+
+for TC in CrayGNU CrayIntel CrayCCE
+do
+    find -name *-$TC-17.08* -exec python ./switch-tc.py --filename {} --toolchain $TC --version 17.12 \;
+done

--- a/jenkins-builds/tools/dep-count.sh
+++ b/jenkins-builds/tools/dep-count.sh
@@ -1,0 +1,7 @@
+#!/bin/bash
+: ${1?"Usage: $0 jenkins-build-file"}
+rm -rf deps.out
+while read eb; do
+      eb -D $eb | grep module | cut -f2 -d: | cut -f1 -d/ >> deps.out
+  done <$1
+cat deps.out | sort | uniq -c | sort -n

--- a/jenkins-builds/tools/switch-tc.py
+++ b/jenkins-builds/tools/switch-tc.py
@@ -1,0 +1,74 @@
+#!/usr/bin/env python
+__author__ = 'petar.forai'
+
+import argparse
+import string
+import re
+
+# matching groups (0) and (1) for toolchain name as in source file and
+# toolchain\s=\s\{'name':\s'(\w*)',\s*'version'\s*:\s*'(\d*.\d*.\d*)'\s*}
+
+
+def main():
+    parser = argparse.ArgumentParser(description='Switch toolchain to.')
+    parser.add_argument('--filename',
+                        required=True,
+                        metavar='FILE',
+                        help="wich file to operate on.")
+    parser.add_argument('--toolchain',
+                        required=True,
+                        metavar='TC',
+                        help="toolchain to switch to.")
+    parser.add_argument('--version',
+                        required=True,
+                        metavar='VERSION',
+                        help="toolchain version to use.")
+
+    args = vars(parser.parse_args())
+
+    print args
+    print "Will use EasyBuild config %s." % (args['filename'])
+    print "New toolchain is set %s %s" % (args['toolchain'], args['version'])
+    print "The new config will be placed in this directory."
+
+    with open(args['filename'], "r") as originalconfig:
+        ec = originalconfig.read()  # contains newlines.
+    print "----"
+    print "The original config was:\n %s" % (ec)
+
+    # <GPP> updated regex to accept '.' on the version
+    tcpattern = re.compile("toolchain\s=\s\{'name':\s'(\S*)',\s*'version'\s*:\s*'(\S*)'\s*}")
+
+    matches = re.search(tcpattern, ec)
+
+    if matches:
+        print "found matches from the config: ", matches.group()
+        print "found original toolchain in config: ", matches.group(1)
+        print "found original toolchain version in config: ", matches.group(2)
+    else:
+        print "Couldn't determine toolchain information in supplied EasyBuild config."
+
+    oldecfilename = args['filename']
+    if not ((args['toolchain'] == 'dummy') and (args['version'] == 'dummy')):
+        newecfilename = oldecfilename.replace(matches.group(1), args['toolchain'])
+        newecfilename = newecfilename.replace(matches.group(2), args['version'])
+    else:
+        newecfilename = oldecfilename.replace('-' + matches.group(1), '')
+        newecfilename = newecfilename.replace('-' + matches.group(2), '')
+        print "Dummy toolchain specified. Taking care of proper naming."
+
+    print "New config file name will be: ", newecfilename
+
+    oldec = string.replace(ec, matches.group(1), args['toolchain'])
+    newec = string.replace(oldec, matches.group(2), args['version'])
+
+    print "New config will be: ", newec
+
+    with open(newecfilename, "w") as newconfig:
+        newconfig.write(newec)  # contains newlines.
+
+    print "Finished writing new config."
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
* `dep-count.sh`
  * script for counting number of times each dep is used given a jenkins production build file
* `convert-all-tc.sh` 
  *  script for in-place bulk creating EB files for a new toolchain (as requested by @victorusu )