### PR TITLE
[dom] VASP recipes for 18.07

### DIFF
--- a/easybuild/easyconfigs/v/VASP/VASP-5.4.4-CrayIntel-18.07-cuda-9.1.eb
+++ b/easybuild/easyconfigs/v/VASP/VASP-5.4.4-CrayIntel-18.07-cuda-9.1.eb
@@ -1,0 +1,39 @@
+# contributed by Luca Marsella (CSCS)
+easyblock = 'MakeCp'
+
+name = 'VASP'
+version = '5.4.4'
+cudaversion = '9.1'
+versionsuffix = '-cuda-%s' % cudaversion
+
+homepage = 'http://www.vasp.at'
+description = """The Vienna Ab initio Simulation Package (VASP) is a computer program for atomic scale materials modelling, e.g. electronic structure calculations and quantum-mechanical molecular dynamics, from first principles. """
+
+toolchain = {'name': 'CrayIntel', 'version': '18.07'}
+toolchainopts = { 'usempi': True }
+
+patches = [('%(name)s-%(version)s-%(toolchain_name)s-%(toolchain_version)s%(versionsuffix)s.makefile.include', '%(builddir)s/%(namelower)s-%(version)s')]
+
+sources = ['/apps/common/UES/easybuild/sources/%(nameletterlower)s/%(name)s/' + SOURCELOWER_TAR_BZ2]
+
+builddependencies = [
+    ('cudatoolkit/%s.85_3.10-6.0.6.1_2.1__gf7a1bfb' %cudaversion, EXTERNAL_MODULE),
+    ('cray-fftw/3.3.6.5', EXTERNAL_MODULE),
+]
+
+prebuildopts = ' mv %(name)s-%(version)s-%(toolchain_name)s-%(toolchain_version)s%(versionsuffix)s.makefile.include makefile.include && ' 
+
+# don't use parallel make, results in compilation failure
+parallel = 1
+
+# build type
+buildopts = ' gpu gpu_ncl '
+ 
+files_to_copy = [(['./bin/vasp_*'],'bin')]
+
+sanity_check_paths = {
+    'files': ['bin/vasp_gpu','bin/vasp_gpu_ncl'],
+    'dirs': [],
+}
+
+moduleclass = 'phys'

--- a/easybuild/easyconfigs/v/VASP/VASP-5.4.4-CrayIntel-18.07-cuda-9.1.makefile.include
+++ b/easybuild/easyconfigs/v/VASP/VASP-5.4.4-CrayIntel-18.07-cuda-9.1.makefile.include
@@ -1,0 +1,74 @@
+# Precompiler options
+CPP_OPTIONS= -DHOST=\"LinuxIFC\"\
+             -DMPI -DMPI_BLOCK=8000 \
+             -Duse_collective \
+             -DscaLAPACK \
+             -DCACHE_SIZE=4000 \
+             -Davoidalloc \
+             -Duse_bse_te \
+             -Dtbdyn \
+             -Duse_shmem
+
+CPP        = fpp -f_com=no -free -w0  $*$(FUFFIX) $*$(SUFFIX) $(CPP_OPTIONS)
+
+FC         = ftn
+FCL        = ftn
+
+FREE       = -free -names lowercase
+
+FFLAGS     = -assume byterecl -w
+OFLAG      = -O2
+OFLAG_IN   = $(OFLAG)
+DEBUG      = -O0
+
+BLAS       = $(MKLROOT)/lib/intel64/libmkl_blas95_lp64.a
+LAPACK     = $(MKLROOT)/lib/intel64/libmkl_lapack95_lp64.a
+BLACS      = -lmkl_blacs_intelmpi_lp64
+SCALAPACK  = -L$(MKLROOT)/lib/intel64 -lmkl_scalapack_lp64 -lmkl_intel_lp64 -lmkl_sequential -lmkl_core -lmkl_blacs_intelmpi_lp64
+
+OBJECTS    = fftmpiw.o fftmpi_map.o fft3dlib.o fftw3d.o
+FFT_LIB    = -L$(FFTW_DIR) -lfftw3                                           
+INCS       = -I$(FFTW_INC)           
+LLIBS      = $(SCALAPACK) $(BLACS) $(LAPACK) $(BLAS) $(FFT_LIB)
+
+OBJECTS_O1 += fftw3d.o fftmpi.o fftmpiw.o
+OBJECTS_O2 += fft3dlib.o
+
+# For what used to be vasp.5.lib
+CPP_LIB    = $(CPP)
+FC_LIB     = $(FC)
+CC_LIB     = cc
+CFLAGS_LIB = -O
+FFLAGS_LIB = -O1
+FREE_LIB   = $(FREE)
+
+OBJECTS_LIB= linpack_double.o getshmem.o
+
+# For the parser library
+CXX_PARS   = CC
+
+LIBS       += parser
+LLIBS      += -Lparser -lparser -lstdc++
+
+# Normally no need to change this
+SRCDIR     = ../../src
+BINDIR     = ../../bin
+
+#================================================
+# GPU Stuff
+
+CPP_GPU    = -DCUDA_GPU -DRPROMU_CPROJ_OVERLAP -DUSE_PINNED_MEMORY -DCUFFT_MIN=28 -UscaLAPACK
+
+OBJECTS_GPU = fftmpiw.o fftmpi_map.o fft3dlib.o fftw3d_gpu.o fftmpiw_gpu.o
+
+CC         = cc
+CXX        = CC
+CFLAGS     = -fPIC -DADD_ -Wall -openmp -DMAGMA_WITH_MKL -DMAGMA_SETAFFINITY -DGPUSHMEM=300 -DHAVE_CUBLAS
+
+CUDA_ROOT  := $(CUDATOOLKIT_HOME)
+NVCC       := $(CUDA_ROOT)/bin/nvcc
+CUDA_LIB   := -L$(CUDA_ROOT)/lib64 -lnvToolsExt -lcudart -lcuda -lcufft -lcublas
+
+GENCODE_ARCH := -gencode=arch=compute_60,code=\"sm_60,compute_60\"
+
+MPI_INC    = $(MPICH_DIR)/include/

--- a/easybuild/easyconfigs/v/VASP/VASP-5.4.4-CrayIntel-18.07.eb
+++ b/easybuild/easyconfigs/v/VASP/VASP-5.4.4-CrayIntel-18.07.eb
@@ -1,0 +1,34 @@
+# contributed by Luca Marsella (CSCS)
+easyblock = 'MakeCp'
+
+name = 'VASP'
+version = '5.4.4'
+
+homepage = 'http://www.vasp.at'
+description = """The Vienna Ab initio Simulation Package (VASP) is a computer program for atomic scale materials modelling, e.g. electronic structure calculations and quantum-mechanical molecular dynamics, from first principles. """
+
+toolchain = {'name': 'CrayIntel', 'version': '18.07'}
+toolchainopts = { 'usempi': True }
+
+patches = [('%(name)s-%(version)s-%(toolchain_name)s-%(toolchain_version)s.makefile.include', '%(builddir)s/%(namelower)s-%(version)s')]
+sources = ['/apps/common/UES/easybuild/sources/%(nameletterlower)s/%(name)s/' + SOURCELOWER_TAR_BZ2]
+
+builddependencies = [
+    ('cray-fftw/3.3.6.5', EXTERNAL_MODULE),
+]
+
+prebuildopts = ' mv %(name)s-%(version)s-%(toolchain_name)s-%(toolchain_version)s.makefile.include makefile.include && '
+# don't use parallel make, results in compilation failure
+parallel = 1
+
+# build type
+buildopts = ' all '
+ 
+files_to_copy = [(['./bin/vasp_*'],'bin')]
+
+sanity_check_paths = {
+    'files': ['bin/vasp_gam','bin/vasp_ncl','bin/vasp_std'],
+    'dirs': [],
+}
+
+moduleclass = 'phys'

--- a/easybuild/easyconfigs/v/VASP/VASP-5.4.4-CrayIntel-18.07.makefile.include
+++ b/easybuild/easyconfigs/v/VASP/VASP-5.4.4-CrayIntel-18.07.makefile.include
@@ -1,0 +1,57 @@
+# Precompiler options
+CPP_OPTIONS= -DHOST=\"LinuxIFC\"\
+             -DMPI -DMPI_BLOCK=8000 \
+             -Duse_collective \
+             -DscaLAPACK \
+             -DCACHE_SIZE=4000 \
+             -Davoidalloc \
+             -Duse_bse_te \
+             -Dtbdyn \
+             -Duse_shmem
+
+CPP        = fpp -f_com=no -free -w0  $*$(FUFFIX) $*$(SUFFIX) $(CPP_OPTIONS)
+
+FC         = ftn
+FCL        = ftn
+
+FREE       = -free -names lowercase
+
+FFLAGS     = -assume byterecl -w
+OFLAG      = -O2
+OFLAG_IN   = $(OFLAG)
+DEBUG      = -O0
+
+BLAS       = $(MKLROOT)/lib/intel64/libmkl_blas95_lp64.a
+LAPACK     = $(MKLROOT)/lib/intel64/libmkl_lapack95_lp64.a
+BLACS      = -lmkl_blacs_intelmpi_lp64
+SCALAPACK  = -L$(MKLROOT)/lib/intel64 -lmkl_scalapack_lp64 -lmkl_intel_lp64 -lmkl_sequential -lmkl_core -lmkl_blacs_intelmpi_lp64
+
+OBJECTS    = fftmpiw.o fftmpi_map.o fft3dlib.o fftw3d.o
+FFT_LIB    = -L$(FFTW_DIR) -lfftw3                                           
+INCS       = -I$(FFTW_INC)           
+LLIBS      = $(SCALAPACK) $(BLACS) $(LAPACK) $(BLAS) $(FFT_LIB)
+
+OBJECTS_O1 += fftw3d.o fftmpi.o fftmpiw.o
+OBJECTS_O2 += fft3dlib.o
+
+# For what used to be vasp.5.lib
+CPP_LIB    = $(CPP)
+FC_LIB     = $(FC)
+CC_LIB     = cc
+CFLAGS_LIB = -O
+FFLAGS_LIB = -O1
+FREE_LIB   = $(FREE)
+
+OBJECTS_LIB= linpack_double.o getshmem.o
+
+# For the parser library
+CXX_PARS   = CC
+
+LIBS       += parser
+LLIBS      += -Lparser -lparser -lstdc++
+
+# Normally no need to change this
+SRCDIR     = ../../src
+BINDIR     = ../../bin
+
+MPI_INC    = $(MPICH_DIR)/include/

--- a/jenkins-builds/6.0.UP06-18.07-gpu
+++ b/jenkins-builds/6.0.UP06-18.07-gpu
@@ -43,5 +43,6 @@
  Theano-1.0.2-CrayGNU-18.07-cuda-9.1-python3.eb     --set-default-module
  Understand-4.0.926.eb                              --set-default-module --hidden
  vampir-9.5.0.eb                                    --set-default-module
+ VASP-5.4.4-CrayIntel-18.07-cuda-9.1.eb             --set-default-module
  VMD-1.9.3-egl.eb
  VMD-1.9.3-ogl.eb

--- a/jenkins-builds/6.0.UP06-18.07-mc
+++ b/jenkins-builds/6.0.UP06-18.07-mc
@@ -37,3 +37,4 @@
  Spark-2.3.1-CrayGNU-18.07-Hadoop-2.7.eb
  Understand-4.0.926.eb                              --set-default-module --hidden
  vampir-9.5.0.eb                                    --set-default-module
+ VASP-5.4.4-CrayIntel-18.07.eb                      --set-default-module


### PR DESCRIPTION
VASP stable release is still `5.4.4` as already available in production. 