### PR TITLE
[daint-gpu] Update 6.0.UP04-17.08-gpu

### DIFF
--- a/jenkins-builds/6.0.UP04-17.08-gpu
+++ b/jenkins-builds/6.0.UP04-17.08-gpu
@@ -49,8 +49,7 @@
  papi-wrap-1.0-CrayGNU-17.08.eb                     --set-default-module
  papi-wrap-1.0-CrayCCE-17.08.eb
  papi-wrap-1.0-CrayIntel-17.08.eb
- ParaView-5.4.1-EGL-CrayGNU-17.08.eb
- ParaView-5.5.0-EGL-CrayGNU-17.08.eb                --set-default-module
+ ParaView-5.5.1-EGL-CrayGNU-17.08.eb                --set-default-module
  perf-reports-7.1.eb                                --set-default-module
  PLUMED-2.3.0-CrayGNU-17.08.eb
  Python-bare-3.6.2.eb                               --hidden


### PR DESCRIPTION
ParaView 5.5.1 shall supersede 5.5.0 and previous versions.