### PR TITLE
[daint] Updating cray-python dependency of h5py

### DIFF
--- a/easybuild/easyconfigs/h/h5py/h5py-2.7.1-CrayGNU-17.08-python3-parallel.eb
+++ b/easybuild/easyconfigs/h/h5py/h5py-2.7.1-CrayGNU-17.08-python3-parallel.eb
@@ -1,12 +1,13 @@
+# contributed by Luca Marsella (CSCS)
 easyblock = "PythonPackage"
 
 name = 'h5py'
 version = '2.7.1'
-
-python = 'python'
-pyver = '3'
-versionsuffix = '-%s%s-parallel' % (python, pyver)
-pyshortver = '3.5'
+req_py_majver = '3'
+req_py_minver = '6'
+py_rev_ver = '1.1'
+pyver = '%s.%s' % (req_py_majver, req_py_minver)
+versionsuffix = '-python%s-parallel' % req_py_majver
 
 homepage = 'http://www.h5py.org/'
 description = """HDF5 for Python (h5py) is a general-purpose Python interface
@@ -20,16 +21,12 @@ source_urls = [PYPI_SOURCE]
 sources = [SOURCE_TAR_GZ]
 
 dependencies = [
-    ('cray-python/17.06.1', EXTERNAL_MODULE),
-    ('PyExtensions', '3.5'),
+    ('cray-python/%s.%s' % (pyver, py_rev_ver), EXTERNAL_MODULE),
+    ('PyExtensions', '%s' % pyver),
     ('cray-hdf5-parallel/1.10.0.3', EXTERNAL_MODULE),
 ]
 
-req_py_majver = '3'
-req_py_minver = '5'
-
-
-prebuildopts  = ' python3 setup.py configure --mpi'
+prebuildopts  = ' python setup.py configure --mpi'
 prebuildopts += ' --hdf5-version=1.10.0 --hdf5=$HDF5_DIR && '
 
 # sanity checks (import h5py) fails on login nodes (MPI not available) 
@@ -37,7 +34,7 @@ options = {'modulename': 'os'}
 
 sanity_check_paths = {
     'files': [],
-    'dirs': ['lib/python%(pv)s/site-packages/%%(name)s-%%(version)s-py%(pv)s-linux-x86_64.egg' % {'pv': pyshortver}],
+    'dirs': ['lib/python%(pv)s/site-packages/%%(name)s-%%(version)s-py%(pv)s-linux-x86_64.egg' % {'pv': pyver}],
 }
 
 moduleclass = 'data'

--- a/easybuild/easyconfigs/h/h5py/h5py-2.7.1-CrayGNU-17.08-python3-serial.eb
+++ b/easybuild/easyconfigs/h/h5py/h5py-2.7.1-CrayGNU-17.08-python3-serial.eb
@@ -1,12 +1,12 @@
+# contributed by Luca Marsella (CSCS)
 easyblock = "PythonPackage"
-
 name = 'h5py'
 version = '2.7.1'
-
-python = 'python'
-pyver = '3'
-versionsuffix = '-%s%s-serial' % (python, pyver)
-pyshortver = '3.5'
+req_py_majver = '3'
+req_py_minver = '6'
+py_rev_ver = '1.1'
+pyver = '%s.%s' % (req_py_majver, req_py_minver)
+versionsuffix = '-python%s-serial' % req_py_majver
 
 homepage = 'http://www.h5py.org/'
 description = """HDF5 for Python (h5py) is a general-purpose Python interface
@@ -20,24 +20,19 @@ source_urls = [PYPI_SOURCE]
 sources = [SOURCE_TAR_GZ]
 
 dependencies = [
-    ('cray-python/17.06.1', EXTERNAL_MODULE),
-    ('PyExtensions', '3.5'),
+    ('cray-python/%s.%s' % (pyver, py_rev_ver), EXTERNAL_MODULE),
+    ('PyExtensions', '%s' % pyver),
     ('cray-hdf5/1.10.0.3', EXTERNAL_MODULE),
 ]
 
-req_py_majver = '3'
-req_py_minver = '5'
-
-prebuildopts  = ' python3 setup.py configure '
+prebuildopts  = ' python setup.py configure '
 prebuildopts += ' --hdf5-version=1.10.0 --hdf5=$HDF5_DIR && '
 
 options = {'modulename': 'os'}
 
-sanity_check_commands = [('python3', "-c 'import %(namelower)s'")]
-
 sanity_check_paths = {
     'files': [],
-    'dirs': ['lib/python%(pv)s/site-packages/%%(name)s-%%(version)s-py%(pv)s-linux-x86_64.egg' % {'pv': pyshortver}],
+    'dirs': ['lib/python%(pv)s/site-packages/%%(name)s-%%(version)s-py%(pv)s-linux-x86_64.egg' % {'pv': pyver}],
 }
 
 moduleclass = 'data'

--- a/easybuild/easyconfigs/p/PyExtensions/PyExtensions-3.6-CrayGNU-17.08.eb
+++ b/easybuild/easyconfigs/p/PyExtensions/PyExtensions-3.6-CrayGNU-17.08.eb
@@ -1,0 +1,71 @@
+# contributed by Luca Marsella (CSCS)
+easyblock = 'Bundle'
+name = 'PyExtensions'
+py_maj_ver = '3'
+py_min_ver = '6'
+py_rev_ver = '1.1'
+pyver = '%s.%s' % (py_maj_ver, py_min_ver)
+version = '%s' % pyver
+
+homepage = 'https://pypi.python.org/pypi'
+description = """This module is a bundle of Python packages on Cray systems based on the module cray-python"""
+
+toolchain = {'name': 'CrayGNU', 'version': '17.08'}
+toolchainopts = {'pic': True, 'verbose': False}
+
+dependencies = [
+    ('cray-python/%s.%s.%s' % (py_maj_ver, py_min_ver, py_rev_ver), EXTERNAL_MODULE),
+]
+
+# bundle of Python packages
+exts_defaultclass = 'PythonPackage'
+
+exts_list = [
+    ('Cython', '0.28.2', {
+        'req_py_majver': '3',
+        'req_py_minver': '6',
+        'source_urls': ['https://pypi.python.org/packages/source/c/cython/'],
+    }),
+    ('six', '1.11.0', {
+        'req_py_majver': '3',
+        'req_py_minver': '6',
+        'source_urls': ['https://pypi.python.org/packages/source/s/six/'],
+    }),
+    ('matplotlib', '2.2.2', {
+        'req_py_majver': '3',
+        'req_py_minver': '6',
+        'source_urls': ['https://pypi.python.org/packages/source/m/matplotlib/'],
+    }),
+    ('pandas', '0.22.0', {
+        'req_py_majver': '3',
+        'req_py_minver': '6',
+        'source_urls': ['https://pypi.python.org/packages/source/p/pandas/'],
+    }),
+    ('pygelf', '0.3.1', {
+        'req_py_majver': '3',
+        'req_py_minver': '6',
+        'source_urls': ['https://pypi.python.org/packages/source/p/pygelf/'],
+    }),
+    ('PyMySQL', '0.7.11', {
+        'req_py_majver': '3',
+        'req_py_minver': '6',
+        'source_urls': ['https://pypi.python.org/packages/source/p/pymysql/'],
+    }),
+    ('influxdb', '4.1.1', {
+        'req_py_majver': '3',
+        'req_py_minver': '6',
+        'source_urls': ['https://pypi.python.org/packages/source/i/influxdb/'],
+    }),
+]
+
+# specify that Bundle easyblock should run a full sanity check, rather than just trying to load the module
+full_sanity_check = True
+
+modextrapaths = {'PYTHONPATH': ['lib/python{0}/site-packages'.format(pyver)]}
+
+sanity_check_paths = {
+    'files': [],
+    'dirs': ['lib/python%s/site-packages' % pyver]
+}
+
+moduleclass = 'tools'

--- a/easybuild/easyconfigs/p/PyExtensions/PyExtensions-3.6-CrayGNU-17.08.eb
+++ b/easybuild/easyconfigs/p/PyExtensions/PyExtensions-3.6-CrayGNU-17.08.eb
@@ -50,12 +50,7 @@ exts_list = [
         'req_py_majver': '3',
         'req_py_minver': '6',
         'source_urls': ['https://pypi.python.org/packages/source/p/pymysql/'],
-    }),
-    ('influxdb', '4.1.1', {
-        'req_py_majver': '3',
-        'req_py_minver': '6',
-        'source_urls': ['https://pypi.python.org/packages/source/i/influxdb/'],
-    }),
+    })
 ]
 
 # specify that Bundle easyblock should run a full sanity check, rather than just trying to load the module


### PR DESCRIPTION
Changed dependency to `cray-python/3.6.1.1` to match the use of `Python 3` and address #610 .