### PR TITLE
WIP [kesch] Update MCH-RH7.3-17.02

### DIFF
--- a/jenkins-builds/MCH-RH7.3-17.02
+++ b/jenkins-builds/MCH-RH7.3-17.02
@@ -30,7 +30,7 @@
  Python-3.6.2-gmvolf-17.02.eb
  R-3.3.2-gmvolf-17.02-libX11-1.6.3.eb
  reframe-2.12.eb                                     --set-default-module
- Ruby-2.2.2-gmvolf-17.02.eb
+ Ruby-2.4.0-gmvolf-17.02.eb
  ncview-2.1.7-gmvolf-17.02.eb
  netCDF-C++-4.3.0-gmvolf-17.02.eb
  netCDF-Fortran-4.4.4-gmvolf-17.02.eb


### PR DESCRIPTION
Update version of Ruby on Kesch in production: version `2.4.0` was originally requested in RT #29008 and the previous version `2.2.2` is currently failing to build on the system, as reported in #644. The former modulefile will not be deleted and will still be available on the system.