### PR TITLE
[daint dom] Boost with cray-python/2.7.13.1 and cray-python/3.6.1.1

### DIFF
--- a/easybuild/easyconfigs/b/Boost/Boost-1.65.0-CrayGNU-17.08-python2.eb
+++ b/easybuild/easyconfigs/b/Boost/Boost-1.65.0-CrayGNU-17.08-python2.eb
@@ -19,7 +19,7 @@ configopts += ' --with-python-root=$EBROOTCRAYPYTHON/lib/python2.7'
 dependencies = [
     ('bzip2', '1.0.6'),
     ('zlib', '1.2.11'),
-    ('cray-python/17.06.1', EXTERNAL_MODULE),
+    ('cray-python/2.7.13.1', EXTERNAL_MODULE),
 ]
 
 # also build boost_mpi

--- a/easybuild/easyconfigs/b/Boost/Boost-1.65.0-CrayGNU-17.08-python3.eb
+++ b/easybuild/easyconfigs/b/Boost/Boost-1.65.0-CrayGNU-17.08-python3.eb
@@ -18,7 +18,7 @@ configopts  = ' --with-python=$EBROOTPYTHON/bin/python3'
 dependencies = [
     ('bzip2', '1.0.6'),
     ('zlib', '1.2.11'),
-    ('cray-python/17.06.1', EXTERNAL_MODULE),
+    ('cray-python/3.6.1.1', EXTERNAL_MODULE),
 ]
 
 patches = ['Boost-1.65.0_python3.patch']


### PR DESCRIPTION
splitting the use of cray-python/17.06.1 to the newer style version 2 or 3 

cray-python/2.7.13.1
cray-python/3.6.1.1

fixes issue #642 
