### PR TITLE
[dom] papi-wrap for toolchain version 18.07

### DIFF
--- a/easybuild/easyconfigs/p/papi-wrap/papi-wrap-1.0-CrayCCE-18.07.eb
+++ b/easybuild/easyconfigs/p/papi-wrap/papi-wrap-1.0-CrayCCE-18.07.eb
@@ -1,0 +1,30 @@
+# jgp@cscs
+easyblock = 'MakeCp'
+
+name = "papi-wrap"
+version = "1.0"
+
+homepage = 'https://github.com/bcumming/papi-wrap'
+description = """wrappers around papi hardware counters."""
+
+toolchain = {'name': 'CrayCCE', 'version': '18.07'}
+source_urls = [ ' https://github.com/jgphpc/papi-wrap/archive/' ]
+sources = [ '%(version)s.tar.gz' ] 
+checksums = [ 'e72a6c1d631ffb600e9cea1a0b4da947' ]
+dependencies = [ ('papi/5.5.1.2', EXTERNAL_MODULE), ]
+parallel = 1
+prebuildopts = ' ln -fs cscs/makefile . ;'
+files_to_copy = [ 
+    (['libpapi_wrap.a'], 'lib'), 
+    (['*.mod'], 'include'), 
+]
+
+sanity_check_paths = {
+    'files': [ 'lib/libpapi_wrap.a', ],
+    'dirs': [],
+}
+
+modextravars = { 'CSCSPERF_EVENTS' : 'PAPI_TOT_CYC|PAPI_TOT_INS', }
+
+moduleclass = 'perf'
+

--- a/easybuild/easyconfigs/p/papi-wrap/papi-wrap-1.0-CrayCCE-18.07.eb
+++ b/easybuild/easyconfigs/p/papi-wrap/papi-wrap-1.0-CrayCCE-18.07.eb
@@ -11,7 +11,10 @@ toolchain = {'name': 'CrayCCE', 'version': '18.07'}
 source_urls = [ ' https://github.com/jgphpc/papi-wrap/archive/' ]
 sources = [ '%(version)s.tar.gz' ] 
 checksums = [ 'e72a6c1d631ffb600e9cea1a0b4da947' ]
-dependencies = [ ('papi/5.5.1.2', EXTERNAL_MODULE), ]
+
+# papi provided by perftools-base since 7.0.2 (results in conflict otherwise) 
+# dependencies = [ ('papi/5.5.1.2', EXTERNAL_MODULE), ]
+
 parallel = 1
 prebuildopts = ' ln -fs cscs/makefile . ;'
 files_to_copy = [ 

--- a/easybuild/easyconfigs/p/papi-wrap/papi-wrap-1.0-CrayGNU-18.07.eb
+++ b/easybuild/easyconfigs/p/papi-wrap/papi-wrap-1.0-CrayGNU-18.07.eb
@@ -11,9 +11,13 @@ toolchain = {'name': 'CrayGNU', 'version': '18.07'}
 source_urls = [ ' https://github.com/jgphpc/papi-wrap/archive/' ]
 sources = [ '%(version)s.tar.gz' ] 
 checksums = [ 'e72a6c1d631ffb600e9cea1a0b4da947' ]
-dependencies = [ ('papi/5.5.1.2', EXTERNAL_MODULE), ]
+
+# papi provided by perftools-base since 7.0.2 (results in conflict otherwise) 
+# dependencies = [ ('papi/5.6.0.2', EXTERNAL_MODULE), ]
+
 parallel = 1
 prebuildopts = ' ln -fs cscs/makefile . ;'
+
 files_to_copy = [ 
     (['libpapi_wrap.a'], 'lib'), 
     (['*.mod'], 'include'), 
@@ -21,17 +25,9 @@ files_to_copy = [
 
 sanity_check_paths = {
     'files': [ 'lib/libpapi_wrap.a', ],
-    #'files': files_to_copy,
     'dirs': [],
 }
 
 modextravars = { 'CSCSPERF_EVENTS' : 'PAPI_TOT_CYC|PAPI_TOT_INS', }
 
 moduleclass = 'perf'
-
-# postinstallcmds = ["mv *.mod %(installdir)s/"]
-# modextrapaths = {'PATH': ['']}
-# PAPI_PATH=`pkg-config --variable=papi_prefix papi`
-# runtest = 'test'
-# export CSCSPERF_EVENTS="PAPI_TOT_CYC|PAPI_TOT_INS"
-# export OMP_NUM_THREADS=1

--- a/easybuild/easyconfigs/p/papi-wrap/papi-wrap-1.0-CrayGNU-18.07.eb
+++ b/easybuild/easyconfigs/p/papi-wrap/papi-wrap-1.0-CrayGNU-18.07.eb
@@ -1,0 +1,37 @@
+# jgp@cscs
+easyblock = 'MakeCp'
+
+name = "papi-wrap"
+version = "1.0"
+
+homepage = 'https://github.com/bcumming/papi-wrap'
+description = """wrappers around papi hardware counters."""
+
+toolchain = {'name': 'CrayGNU', 'version': '18.07'}
+source_urls = [ ' https://github.com/jgphpc/papi-wrap/archive/' ]
+sources = [ '%(version)s.tar.gz' ] 
+checksums = [ 'e72a6c1d631ffb600e9cea1a0b4da947' ]
+dependencies = [ ('papi/5.5.1.2', EXTERNAL_MODULE), ]
+parallel = 1
+prebuildopts = ' ln -fs cscs/makefile . ;'
+files_to_copy = [ 
+    (['libpapi_wrap.a'], 'lib'), 
+    (['*.mod'], 'include'), 
+]
+
+sanity_check_paths = {
+    'files': [ 'lib/libpapi_wrap.a', ],
+    #'files': files_to_copy,
+    'dirs': [],
+}
+
+modextravars = { 'CSCSPERF_EVENTS' : 'PAPI_TOT_CYC|PAPI_TOT_INS', }
+
+moduleclass = 'perf'
+
+# postinstallcmds = ["mv *.mod %(installdir)s/"]
+# modextrapaths = {'PATH': ['']}
+# PAPI_PATH=`pkg-config --variable=papi_prefix papi`
+# runtest = 'test'
+# export CSCSPERF_EVENTS="PAPI_TOT_CYC|PAPI_TOT_INS"
+# export OMP_NUM_THREADS=1

--- a/easybuild/easyconfigs/p/papi-wrap/papi-wrap-1.0-CrayIntel-18.07.eb
+++ b/easybuild/easyconfigs/p/papi-wrap/papi-wrap-1.0-CrayIntel-18.07.eb
@@ -11,7 +11,10 @@ toolchain = {'name': 'CrayIntel', 'version': '18.07'}
 source_urls = [ ' https://github.com/jgphpc/papi-wrap/archive/' ]
 sources = [ '%(version)s.tar.gz' ] 
 checksums = [ 'e72a6c1d631ffb600e9cea1a0b4da947' ]
-dependencies = [ ('papi/5.5.1.2', EXTERNAL_MODULE), ]
+
+# papi provided by perftools-base since 7.0.2 (results in conflict otherwise) 
+# dependencies = [ ('papi/5.5.1.2', EXTERNAL_MODULE), ]
+
 parallel = 1
 prebuildopts = ' ln -fs cscs/makefile . ;'
 files_to_copy = [ 

--- a/easybuild/easyconfigs/p/papi-wrap/papi-wrap-1.0-CrayIntel-18.07.eb
+++ b/easybuild/easyconfigs/p/papi-wrap/papi-wrap-1.0-CrayIntel-18.07.eb
@@ -1,0 +1,30 @@
+# jgp@cscs
+easyblock = 'MakeCp'
+
+name = "papi-wrap"
+version = "1.0"
+
+homepage = 'https://github.com/bcumming/papi-wrap'
+description = """wrappers around papi hardware counters."""
+
+toolchain = {'name': 'CrayIntel', 'version': '18.07'}
+source_urls = [ ' https://github.com/jgphpc/papi-wrap/archive/' ]
+sources = [ '%(version)s.tar.gz' ] 
+checksums = [ 'e72a6c1d631ffb600e9cea1a0b4da947' ]
+dependencies = [ ('papi/5.5.1.2', EXTERNAL_MODULE), ]
+parallel = 1
+prebuildopts = ' ln -fs cscs/makefile . ;'
+files_to_copy = [ 
+    (['libpapi_wrap.a'], 'lib'), 
+    (['*.mod'], 'include'), 
+]
+
+sanity_check_paths = {
+    'files': [ 'lib/libpapi_wrap.a', ],
+    'dirs': [],
+}
+
+modextravars = { 'CSCSPERF_EVENTS' : 'PAPI_TOT_CYC|PAPI_TOT_INS', }
+
+moduleclass = 'perf'
+

--- a/easybuild/easyconfigs/p/papi-wrap/papi-wrap-1.0-CrayPGI-18.07.eb
+++ b/easybuild/easyconfigs/p/papi-wrap/papi-wrap-1.0-CrayPGI-18.07.eb
@@ -1,0 +1,34 @@
+# jgp@cscs
+easyblock = 'MakeCp'
+
+name = "papi-wrap"
+version = "1.0"
+
+homepage = 'https://github.com/bcumming/papi-wrap'
+description = """wrappers around papi hardware counters."""
+
+toolchain = {'name': 'CrayPGI', 'version': '18.07'}
+source_urls = [ ' https://github.com/jgphpc/papi-wrap/archive/' ]
+sources = [ '%(version)s.tar.gz' ] 
+checksums = [ 'e72a6c1d631ffb600e9cea1a0b4da947' ]
+
+# papi provided by perftools-base since 7.0.2 (results in conflict otherwise) 
+# dependencies = [ ('papi/5.5.1.2', EXTERNAL_MODULE), ]
+
+parallel = 1
+prebuildopts  = 'sed -i "s-\$(error-# -" cscs/makefile && '
+prebuildopts += 'ln -fs cscs/makefile . ; '
+files_to_copy = [ 
+    (['libpapi_wrap.a'], 'lib'), 
+    (['*.mod'], 'include'), 
+]
+
+sanity_check_paths = {
+    'files': [ 'lib/libpapi_wrap.a', ],
+    'dirs': [],
+}
+
+modextravars = { 'CSCSPERF_EVENTS' : 'PAPI_TOT_CYC|PAPI_TOT_INS', }
+
+moduleclass = 'perf'
+


### PR DESCRIPTION
Dependency of PAPI was not updated due to conflict with perftools.
papi (current) 5.5.1.2
papi (latest on dom) 5.6.0.2