### PR TITLE
[daint] fix h5py-2.7.x 

### DIFF
--- a/easybuild/easyconfigs/h/h5py/h5py-2.7.0-CrayGNU-17.08-python2-parallel.eb
+++ b/easybuild/easyconfigs/h/h5py/h5py-2.7.0-CrayGNU-17.08-python2-parallel.eb
@@ -1,12 +1,13 @@
+# contributed by Luca Marsella (CSCS)
 easyblock = "PythonPackage"
 
 name = 'h5py'
 version = '2.7.0'
-
-python = 'python'
-pyver = '2'
-versionsuffix = '-%s%s-parallel' % (python, pyver)
-pyshortver = '2.7'
+req_py_majver = '2'
+req_py_minver = '7'
+pyver = '%s.%s' % (req_py_majver, req_py_minver)
+py_rev_ver = '13.1'
+versionsuffix = '-python%s-parallel' % req_py_majver
 
 homepage = 'http://www.h5py.org/'
 description = """HDF5 for Python (h5py) is a general-purpose Python interface
@@ -20,20 +21,19 @@ source_urls = [PYPI_SOURCE]
 sources = [SOURCE_TAR_GZ]
 
 dependencies = [
-    ('cray-python/17.06.1', EXTERNAL_MODULE),
-    ('PyExtensions', '2.7'),
+    ('cray-python/%s.%s' % (pyver, py_rev_ver), EXTERNAL_MODULE),
+    ('PyExtensions', '2.7.13.1'),
     ('cray-hdf5-parallel/1.10.0.3', EXTERNAL_MODULE),
 ]
 
-prebuildopts  = ' python setup.py configure --mpi'
-prebuildopts += ' --hdf5-version=1.10.0 --hdf5=$HDF5_DIR && '
+prebuildopts  = ' python setup.py configure --mpi --hdf5-version=1.10.0 --hdf5=$HDF5_DIR && '
 
 # sanity checks (import h5py) fails on login nodes (MPI not available) 
 options = {'modulename': 'os'}
 
 sanity_check_paths = {
     'files': [],
-    'dirs': ['lib/python%(pv)s/site-packages/%%(name)s-%%(version)s-py%(pv)s-linux-x86_64.egg' % {'pv': pyshortver}],
+    'dirs': ['lib/python%(pv)s/site-packages/%%(name)s-%%(version)s-py%(pv)s-linux-x86_64.egg' % {'pv': pyver}],
 }
 
 moduleclass = 'data'

--- a/easybuild/easyconfigs/h/h5py/h5py-2.7.0-CrayGNU-17.08-python2-parallel.eb
+++ b/easybuild/easyconfigs/h/h5py/h5py-2.7.0-CrayGNU-17.08-python2-parallel.eb
@@ -21,8 +21,7 @@ source_urls = [PYPI_SOURCE]
 sources = [SOURCE_TAR_GZ]
 
 dependencies = [
-    ('cray-python/%s.%s' % (pyver, py_rev_ver), EXTERNAL_MODULE),
-    ('PyExtensions', '2.7.13.1'),
+    ('PyExtensions', '%s.%s' % (pyver, py_rev_ver)),
     ('cray-hdf5-parallel/1.10.0.3', EXTERNAL_MODULE),
 ]
 

--- a/easybuild/easyconfigs/h/h5py/h5py-2.7.0-CrayGNU-17.08-python2-serial.eb
+++ b/easybuild/easyconfigs/h/h5py/h5py-2.7.0-CrayGNU-17.08-python2-serial.eb
@@ -1,12 +1,13 @@
+# contributed by Luca Marsella (CSCS)
 easyblock = "PythonPackage"
 
 name = 'h5py'
 version = '2.7.0'
-
-python = 'python'
-pyver = '2'
-versionsuffix = '-%s%s-serial' % (python, pyver)
-pyshortver = '2.7'
+req_py_majver = '2'
+req_py_minver = '7'
+pyver = '%s.%s' % (req_py_majver, req_py_minver)
+py_rev_ver = '13.1'
+versionsuffix = '-python%s-serial' % req_py_majver
 
 homepage = 'http://www.h5py.org/'
 description = """HDF5 for Python (h5py) is a general-purpose Python interface
@@ -20,20 +21,18 @@ source_urls = [PYPI_SOURCE]
 sources = [SOURCE_TAR_GZ]
 
 dependencies = [
-    ('cray-python/17.06.1', EXTERNAL_MODULE),
-    ('PyExtensions', '2.7'),
+    ('cray-python/%s.%s' % (pyver, py_rev_ver), EXTERNAL_MODULE),
+    ('PyExtensions', '2.7.13.1'),
     ('cray-hdf5/1.10.0.3', EXTERNAL_MODULE),
 ]
 
-prebuildopts  = ' python setup.py configure '
-prebuildopts += ' --hdf5-version=1.10.0 --hdf5=$HDF5_DIR && '
+prebuildopts  = ' python setup.py configure --hdf5-version=1.10.0 --hdf5=$HDF5_DIR && '
 
-# sanity checks (import h5py) fails on login nodes (MPI not available) 
 options = {'modulename': 'os'}
 
 sanity_check_paths = {
     'files': [],
-    'dirs': ['lib/python%(pv)s/site-packages/%%(name)s-%%(version)s-py%(pv)s-linux-x86_64.egg' % {'pv': pyshortver}],
+    'dirs': ['lib/python%(pv)s/site-packages/%%(name)s-%%(version)s-py%(pv)s-linux-x86_64.egg' % {'pv': pyver}],
 }
 
 moduleclass = 'data'

--- a/easybuild/easyconfigs/h/h5py/h5py-2.7.0-CrayGNU-17.08-python2-serial.eb
+++ b/easybuild/easyconfigs/h/h5py/h5py-2.7.0-CrayGNU-17.08-python2-serial.eb
@@ -21,8 +21,7 @@ source_urls = [PYPI_SOURCE]
 sources = [SOURCE_TAR_GZ]
 
 dependencies = [
-    ('cray-python/%s.%s' % (pyver, py_rev_ver), EXTERNAL_MODULE),
-    ('PyExtensions', '2.7.13.1'),
+    ('PyExtensions', '%s.%s' % (pyver, py_rev_ver)),
     ('cray-hdf5/1.10.0.3', EXTERNAL_MODULE),
 ]
 

--- a/easybuild/easyconfigs/h/h5py/h5py-2.7.0-CrayGNU-17.08-python3-parallel.eb
+++ b/easybuild/easyconfigs/h/h5py/h5py-2.7.0-CrayGNU-17.08-python3-parallel.eb
@@ -1,12 +1,13 @@
+# contributed by Luca Marsella (CSCS)
 easyblock = "PythonPackage"
 
 name = 'h5py'
 version = '2.7.0'
-
-python = 'python'
-pyver = '3'
-versionsuffix = '-%s%s-parallel' % (python, pyver)
-pyshortver = '3.5'
+req_py_majver = '3'
+req_py_minver = '6'
+pyver = '%s.%s' % (req_py_majver, req_py_minver)
+py_rev_ver = '1.1'
+versionsuffix = '-python%s-parallel' % req_py_majver
 
 homepage = 'http://www.h5py.org/'
 description = """HDF5 for Python (h5py) is a general-purpose Python interface
@@ -20,24 +21,18 @@ source_urls = [PYPI_SOURCE]
 sources = [SOURCE_TAR_GZ]
 
 dependencies = [
-    ('cray-python/17.06.1', EXTERNAL_MODULE),
-    ('PyExtensions', '3.5'),
+    ('cray-python/%s.%s' % (pyver, py_rev_ver), EXTERNAL_MODULE),
     ('cray-hdf5-parallel/1.10.0.3', EXTERNAL_MODULE),
 ]
 
-req_py_majver = '3'
-req_py_minver = '5'
-
-
-prebuildopts  = ' python3 setup.py configure --mpi'
-prebuildopts += ' --hdf5-version=1.10.0 --hdf5=$HDF5_DIR && '
+prebuildopts  = ' python setup.py configure --mpi --hdf5-version=1.10.0 --hdf5=$HDF5_DIR && '
 
 # sanity checks (import h5py) fails on login nodes (MPI not available) 
 options = {'modulename': 'os'}
 
 sanity_check_paths = {
     'files': [],
-    'dirs': ['lib/python%(pv)s/site-packages/%%(name)s-%%(version)s-py%(pv)s-linux-x86_64.egg' % {'pv': pyshortver}],
+    'dirs': ['lib/python%(pv)s/site-packages/%%(name)s-%%(version)s-py%(pv)s-linux-x86_64.egg' % {'pv': pyver}],
 }
 
 moduleclass = 'data'

--- a/easybuild/easyconfigs/h/h5py/h5py-2.7.0-CrayGNU-17.08-python3-parallel.eb
+++ b/easybuild/easyconfigs/h/h5py/h5py-2.7.0-CrayGNU-17.08-python3-parallel.eb
@@ -22,6 +22,7 @@ sources = [SOURCE_TAR_GZ]
 
 dependencies = [
     ('cray-python/%s.%s' % (pyver, py_rev_ver), EXTERNAL_MODULE),
+    ('PyExtensions', '3.6.1.1'),
     ('cray-hdf5-parallel/1.10.0.3', EXTERNAL_MODULE),
 ]
 

--- a/easybuild/easyconfigs/h/h5py/h5py-2.7.0-CrayGNU-17.08-python3-parallel.eb
+++ b/easybuild/easyconfigs/h/h5py/h5py-2.7.0-CrayGNU-17.08-python3-parallel.eb
@@ -21,8 +21,7 @@ source_urls = [PYPI_SOURCE]
 sources = [SOURCE_TAR_GZ]
 
 dependencies = [
-    ('cray-python/%s.%s' % (pyver, py_rev_ver), EXTERNAL_MODULE),
-    ('PyExtensions', '3.6.1.1'),
+    ('PyExtensions', '%s.%s' % (pyver, py_rev_ver)),
     ('cray-hdf5-parallel/1.10.0.3', EXTERNAL_MODULE),
 ]
 

--- a/easybuild/easyconfigs/h/h5py/h5py-2.7.0-CrayGNU-17.08-python3-serial.eb
+++ b/easybuild/easyconfigs/h/h5py/h5py-2.7.0-CrayGNU-17.08-python3-serial.eb
@@ -21,8 +21,7 @@ source_urls = [PYPI_SOURCE]
 sources = [SOURCE_TAR_GZ]
 
 dependencies = [
-    ('cray-python/%s.%s' % (pyver, py_rev_ver), EXTERNAL_MODULE),
-    ('PyExtensions', '3.6.1.1'),
+    ('PyExtensions', '%s.%s' % (pyver, py_rev_ver)),
     ('cray-hdf5/1.10.0.3', EXTERNAL_MODULE),
 ]
 

--- a/easybuild/easyconfigs/h/h5py/h5py-2.7.0-CrayGNU-17.08-python3-serial.eb
+++ b/easybuild/easyconfigs/h/h5py/h5py-2.7.0-CrayGNU-17.08-python3-serial.eb
@@ -22,12 +22,11 @@ sources = [SOURCE_TAR_GZ]
 
 dependencies = [
     ('cray-python/%s.%s' % (pyver, py_rev_ver), EXTERNAL_MODULE),
+    ('PyExtensions', '3.6.1.1'),
     ('cray-hdf5/1.10.0.3', EXTERNAL_MODULE),
 ]
 
 prebuildopts  = ' python setup.py configure --hdf5-version=1.10.0 --hdf5=$HDF5_DIR && '
-
-options = {'modulename': 'os'}
 
 sanity_check_paths = {
     'files': [],

--- a/easybuild/easyconfigs/h/h5py/h5py-2.7.0-CrayGNU-17.08-python3-serial.eb
+++ b/easybuild/easyconfigs/h/h5py/h5py-2.7.0-CrayGNU-17.08-python3-serial.eb
@@ -1,12 +1,13 @@
+# contributed by Luca Marsella (CSCS)
 easyblock = "PythonPackage"
 
 name = 'h5py'
 version = '2.7.0'
-
-python = 'python'
-pyver = '3'
-versionsuffix = '-%s%s-serial' % (python, pyver)
-pyshortver = '3.5'
+req_py_majver = '3'
+req_py_minver = '6'
+pyver = '%s.%s' % (req_py_majver, req_py_minver)
+py_rev_ver = '1.1'
+versionsuffix = '-python%s-serial' % req_py_majver
 
 homepage = 'http://www.h5py.org/'
 description = """HDF5 for Python (h5py) is a general-purpose Python interface
@@ -20,24 +21,17 @@ source_urls = [PYPI_SOURCE]
 sources = [SOURCE_TAR_GZ]
 
 dependencies = [
-    ('cray-python/17.06.1', EXTERNAL_MODULE),
-    ('PyExtensions', '3.5'),
+    ('cray-python/%s.%s' % (pyver, py_rev_ver), EXTERNAL_MODULE),
     ('cray-hdf5/1.10.0.3', EXTERNAL_MODULE),
 ]
 
-req_py_majver = '3'
-req_py_minver = '5'
-
-prebuildopts  = ' python3 setup.py configure '
-prebuildopts += ' --hdf5-version=1.10.0 --hdf5=$HDF5_DIR && '
+prebuildopts  = ' python setup.py configure --hdf5-version=1.10.0 --hdf5=$HDF5_DIR && '
 
 options = {'modulename': 'os'}
 
-sanity_check_commands = [('python3', "-c 'import %(namelower)s'")]
-
 sanity_check_paths = {
     'files': [],
-    'dirs': ['lib/python%(pv)s/site-packages/%%(name)s-%%(version)s-py%(pv)s-linux-x86_64.egg' % {'pv': pyshortver}],
+    'dirs': ['lib/python%(pv)s/site-packages/%%(name)s-%%(version)s-py%(pv)s-linux-x86_64.egg' % {'pv': pyver}],
 }
 
 moduleclass = 'data'

--- a/easybuild/easyconfigs/h/h5py/h5py-2.7.1-CrayGNU-17.08-python2-parallel.eb
+++ b/easybuild/easyconfigs/h/h5py/h5py-2.7.1-CrayGNU-17.08-python2-parallel.eb
@@ -22,6 +22,7 @@ sources = [SOURCE_TAR_GZ]
 
 dependencies = [
     ('cray-python/%s.%s' % (pyver, py_rev_ver), EXTERNAL_MODULE),
+    ('PyExtensions', '2.7.13.1'),
     ('cray-hdf5-parallel/1.10.0.3', EXTERNAL_MODULE),
 ]
 

--- a/easybuild/easyconfigs/h/h5py/h5py-2.7.1-CrayGNU-17.08-python2-parallel.eb
+++ b/easybuild/easyconfigs/h/h5py/h5py-2.7.1-CrayGNU-17.08-python2-parallel.eb
@@ -21,8 +21,7 @@ source_urls = [PYPI_SOURCE]
 sources = [SOURCE_TAR_GZ]
 
 dependencies = [
-    ('cray-python/%s.%s' % (pyver, py_rev_ver), EXTERNAL_MODULE),
-    ('PyExtensions', '2.7.13.1'),
+    ('PyExtensions', '%s.%s' % (pyver, py_rev_ver)),
     ('cray-hdf5-parallel/1.10.0.3', EXTERNAL_MODULE),
 ]
 

--- a/easybuild/easyconfigs/h/h5py/h5py-2.7.1-CrayGNU-17.08-python2-serial.eb
+++ b/easybuild/easyconfigs/h/h5py/h5py-2.7.1-CrayGNU-17.08-python2-serial.eb
@@ -22,6 +22,7 @@ sources = [SOURCE_TAR_GZ]
 
 dependencies = [
     ('cray-python/%s.%s' % (pyver, py_rev_ver), EXTERNAL_MODULE),
+    ('PyExtensions', '2.7.13.1'),
     ('cray-hdf5/1.10.0.3', EXTERNAL_MODULE),
 ]
 

--- a/easybuild/easyconfigs/h/h5py/h5py-2.7.1-CrayGNU-17.08-python2-serial.eb
+++ b/easybuild/easyconfigs/h/h5py/h5py-2.7.1-CrayGNU-17.08-python2-serial.eb
@@ -21,8 +21,7 @@ source_urls = [PYPI_SOURCE]
 sources = [SOURCE_TAR_GZ]
 
 dependencies = [
-    ('cray-python/%s.%s' % (pyver, py_rev_ver), EXTERNAL_MODULE),
-    ('PyExtensions', '2.7.13.1'),
+    ('PyExtensions', '%s.%s' % (pyver, py_rev_ver)),
     ('cray-hdf5/1.10.0.3', EXTERNAL_MODULE),
 ]
 

--- a/easybuild/easyconfigs/h/h5py/h5py-2.7.1-CrayGNU-17.08-python3-parallel.eb
+++ b/easybuild/easyconfigs/h/h5py/h5py-2.7.1-CrayGNU-17.08-python3-parallel.eb
@@ -22,6 +22,7 @@ sources = [SOURCE_TAR_GZ]
 
 dependencies = [
     ('cray-python/%s.%s' % (pyver, py_rev_ver), EXTERNAL_MODULE),
+    ('PyExtensions', '3.6.1.1'),
     ('cray-hdf5-parallel/1.10.0.3', EXTERNAL_MODULE),
 ]
 

--- a/easybuild/easyconfigs/h/h5py/h5py-2.7.1-CrayGNU-17.08-python3-parallel.eb
+++ b/easybuild/easyconfigs/h/h5py/h5py-2.7.1-CrayGNU-17.08-python3-parallel.eb
@@ -21,8 +21,8 @@ source_urls = [PYPI_SOURCE]
 sources = [SOURCE_TAR_GZ]
 
 dependencies = [
-    ('cray-python/%s.%s' % (pyver, py_rev_ver), EXTERNAL_MODULE),
-    ('PyExtensions', '3.6.1.1'),
+#    ('cray-python/%s.%s' % (pyver, py_rev_ver), EXTERNAL_MODULE),
+    ('PyExtensions', '%s.%s' % (pyver, py_rev_ver)),
     ('cray-hdf5-parallel/1.10.0.3', EXTERNAL_MODULE),
 ]
 

--- a/easybuild/easyconfigs/h/h5py/h5py-2.7.1-CrayGNU-17.08-python3-serial.eb
+++ b/easybuild/easyconfigs/h/h5py/h5py-2.7.1-CrayGNU-17.08-python3-serial.eb
@@ -21,8 +21,7 @@ source_urls = [PYPI_SOURCE]
 sources = [SOURCE_TAR_GZ]
 
 dependencies = [
-    ('cray-python/%s.%s' % (pyver, py_rev_ver), EXTERNAL_MODULE),
-    ('PyExtensions', '3.6.1.1'),
+    ('PyExtensions', '%s.%s' % (pyver, py_rev_ver)),
     ('cray-hdf5/1.10.0.3', EXTERNAL_MODULE),
 ]
 

--- a/easybuild/easyconfigs/h/h5py/h5py-2.7.1-CrayGNU-17.08-python3-serial.eb
+++ b/easybuild/easyconfigs/h/h5py/h5py-2.7.1-CrayGNU-17.08-python3-serial.eb
@@ -22,12 +22,11 @@ sources = [SOURCE_TAR_GZ]
 
 dependencies = [
     ('cray-python/%s.%s' % (pyver, py_rev_ver), EXTERNAL_MODULE),
+    ('PyExtensions', '3.6.1.1'),
     ('cray-hdf5/1.10.0.3', EXTERNAL_MODULE),
 ]
 
 prebuildopts  = ' python setup.py configure --hdf5-version=1.10.0 --hdf5=$HDF5_DIR && '
-
-options = {'modulename': 'os'}
 
 sanity_check_paths = {
     'files': [],

--- a/jenkins-builds/6.0.UP04-17.08-gpu
+++ b/jenkins-builds/6.0.UP04-17.08-gpu
@@ -22,6 +22,10 @@
  GSL-2.4-CrayGNU-17.08.eb                           --set-default-module
  GSL-2.4-CrayCCE-17.08.eb
  GSL-2.4-CrayIntel-17.08.eb
+ h5py-2.7.0-CrayGNU-17.08-python2-parallel.eb
+ h5py-2.7.0-CrayGNU-17.08-python2-serial.eb
+ h5py-2.7.0-CrayGNU-17.08-python3-parallel.eb       --set-default-module
+ h5py-2.7.0-CrayGNU-17.08-python3-serial.eb
  h5py-2.7.1-CrayGNU-17.08-python2-parallel.eb
  h5py-2.7.1-CrayGNU-17.08-python2-serial.eb
  h5py-2.7.1-CrayGNU-17.08-python3-parallel.eb       --set-default-module

--- a/jenkins-builds/6.0.UP04-17.08-mc
+++ b/jenkins-builds/6.0.UP04-17.08-mc
@@ -21,6 +21,10 @@
  GSL-2.4-CrayGNU-17.08.eb                           --set-default-module
  GSL-2.4-CrayCCE-17.08.eb
  GSL-2.4-CrayIntel-17.08.eb
+ h5py-2.7.0-CrayGNU-17.08-python2-parallel.eb
+ h5py-2.7.0-CrayGNU-17.08-python2-serial.eb
+ h5py-2.7.0-CrayGNU-17.08-python3-parallel.eb       --set-default-module
+ h5py-2.7.0-CrayGNU-17.08-python3-serial.eb
  h5py-2.7.1-CrayGNU-17.08-python2-parallel.eb
  h5py-2.7.1-CrayGNU-17.08-python2-serial.eb
  h5py-2.7.1-CrayGNU-17.08-python3-parallel.eb       --set-default-module


### PR DESCRIPTION
- EB 2.7.0 recipe was copied from latest version 2.7.1
- Added pyextensions (missing 'six' package)
- Enabled sanity checking for the serial versions (only the parallel versions have the `MPI_Init` issue and doing the check on the serial versions will ensure that importing h5py works )