### PR TITLE
[daint] Adding the BOOST_ROOT to no python version

### DIFF
--- a/easybuild/easyconfigs/b/Boost/Boost-1.65.0-CrayGNU-17.08.eb
+++ b/easybuild/easyconfigs/b/Boost/Boost-1.65.0-CrayGNU-17.08.eb
@@ -20,4 +20,8 @@ dependencies = [
 configopts = ' --without-libraries=python'
 boost_mpi = True
 
+modextravars = {
+    'BOOST_ROOT' : "%(installdir)s",
+}
+
 moduleclass = 'devel'


### PR DESCRIPTION
The following code is not being called for Boost without Python support.
```
    def make_module_extra(self):
        """Set up a BOOST_ROOT environment variable to e.g. ease Boost
handling by cmake"""
        txt = super(EB_Boost, self).make_module_extra()
        txt += self.module_generator.set_environment('BOOST_ROOT',
self.installdir)
        return txt
```

There are two possible fixes
1. Fix the easyblock to always run it
2. Add the modextravars to the easyconfig without python

This PR does the number 2