### PR TITLE
[dom-gpu] Example COSMO with easybuild (please do not merge)

### DIFF
--- a/easybuild/easyblocks/cosmo_dycore.py
+++ b/easybuild/easyblocks/cosmo_dycore.py
@@ -1,0 +1,50 @@
+"""
+EasyBuild support for building and installing the COSMO C++ dynamical core
+
+@author: Hannes Vogt (CSCS)
+"""
+import glob
+import os
+import re
+import shutil
+from distutils.version import LooseVersion
+
+import easybuild.tools.environment as env
+import easybuild.tools.toolchain as toolchain
+from easybuild.easyblocks.generic.configuremake import ConfigureMake
+from easybuild.easyblocks.generic.cmakemake import CMakeMake
+from easybuild.framework.easyconfig import CUSTOM
+from easybuild.tools.build_log import EasyBuildError
+from easybuild.tools.filetools import download_file, extract_file, which
+from easybuild.tools.modules import get_software_libdir, get_software_root, get_software_version
+from easybuild.tools.run import run_cmd
+from easybuild.tools.systemtools import get_platform_name , get_shared_lib_ext
+
+
+class EB_COSMO_DYCORE(CMakeMake):
+    """Support for building/installing the COSMO C++ dynamical core."""
+
+    @staticmethod
+    def extra_options():
+        extra_vars = {
+            'enable_cuda': [False, "Enable CUDA backend (-DCUDA_BACKEND=ON)", CUSTOM],
+        }
+        return CMakeMake.extra_options(extra_vars)
+
+    def __init__(self, *args, **kwargs):
+        super(EB_COSMO_DYCORE, self).__init__(*args, **kwargs)
+        self.lib_subdir = ''
+        self.pre_env = ''
+
+    def configure_step(self):
+        
+        self.cfg.update('configopts', "-DCMAKE_BUILD_TYPE=Release")
+
+
+        if self.cfg['enable_cuda']:
+            self.cfg.update('configopts', "-DCUDA_BACKEND=ON")
+        else:
+            self.cfg.update('configopts', "-DCUDA_BACKEND=OFF")
+
+        out = super(EB_COSMO_DYCORE, self).configure_step()
+

--- a/easybuild/easyblocks/stella.py
+++ b/easybuild/easyblocks/stella.py
@@ -1,0 +1,77 @@
+"""
+EasyBuild support for building and installing STELLA, implemented as an easyblock
+
+@author: Hannes Vogt (CSCS)
+"""
+import glob
+import os
+import re
+import shutil
+from distutils.version import LooseVersion
+
+import easybuild.tools.environment as env
+import easybuild.tools.toolchain as toolchain
+from easybuild.easyblocks.generic.configuremake import ConfigureMake
+from easybuild.easyblocks.generic.cmakemake import CMakeMake
+from easybuild.framework.easyconfig import CUSTOM
+from easybuild.tools.build_log import EasyBuildError
+from easybuild.tools.filetools import download_file, extract_file, which
+from easybuild.tools.modules import get_software_libdir, get_software_root, get_software_version
+from easybuild.tools.run import run_cmd
+from easybuild.tools.systemtools import get_platform_name , get_shared_lib_ext
+
+
+class EB_STELLA(CMakeMake):
+    """Support for building/installing STELLA."""
+
+    @staticmethod
+    def extra_options():
+        extra_vars = {
+#            'single_precision': [False, "Build with single precision enabled (-DSINGLEPRECISION=ON)", CUSTOM],
+            'enable_cuda': [False, "Enable CUDA backend (-DCUDA_BACKEND=ON)", CUSTOM],
+            'cuda_compute_capability': ['sm_60', "CUDA compute capability (if CUDA backend enabled)", CUSTOM],
+            'ksize': [60, "Compile-time k-size hint", CUSTOM],
+            'kflat': [11, "k-level that defines the split between flat and terrain coordinates", CUSTOM],
+            'enable_openmp': [False, "Enable OpenMP backend (-DENABLE_OPENMP)", CUSTOM],
+            'use_gcl': [True, "Use GCL", CUSTOM],
+        }
+        return CMakeMake.extra_options(extra_vars)
+
+    def __init__(self, *args, **kwargs):
+        """Initialize STELLA-specific variables."""
+        super(EB_STELLA, self).__init__(*args, **kwargs)
+        self.lib_subdir = ''
+        self.pre_env = ''
+
+    def configure_step(self):
+        """Custom configuration procedure for STELLA: set configure options for configure or cmake."""
+        # build a release build
+        self.cfg.update('configopts', "-DCMAKE_BUILD_TYPE=Release")
+
+
+        if "float" in self.cfg['versionsuffix']:
+            self.cfg.update('configopts', "-DSINGLEPRECISION=ON")
+        else:
+            self.cfg.update('configopts', "-DSINGLEPRECISION=OFF")
+
+        if self.cfg['enable_cuda']:
+            self.cfg.update('configopts', "-DCUDA_BACKEND=ON")
+            self.cfg.update('configopts', "-DCUDA_COMPUTE_CAPABILITY=%s" % self.cfg['cuda_compute_capability'])
+        else:
+            self.cfg.update('configopts', "-DCUDA_BACKEND=OFF")
+
+        self.cfg.update('configopts', "-DSTELLA_KSIZE=%d -DSTELLA_KFLAT=%d" % (self.cfg['ksize'], self.cfg['kflat']))
+
+
+        if self.cfg['enable_openmp']:
+            self.cfg.update('configopts', "-DENABLE_OPENMP=ON")
+        else:
+            self.cfg.update('configopts', "-DENABLE_OPENMP=OFF")
+
+        if self.cfg['use_gcl']:
+            self.cfg.update('configopts', "-DGCL=ON")
+        else:
+            self.cfg.update('configopts', "-DGCL=OFF")
+
+        out = super(EB_STELLA, self).configure_step()
+

--- a/easybuild/easyconfigs/b/Boost/Boost-1.66.0-CrayGNU-17.08.eb
+++ b/easybuild/easyconfigs/b/Boost/Boost-1.66.0-CrayGNU-17.08.eb
@@ -1,0 +1,23 @@
+easyblock = 'boostcray'
+
+name = 'Boost'
+version = '1.66.0'
+
+homepage = 'http://www.boost.org/'
+description = """Boost provides free peer-reviewed portable C++ source
+libraries."""
+
+toolchain = {'name': 'CrayGNU', 'version': '17.08'}
+toolchainopts = {'pic': True, 'usempi': True}
+source_urls = [SOURCEFORGE_SOURCE]
+sources = ['%%(namelower)s_%s.tar.gz' % '_'.join(version.split('.'))]
+
+dependencies = [
+    ('bzip2', '1.0.6'),
+    ('zlib', '1.2.11'),
+]
+
+configopts = ' --without-libraries=python'
+boost_mpi = True
+
+moduleclass = 'devel'

--- a/easybuild/easyconfigs/c/COSMO/COSMO-master-CrayCCE-17.08float.eb
+++ b/easybuild/easyconfigs/c/COSMO/COSMO-master-CrayCCE-17.08float.eb
@@ -1,0 +1,45 @@
+easyblock = 'MakeCp'
+
+name = 'COSMO'
+version = 'master'
+versionsuffix = 'float'
+
+homepage = 'https://github.com/MeteoSwiss-APN/cosmo-pompa'
+description = """cosmo-pompa"""
+
+toolchain = {'name': 'CrayCCE', 'version': '17.08'}
+toolchainopts = {'verbose': False}
+
+#source_urls = ['/scratch/snx3000/vogtha/test_easybuild/repo']
+#source_urls = ['https://github.com/MeteoSwiss-APN/stella/archive/']
+#sources = ['%(version)s.tar.gz']
+
+sources = [{
+'filename': '/scratch/snx3000/vogtha/test_easybuild/repo/cosmo-pompa-%(version)s.tar.gz'}]
+
+
+dependencies = [ ('cudatoolkit/8.0.61_2.4.3-6.0.4.0_3.1__gb475d12', EXTERNAL_MODULE),
+#  ('Serialbox', '2.2.1'),
+#  ('STELLA', '1.05.00', "%(versionsuffix)s"),
+    ('cray-netcdf', EXTERNAL_MODULE),
+    ('craype-accel-nvidia60', EXTERNAL_MODULE),
+ ]
+
+builddependencies = [
+    ('COSMO_dycore', 'master', "%(versionsuffix)s", ('CrayGNU', '17.08')),
+    ('gcc/5.3.0', EXTERNAL_MODULE),
+    ('cray-netcdf', EXTERNAL_MODULE),
+]
+
+patches = ['Options.lib.gpu.patch']
+
+prebuildopts = 'cd cosmo && cp Options.daint.cray.gpu Options && module swap PrgEnv-gnu PrgEnv-cray && module list &&  export FTN="ftn -D__CRAY_FORTRAN__" && CXX=$GCC_PATH/snos/bin/g++ CC=$GCC_PATH/snos/bin/gcc FC=ftn LDFLAGS="-L$GCC_PATH/snos/lib64 ${LDFLAGS}" VERBOSE=1 '
+
+buildopts = 'CPP_DYCORE=1 paropt && dir'
+
+files_to_copy = ['cosmo/cosmo']
+
+parallel = '1'
+
+moduleclass = 'devel'
+

--- a/easybuild/easyconfigs/c/COSMO/Options.lib.gpu.patch
+++ b/easybuild/easyconfigs/c/COSMO/Options.lib.gpu.patch
@@ -1,0 +1,11 @@
+--- cosmo/Options.lib.gpu.bak	2018-01-12 13:39:20.000000000 +0100
++++ cosmo/Options.lib.gpu	2018-01-12 13:40:23.000000000 +0100
+@@ -28,7 +28,7 @@
+ 
+ # NetCDF library
+ NETCDFL  = 
+-NETCDFI  = 
++NETCDFI  = -I$(NETCDF_DIR)/include 
+ 
+ # Synsat library
+ RTTOV7L  = -L$(INSTALL_DIR)/librttov7 -lrttov7_$(COMPILER)

--- a/easybuild/easyconfigs/c/COSMO_dycore/COSMO_dycore-5.0_2017.6-CrayGNU-17.08.eb
+++ b/easybuild/easyconfigs/c/COSMO_dycore/COSMO_dycore-5.0_2017.6-CrayGNU-17.08.eb
@@ -1,0 +1,36 @@
+easyblock = 'CMakeMake'
+
+name = 'COSMO_dycore'
+version = '5.0_2017.6'
+
+homepage = 'https://github.com/MeteoSwiss-APN/cosmo-pompa'
+description = """cosmo-pompa"""
+
+toolchain = {'name': 'CrayGNU', 'version': '17.08'}
+#source_urls = ['/scratch/snx3000/vogtha/test_easybuild/repo']
+#source_urls = ['https://github.com/MeteoSwiss-APN/stella/archive/']
+#sources = ['%(version)s.tar.gz']
+
+sources = [{
+'filename': '/scratch/snx3000/vogtha/test_easybuild/repo/cosmo-pompa-%(version)s.tar.gz'}]
+
+
+dependencies = [ ('cudatoolkit/8.0.61_2.4.3-6.0.4.0_3.1__gb475d12', EXTERNAL_MODULE),
+  ('STELLA', '1.04.18'),
+ ]
+
+builddependencies = [
+    ('CMake', '3.9.1', '', ('dummy', '')),
+#    ('cudatoolkit', '8.0.61', '_2.4.3-6.0.4.0_3.1__gb475d12', ('dummy', '')),
+]
+
+#configure_cmd_prefix = "cd dycore && "
+srcdir = "../cosmo-pompa-%(version)s/dycore"
+
+configopts = "-DCMAKE_BUILD_TYPE=Release -DSINGLEPRECISION=ON"
+configopts += "-DCUDA_BACKEND=ON -DSTELLA_DIR=${EBROOTSTELLA}" 
+
+separate_build_dir = True
+
+moduleclass = 'devel'
+

--- a/easybuild/easyconfigs/c/COSMO_dycore/COSMO_dycore-master-CrayGNU-17.08float.eb
+++ b/easybuild/easyconfigs/c/COSMO_dycore/COSMO_dycore-master-CrayGNU-17.08float.eb
@@ -1,0 +1,39 @@
+easyblock = 'CMakeMake'
+
+name = 'COSMO_dycore'
+version = 'master'
+versionsuffix = 'float'
+
+homepage = 'https://github.com/MeteoSwiss-APN/cosmo-pompa'
+description = """cosmo-pompa"""
+
+toolchain = {'name': 'CrayGNU', 'version': '17.08'}
+toolchainopts = {'verbose': False}
+
+#source_urls = ['/scratch/snx3000/vogtha/test_easybuild/repo']
+#source_urls = ['https://github.com/MeteoSwiss-APN/stella/archive/']
+#sources = ['%(version)s.tar.gz']
+
+sources = [{
+'filename': '/scratch/snx3000/vogtha/test_easybuild/repo/cosmo-pompa-%(version)s.tar.gz'}]
+
+
+dependencies = [ ('cudatoolkit/8.0.61_2.4.3-6.0.4.0_3.1__gb475d12', EXTERNAL_MODULE),
+  ('Serialbox', '2.2.1'),
+  ('STELLA', '1.05.00', "%(versionsuffix)s"),
+ ]
+
+builddependencies = [
+    ('CMake', '3.9.1', '', ('dummy', '')),
+#    ('cudatoolkit', '8.0.61', '_2.4.3-6.0.4.0_3.1__gb475d12', ('dummy', '')),
+]
+
+#configure_cmd_prefix = "cd dycore && "
+srcdir = "../cosmo-pompa-%(version)s/dycore"
+
+configopts = "-DSTELLA_DIR=${EBROOTSTELLA} " 
+
+separate_build_dir = True
+
+moduleclass = 'devel'
+

--- a/easybuild/easyconfigs/s/STELLA/STELLA-1.04.18-CrayGNU-17.08.eb
+++ b/easybuild/easyconfigs/s/STELLA/STELLA-1.04.18-CrayGNU-17.08.eb
@@ -1,0 +1,32 @@
+easyblock = 'CMakeMake'
+
+name = 'STELLA'
+version = '1.04.18'
+
+homepage = 'https://github.com/MeteoSwiss-APN/stella'
+description = """STELLA"""
+
+toolchain = {'name': 'CrayGNU', 'version': '17.08'}
+#source_urls = ['/scratch/snx3000/vogtha/test_easybuild/repo']
+#source_urls = ['https://github.com/MeteoSwiss-APN/stella/archive/']
+#sources = ['%(version)s.tar.gz']
+
+sources = [{
+'filename': '/scratch/snx3000/vogtha/test_easybuild/repo/stella-%(version)s.tar.gz'}]
+
+
+dependencies = [ ('cudatoolkit/8.0.61_2.4.3-6.0.4.0_3.1__gb475d12', EXTERNAL_MODULE),
+ ]
+
+builddependencies = [
+    ('CMake', '3.9.1', '', ('dummy', '')),
+#    ('cudatoolkit', '8.0.61', '_2.4.3-6.0.4.0_3.1__gb475d12', ('dummy', '')),
+]
+
+configopts = "-DCMAKE_BUILD_TYPE=Release -DGCL=ON -DSINGLEPRECISION=ON"
+configopts += "-DCUDA_BACKEND=ON -DCUDA_COMPUTE_CAPABILITY=sm_60 -DBOOST_ROOT=/project/c14/install/daint/boost/boost_1_49_0" 
+
+separate_build_dir = True
+
+moduleclass = 'devel'
+

--- a/easybuild/easyconfigs/s/STELLA/STELLA-1.05.00-CrayGNU-17.08double.eb
+++ b/easybuild/easyconfigs/s/STELLA/STELLA-1.05.00-CrayGNU-17.08double.eb
@@ -1,0 +1,36 @@
+easyblock = 'CMakeMake'
+
+name = 'STELLA'
+version = '1.05.00'
+versionsuffix = 'double'
+
+homepage = 'https://github.com/MeteoSwiss-APN/stella'
+description = """STELLA"""
+
+toolchain = {'name': 'CrayGNU', 'version': '17.08'}
+#source_urls = ['/scratch/snx3000/vogtha/test_easybuild/repo']
+#source_urls = ['https://github.com/MeteoSwiss-APN/stella/archive/']
+#sources = ['%(version)s.tar.gz']
+
+sources = [{
+'filename': '/scratch/snx3000/vogtha/test_easybuild/repo/stella-%(version)s.tar.gz'}]
+
+
+dependencies = [ ('cudatoolkit/8.0.61_2.4.3-6.0.4.0_3.1__gb475d12', EXTERNAL_MODULE),
+  ('Serialbox', '2.2.1'),
+ ]
+
+builddependencies = [
+    ('CMake', '3.9.1', '', ('dummy', '')),
+#    ('cudatoolkit', '8.0.61', '_2.4.3-6.0.4.0_3.1__gb475d12', ('dummy', '')),
+]
+
+enable_single_precision = 'ON' if version == 'double' else 'OFF'
+
+configopts = "-DCMAKE_BUILD_TYPE=Release -DGCL=ON -DSINGLEPRECISION=%(enable_single_precision)s"
+configopts += "-DCUDA_BACKEND=ON -DCUDA_COMPUTE_CAPABILITY=sm_60 -DBOOST_ROOT=/project/c14/install/daint/boost/boost_1_49_0" 
+
+separate_build_dir = True
+
+moduleclass = 'devel'
+

--- a/easybuild/easyconfigs/s/STELLA/STELLA-1.05.00-CrayGNU-17.08float.eb
+++ b/easybuild/easyconfigs/s/STELLA/STELLA-1.05.00-CrayGNU-17.08float.eb
@@ -1,0 +1,37 @@
+easyblock = 'EB_STELLA'
+
+name = 'STELLA'
+version = '1.05.00'
+versionsuffix = 'float'
+
+homepage = 'https://github.com/MeteoSwiss-APN/stella'
+description = """STELLA"""
+
+toolchain = {'name': 'CrayGNU', 'version': '17.08'}
+toolchainopts = {'verbose': False}
+#source_urls = ['/scratch/snx3000/vogtha/test_easybuild/repo']
+#source_urls = ['https://github.com/MeteoSwiss-APN/stella/archive/']
+#sources = ['%(version)s.tar.gz']
+
+sources = [{
+'filename': '/scratch/snx3000/vogtha/test_easybuild/repo/stella-%(version)s.tar.gz'}]
+
+
+dependencies = [ ('craype-accel-nvidia60', EXTERNAL_MODULE),
+  ('Serialbox', '2.2.1'),
+ ]
+
+builddependencies = [
+    ('CMake', '3.9.1', '', ('dummy', '')),
+]
+
+enable_cuda = True
+cuda_compute_capability = "sm_60"
+
+configopts = "-DBoost_INCLUDE_DIR=/project/c14/install/daint/boost/boost_1_49_0/include " 
+configopts += "-DX86_BACKEND=ON " 
+
+separate_build_dir = True
+
+moduleclass = 'devel'
+

--- a/easybuild/easyconfigs/s/Serialbox/Serialbox-2.2.1-CrayGNU-17.08.eb
+++ b/easybuild/easyconfigs/s/Serialbox/Serialbox-2.2.1-CrayGNU-17.08.eb
@@ -1,0 +1,23 @@
+easyblock = 'CMakeMake'
+
+name = 'Serialbox'
+version = '2.2.1'
+
+homepage = 'https://github.com/eth-cscs/serialbox2'
+description = """Serialbox is a serialization library and tools for C/C++, Python3 and Fortran."""
+
+toolchain = {'name': 'CrayGNU', 'version': '17.08'}
+source_urls = ['https://github.com/eth-cscs/serialbox2/archive/']
+sources = ['v%(version)s.tar.gz']
+
+builddependencies = [
+    ('CMake', '3.9.1', '', ('dummy', '')),
+    ('Boost', '1.66.0'),
+]
+
+configopts = "-DSERIALBOX_ENABLE_FORTRAN=ON"
+
+separate_build_dir = True
+
+moduleclass = 'devel'
+


### PR DESCRIPTION
I tried to build COSMO some time ago. I think the following was the status when I stopped.

Let me explain some of my "design" decisions (and please forgive if I mess up with the terminology or don't recall how it works, it was less than one day that I invested in easybuild in total).

The COSMO build (with the C++ dycore) has the following dependency (upper depends on lower)
- COSMO
- C++ dycore
- STELLA

Unfortunately STELLA has some compile time switches (like KFLAT, or single/double etc). When invoke "build COSMO I would like to specify these flags, i.e. on the upper most level, and propagate them down to STELLA.
As a hack I used the versionsuffix to encode this information. Therefore (at least that was my understanding) I needed to use EasyBlocks.

If I remember correctly, the version below works, except building COSMO. I think my conclusion was the the `MakeCp` easyblock is broken. The `files_to_copy` did not work and I couldn't fix it. (Of course the nice solution would be that COSMO comes with a proper install target in its `Makefile`; but you know, it's COSMO...)

Would be nice if you keep me in the loop on how you implement it, I assume it will be very useful for MeteoSwiss as well, but I didn't follow up on this, because of lack of time...
