### PR TITLE
[Leone] Changing MPI in LIGGGHTS/4.0

### DIFF
--- a/easybuild/easyconfigs/l/LIGGGHTS/LIGGGHTS-4.0.eb
+++ b/easybuild/easyconfigs/l/LIGGGHTS/LIGGGHTS-4.0.eb
@@ -17,7 +17,7 @@ toolchain = {'name': 'dummy', 'version': 'dummy'}
 
 dependencies = [ ('CMake/3.4.1', EXTERNAL_MODULE),
                  ('gcc/5.3.0', EXTERNAL_MODULE),
-                 ('mvapich2/2.1-gcc-5.3.0', EXTERNAL_MODULE) ]
+                 ('OpenMPI/1.10.2-GCC-5.3.0-2.26', EXTERNAL_MODULE) ]
 
 modtclfooter = """
 prepend-path PATH "/apps/leone/hilti/RH6.7/LIGGGHTS/LIGGGHTS-HILTI/src"

--- a/jenkins-builds/leone-RHEL6.7EUS-17.06
+++ b/jenkins-builds/leone-RHEL6.7EUS-17.06
@@ -2,7 +2,6 @@
  ddt-18.0.1.eb
  ddt-18.1.1.eb                              --set-default-module
  h-yade-2017.01a-foss-2016b-Python-2.7.12.eb
- LIGGGHTS-3.8.eb
  LIGGGHTS-4.0.eb                            --set-default-module
  OpenFOAM-4.1-foss-2016b.eb                 --set-default-module 
  OpenFOAM-5.0-20180108-foss-2016b.eb


### PR DESCRIPTION
Test by Hilti showed, that the OpenMPI/1.10.2-GCC-5.3.0-2.26 gives better
performance than mvapich2/2.1-gcc-5.3.0. EB-file was adapted accordingly.

Also, LIGGGHTS 3.8 was removed from module list, since the installation
is no longer present

see  webRT ticket number 32590 (https://webrt.cscs.ch/Ticket/Display.html?id=32590)