### PR TITLE
[leone] LIGGGHTS 4.0 build recipe requested by Hilti

### DIFF
--- a/easybuild/easyconfigs/l/LIGGGHTS/LIGGGHTS-4.0.eb
+++ b/easybuild/easyconfigs/l/LIGGGHTS/LIGGGHTS-4.0.eb
@@ -1,0 +1,27 @@
+# LIGGGHTS was requested: WebRT #30237
+# Person in charge of the installation on Leone: Josef Kerbl (DCS Computing GmbH)
+easyblock = 'Bundle'
+name = 'LIGGGHTS'
+version = "4.0"
+
+homepage = 'http://www.cfdem.com'
+description = """
+              LIGGGHTS stands for LAMMPS improved for general granular and 
+              granular heat transfer simulations. LAMMPS is a classical 
+              molecular dynamics simulator. It is widely used in the field of 
+              Molecular Dynamics. Thanks to physical and algorithmic analogies, 
+              LAMMPS is a very good platform for DEM simulations.
+              """
+
+toolchain = {'name': 'dummy', 'version': 'dummy'}
+
+dependencies = [ ('CMake/3.4.1', EXTERNAL_MODULE),
+                 ('gcc/5.3.0', EXTERNAL_MODULE),
+                 ('mvapich2/2.1-gcc-5.3.0', EXTERNAL_MODULE) ]
+
+modtclfooter = """
+prepend-path PATH "/apps/leone/hilti/RH6.7/LIGGGHTS/LIGGGHTS-HILTI/src"
+prepend-path LD_LIBRARY_PATH "/apps/leone/hilti/RH6.7/LIGGGHTS/VTK-8.0.1/lib"
+"""
+
+moduleclass = 'cae'

--- a/jenkins-builds/leone-RHEL6.7EUS-17.06
+++ b/jenkins-builds/leone-RHEL6.7EUS-17.06
@@ -3,6 +3,7 @@
  ddt-18.1.1.eb                              --set-default-module
  h-yade-2017.01a-foss-2016b-Python-2.7.12.eb
  LIGGGHTS-3.8.eb
+ LIGGGHTS-4.0.eb                            --set-default-module
  OpenFOAM-4.1-foss-2016b.eb                 --set-default-module 
  OpenFOAM-5.0-20180108-foss-2016b.eb
  OpenFOAM-Extend-4.0-foss-2016b.eb


### PR DESCRIPTION
(see WebRT https://webrt.cscs.ch/Ticket/Display.html?id=32347)

According to the information, only the version number of LIGGGHTS was adapted.

Version 4.0 of LIGGGHTS was set as default version.