### PR TITLE
[daint dom] Updating python dependency of pycuda with python3

### DIFF
--- a/easybuild/easyconfigs/p/pycuda/pycuda-2017.1.1-CrayGNU-17.08-python3-cuda-8.0.eb
+++ b/easybuild/easyconfigs/p/pycuda/pycuda-2017.1.1-CrayGNU-17.08-python3-cuda-8.0.eb
@@ -1,14 +1,13 @@
 # @author: gppezzi
-# easyblock = "pycuda"
 easyblock = 'PythonPackage'
 
 name = 'pycuda'
 version = '2017.1.1'
-pyver = '3.5.2'
-pyshortver = '3.5'
-versionsuffix = '-python3-cuda-8.0'
+cudaversion = '8.0'
 req_py_majver = 3
-req_py_minver = 5
+req_py_minver = 6
+pyver = '%s.%s' % (req_py_majver, req_py_minver)
+versionsuffix = '-python%s-cuda-%s' % (req_py_majver, cudaversion)
 
 homepage = 'https://pypi.python.org/pypi/pycuda'
 description = """Python wrapper for Nvidia CUDA. PyCUDA lets you access Nvidia
@@ -21,15 +20,15 @@ source_urls = [PYPI_SOURCE]
 sources = [SOURCE_TAR_GZ]
 
 dependencies = [
-    ('cray-python/17.06.1', EXTERNAL_MODULE),
-    ('cudatoolkit/8.0.61_2.4.3-6.0.4.0_3.1__gb475d12', EXTERNAL_MODULE),
+    ('cray-python/%s.1.1' % pyver , EXTERNAL_MODULE),
+    ('cudatoolkit/%s.61_2.4.3-6.0.4.0_3.1__gb475d12' % cudaversion, EXTERNAL_MODULE),
 ]
 
-prebuildopts = "python3 ./configure.py --cuda-root=$EBROOTCUDA --python-exe=python3"
+prebuildopts = "python ./configure.py --cuda-root=$EBROOTCUDA"
 
 sanity_check_paths = {
     'files': [],
-    'dirs': ['lib/python%(pv)s/site-packages/%%(name)s-%%(version)s-py%(pv)s-linux-x86_64.egg' % {'pv': pyshortver}],            
+    'dirs': ['lib/python%(pv)s/site-packages/%%(name)s-%%(version)s-py%(pv)s-linux-x86_64.egg' % {'pv': pyver}],            
 }
 
 moduleclass = 'lang'


### PR DESCRIPTION
Changed dependency to `cray-python/3.6.1.1` to match the use of `Python 3` and address #613.