### PR TITLE
[dom-gpu] Removing cudatoolkit module

### DIFF
--- a/easybuild/easyconfigs/c/CP2K/CP2K-6.1-CrayGNU-18.08-cuda-9.1.eb
+++ b/easybuild/easyconfigs/c/CP2K/CP2K-6.1-CrayGNU-18.08-cuda-9.1.eb
@@ -20,7 +20,7 @@ sources = [SOURCELOWER_TAR_BZ2]
 source_urls = [SOURCEFORGE_SOURCE]
 
 builddependencies = [
-    ('cudatoolkit/%s.85_3.18-6.0.7.0_5.1__g2eb7c52' %cudaversion, EXTERNAL_MODULE),
+    ('craype-accel-nvidia60', EXTERNAL_MODULE),
     ('cray-fftw/3.3.6.5', EXTERNAL_MODULE),
     ('cray-python/2.7.15.1', EXTERNAL_MODULE),
     ('flex', '2.6.4'),

--- a/easybuild/easyconfigs/p/pycuda/pycuda-2017.1.1-CrayGNU-18.08-python2-cuda-9.1.eb
+++ b/easybuild/easyconfigs/p/pycuda/pycuda-2017.1.1-CrayGNU-18.08-python2-cuda-9.1.eb
@@ -27,7 +27,7 @@ sources = [SOURCE_TAR_GZ]
 
 dependencies = [
     ('cray-python/%s' % pyver, EXTERNAL_MODULE),
-    ('cudatoolkit/%s.85_3.18-6.0.7.0_5.1__g2eb7c52' % cudaversion, EXTERNAL_MODULE),
+    ('craype-accel-nvidia60', EXTERNAL_MODULE),
 ]
 
 prebuildopts = "python ./configure.py --cuda-root=$EBROOTCUDA"

--- a/easybuild/easyconfigs/p/pycuda/pycuda-2017.1.1-CrayGNU-18.08-python3-cuda-9.1.eb
+++ b/easybuild/easyconfigs/p/pycuda/pycuda-2017.1.1-CrayGNU-18.08-python3-cuda-9.1.eb
@@ -27,7 +27,7 @@ sources = [SOURCE_TAR_GZ]
 
 dependencies = [
     ('cray-python/%s' % pyver, EXTERNAL_MODULE),
-    ('cudatoolkit/%s.85_3.18-6.0.7.0_5.1__g2eb7c52' % cudaversion, EXTERNAL_MODULE),
+    ('craype-accel-nvidia60', EXTERNAL_MODULE),
 ]
 
 prebuildopts = "python ./configure.py --cuda-root=$EBROOTCUDA"

--- a/easybuild/easyconfigs/v/VASP/VASP-5.4.4-CrayIntel-18.08-cuda-9.1.eb
+++ b/easybuild/easyconfigs/v/VASP/VASP-5.4.4-CrayIntel-18.08-cuda-9.1.eb
@@ -17,7 +17,7 @@ patches = [('%(name)s-%(version)s-%(toolchain_name)s-%(toolchain_version)s%(vers
 sources = ['/apps/common/UES/easybuild/sources/%(nameletterlower)s/%(name)s/' + SOURCELOWER_TAR_BZ2]
 
 builddependencies = [
-    ('cudatoolkit/%s.85_3.18-6.0.7.0_5.1__g2eb7c52' %cudaversion, EXTERNAL_MODULE),
+    ('craype-accel-nvidia60', EXTERNAL_MODULE),
     ('cray-fftw/3.3.6.5', EXTERNAL_MODULE),
 ]
 


### PR DESCRIPTION
Using dependency `craype-accel-nvidia60` as discussed at today's SCS group meeting, following the advice of the GitLab issue https://git.cscs.ch/scs/doc/issues/355