### PR TITLE
[daint dom] New defaults for CP2K and GROMACS in production

### DIFF
--- a/jenkins-builds/6.0.UP04-17.08-gpu
+++ b/jenkins-builds/6.0.UP04-17.08-gpu
@@ -6,8 +6,8 @@
  Boost-1.65.0-CrayGNU-17.08-python3.eb              --set-default-module
  Boost-1.65.0-CrayGNU-17.08.eb
  CMake-3.10.1.eb
- CP2K-5.0r18043-CrayGNU-17.08-cuda-8.0.eb           --set-default-module
- CP2K-5.1-CrayGNU-17.08-cuda-8.0.eb
+ CP2K-5.0r18043-CrayGNU-17.08-cuda-8.0.eb
+ CP2K-5.1-CrayGNU-17.08-cuda-8.0.eb                 --set-default-module
  CDO-1.9.0-CrayGNU-17.08.eb                         --set-default-module
  CDO-1.9.0-CrayIntel-17.08.eb
  CPMD-4.1-CrayIntel-17.08.eb                        --set-default-module
@@ -16,8 +16,8 @@
  Extrae-3.5.2-CrayGNU-17.08.eb                      --set-default-module
  Extrae-3.5.2-CrayIntel-17.08.eb
  GREASY-2.1-cscs-CrayGNU-17.08.eb                   --set-default-module
- GROMACS-2016.3-CrayGNU-17.08-cuda-8.0.eb           --set-default-module
- GROMACS-2018-CrayGNU-17.08-cuda-8.0.eb
+ GROMACS-2016.3-CrayGNU-17.08-cuda-8.0.eb           
+ GROMACS-2018-CrayGNU-17.08-cuda-8.0.eb             --set-default-module
  GSL-2.4-CrayGNU-17.08.eb                           --set-default-module
  GSL-2.4-CrayCCE-17.08.eb
  GSL-2.4-CrayIntel-17.08.eb

--- a/jenkins-builds/6.0.UP04-17.08-mc
+++ b/jenkins-builds/6.0.UP04-17.08-mc
@@ -5,8 +5,8 @@
  Boost-1.65.0-CrayGNU-17.08-python3.eb              --set-default-module
  Boost-1.65.0-CrayGNU-17.08.eb
  CMake-3.10.1.eb
- CP2K-5.0r18043-CrayGNU-17.08.eb                    --set-default-module
- CP2K-5.1-CrayGNU-17.08.eb
+ CP2K-5.0r18043-CrayGNU-17.08.eb                    
+ CP2K-5.1-CrayGNU-17.08.eb                          --set-default-module
  CDO-1.9.0-CrayGNU-17.08.eb                         --set-default-module
  CDO-1.9.0-CrayIntel-17.08.eb
  CPMD-4.1-CrayIntel-17.08.eb                        --set-default-module
@@ -15,8 +15,8 @@
  Extrae-3.5.2-CrayGNU-17.08.eb                      --set-default-module
  Extrae-3.5.2-CrayIntel-17.08.eb
  GREASY-2.1-cscs-CrayGNU-17.08.eb                   --set-default-module
- GROMACS-2016.3-CrayGNU-17.08.eb                    --set-default-module
- GROMACS-2018-CrayGNU-17.08.eb
+ GROMACS-2016.3-CrayGNU-17.08.eb                    
+ GROMACS-2018-CrayGNU-17.08.eb                      --set-default-module
  GSL-2.4-CrayGNU-17.08.eb                           --set-default-module
  GSL-2.4-CrayCCE-17.08.eb
  GSL-2.4-CrayIntel-17.08.eb


### PR DESCRIPTION
Updated files `6.0.UP04-17.08-mc` and  `6.0.UP04-17.08-gpu`, keeping the old release until the end of the current allocation period (June 30th 2018): users selected using `Xalt` have been informed. 

Modules of the new default releases are already available in production and they have been tested successfully using the production tests currently available within the `reframe` testing framework (changing module version manually to run the tests with the new default modules).