### PR TITLE
[daint dom] netcdf-python with python 3

### DIFF
--- a/easybuild/easyconfigs/n/netcdf4-python/netcdf-python-1.2.9-CrayGNU-17.08-python3.eb
+++ b/easybuild/easyconfigs/n/netcdf4-python/netcdf-python-1.2.9-CrayGNU-17.08-python3.eb
@@ -1,6 +1,8 @@
 # contributed by Luca Marsella (CSCS)
 name = 'netcdf-python'
 version = '1.2.9'
+pythonver = '3.6'
+versionsuffix = '-python%s' % pythonver[0]
 
 homepage = 'http://unidata.github.io/netcdf4-python/'
 description = """Python/numpy interface to netCDF."""
@@ -11,22 +13,15 @@ toolchainopts = {'verbose': False}
 source_urls = ['https://pypi.python.org/packages/source/n/netCDF4/']
 sources = ['netCDF4-%(version)s.tar.gz']
 
-req_py_majver = 3
-req_py_minver = 6
-
-pythonver = '%s.%s' % (req_py_majver, req_py_minver)
-versionsuffix = '-python%s' % req_py_majver
-
 dependencies = [
-    ('cray-python/3.6.1.1', EXTERNAL_MODULE),
+    ('cray-python/%s.1.1' % pythonver, EXTERNAL_MODULE),
     ('netCDF-Fortran', '4.4.4'),
     ('cray-hdf5/1.10.0.3', EXTERNAL_MODULE),
 ]
 
 sanity_check_paths = {
     'files': ['bin/nc3tonc4', 'bin/nc4tonc3', 'bin/ncinfo'],
-    'dirs': ['lib/python%(pv)s/site-packages/netCDF4-%%(version)s-py%(pv)s-linux-x86_64.egg' % {'pv': '%s.%s' % (req_py_majver, req_py_minver) }],
+    'dirs': ['lib/python%(pv)s/site-packages/netCDF4-%%(version)s-py%(pv)s-linux-x86_64.egg' % {'pv': '%s' % pythonver }],
 }
 
 moduleclass = 'data'
-

--- a/easybuild/easyconfigs/n/netcdf4-python/netcdf-python-1.2.9-CrayGNU-17.08-python3.eb
+++ b/easybuild/easyconfigs/n/netcdf4-python/netcdf-python-1.2.9-CrayGNU-17.08-python3.eb
@@ -1,4 +1,4 @@
-#
+# contributed by Luca Marsella (CSCS)
 name = 'netcdf-python'
 version = '1.2.9'
 
@@ -12,15 +12,14 @@ source_urls = ['https://pypi.python.org/packages/source/n/netCDF4/']
 sources = ['netCDF4-%(version)s.tar.gz']
 
 req_py_majver = 3
-req_py_minver = 5
+req_py_minver = 6
 
 pythonver = '%s.%s' % (req_py_majver, req_py_minver)
 versionsuffix = '-python%s' % req_py_majver
 
 dependencies = [
-    ('cray-python/17.06.1', EXTERNAL_MODULE),
+    ('cray-python/3.6.1.1', EXTERNAL_MODULE),
     ('netCDF-Fortran', '4.4.4'),
-    #('cray-hdf5/1.8.16', EXTERNAL_MODULE),
     ('cray-hdf5/1.10.0.3', EXTERNAL_MODULE),
 ]
 

--- a/easybuild/easyconfigs/n/netcdf4-python/netcdf-python-1.2.9-CrayGNU-17.08-python3.eb
+++ b/easybuild/easyconfigs/n/netcdf4-python/netcdf-python-1.2.9-CrayGNU-17.08-python3.eb
@@ -1,8 +1,10 @@
 # contributed by Luca Marsella (CSCS)
 name = 'netcdf-python'
 version = '1.2.9'
-pythonver = '3.6'
-versionsuffix = '-python%s' % pythonver[0]
+req_py_majver = 3
+req_py_minver = 6
+pyver = '%s.%s' % (req_py_majver, req_py_minver)
+versionsuffix = '-python%s' % req_py_majver
 
 homepage = 'http://unidata.github.io/netcdf4-python/'
 description = """Python/numpy interface to netCDF."""
@@ -14,14 +16,14 @@ source_urls = ['https://pypi.python.org/packages/source/n/netCDF4/']
 sources = ['netCDF4-%(version)s.tar.gz']
 
 dependencies = [
-    ('cray-python/%s.1.1' % pythonver, EXTERNAL_MODULE),
+    ('cray-python/%s.1.1' % pyver, EXTERNAL_MODULE),
     ('netCDF-Fortran', '4.4.4'),
     ('cray-hdf5/1.10.0.3', EXTERNAL_MODULE),
 ]
 
 sanity_check_paths = {
     'files': ['bin/nc3tonc4', 'bin/nc4tonc3', 'bin/ncinfo'],
-    'dirs': ['lib/python%(pv)s/site-packages/netCDF4-%%(version)s-py%(pv)s-linux-x86_64.egg' % {'pv': '%s' % pythonver }],
+    'dirs': ['lib/python%(pv)s/site-packages/netCDF4-%%(version)s-py%(pv)s-linux-x86_64.egg' % {'pv': '%s' % pyver }],
 }
 
 moduleclass = 'data'


### PR DESCRIPTION
Changed dependency to `cray-python/3.6.1.1` to match the use of `Python 3` and address #611 .