### PR TITLE
[daint dom] Remove abcpy-0.3.0 from production lists

### DIFF
--- a/jenkins-builds/6.0.UP04-17.08-gpu
+++ b/jenkins-builds/6.0.UP04-17.08-gpu
@@ -1,4 +1,3 @@
- abcpy-0.3.0-CrayGNU-17.08-python3.eb
  abcpy-0.5.0-CrayGNU-17.12-python3.eb               --set-default-module
  Amber-16-CrayGNU-17.08-cuda-8.0.eb                 --set-default-module
  Amber-16-CrayGNU-17.08-parallel.eb

--- a/jenkins-builds/6.0.UP04-17.08-mc
+++ b/jenkins-builds/6.0.UP04-17.08-mc
@@ -1,4 +1,3 @@
- abcpy-0.3.0-CrayGNU-17.08-python3.eb
  abcpy-0.5.0-CrayGNU-17.12-python3.eb               --set-default-module
  Amber-16-CrayGNU-17.08-parallel.eb                 --set-default-module
  Amber-16-CrayGNU-17.08-serial.eb


### PR DESCRIPTION
Remove old version `0.3.0` of `abcpy` as the more recent `0.5.0` is built. 
The old release will still be kept on the system anyway until the next major upgrade.