### PR TITLE
[dom]: correcting dom-build lists (- CDO and ParaView)

### DIFF
--- a/jenkins-builds/6.0.UP07-18.08-gpu
+++ b/jenkins-builds/6.0.UP07-18.08-gpu
@@ -3,8 +3,6 @@
  Boost-1.67.0-CrayGNU-18.08-python3.eb              --set-default-module
  Boost-1.67.0-CrayGNU-18.08.eb
  CMake-3.12.0.eb
- CDO-1.9.4-CrayGNU-18.08.eb                         --set-default-module
- CDO-1.9.3-CrayIntel-18.08.eb
  CP2K-6.1-CrayGNU-18.08-cuda-9.1.eb                 --set-default-module
  CubeGUI-4.4.eb                                     --set-default-module --installpath=/apps/dom/UES/jenscscs/6.0.UP07/gpu/easybuild/tools
  ddt-18.1.3-Suse-12.eb                              --set-default-module --installpath=/apps/dom/UES/jenscscs/6.0.UP07/gpu/easybuild/tools
@@ -28,7 +26,6 @@
  papi-wrap-1.0-CrayGNU-18.08.eb                     --set-default-module --installpath=/apps/dom/UES/jenscscs/6.0.UP07/gpu/easybuild/tools
  papi-wrap-1.0-CrayCCE-18.08.eb                     --installpath=/apps/dom/UES/jenscscs/6.0.UP07/gpu/easybuild/tools
  papi-wrap-1.0-CrayIntel-18.08.eb                   --installpath=/apps/dom/UES/jenscscs/6.0.UP07/gpu/easybuild/tools
- ParaView-5.5.2-EGL-CrayGNU-18.08.eb                --set-default-module
  Python-bare-3.6.2.eb                               --hidden
  pycuda-2017.1.1-CrayGNU-18.08-python2-cuda-9.1.eb
  pycuda-2017.1.1-CrayGNU-18.08-python3-cuda-9.1.eb  --set-default-module

--- a/jenkins-builds/6.0.UP07-18.08-mc
+++ b/jenkins-builds/6.0.UP07-18.08-mc
@@ -3,8 +3,6 @@
  Boost-1.67.0-CrayGNU-18.08-python3.eb              --set-default-module
  Boost-1.67.0-CrayGNU-18.08.eb
  CMake-3.12.0.eb
- CDO-1.9.4-CrayGNU-18.08.eb                         --set-default-module
- CDO-1.9.3-CrayIntel-18.08.eb
  CP2K-6.1-CrayGNU-18.08.eb                          --set-default-module
  CubeGUI-4.4.eb                                     --set-default-module    --installpath=/apps/dom/UES/jenscscs/6.0.UP07/mc/easybuild/tools
  ddt-18.1.3-Suse-12.eb                              --set-default-module    --installpath=/apps/dom/UES/jenscscs/6.0.UP07/mc/easybuild/tools


### PR DESCRIPTION
Jenkins builds were failing with the error message 

ERROR: Can't find path /scratch/snx3000tds/jenscscs/dom/workspace/ProductionEB/CDO-1.9.4-CrayGNU-18.08.eb

script returned exit code 2