### PR TITLE
[WIP] [dom] Additional recipes for COSMO-POMPA dependencies

### DIFF
--- a/easybuild/easyconfigs/c/COSMO_pompa_crclim_dycore/COSMO_pompa_crclim_dycore-551f6b44dc13227d92225edfd6e3bfd58c782928-CrayGNU-18.08-double.eb
+++ b/easybuild/easyconfigs/c/COSMO_pompa_crclim_dycore/COSMO_pompa_crclim_dycore-551f6b44dc13227d92225edfd6e3bfd58c782928-CrayGNU-18.08-double.eb
@@ -1,0 +1,36 @@
+# jg (cscs)
+easyblock = 'CMakeMake'
+
+name = 'COSMO_pompa_crclim_dycore'
+version = '551f6b44dc13227d92225edfd6e3bfd58c782928'
+versionsuffix = '-double'
+
+homepage = 'https://github.com/C2SM-RCM/cosmo-pompa/tree/master/dycore (-b crclim)'
+description = """cosmo-pompa-dycore"""
+
+toolchain = {'name': 'CrayGNU', 'version': '18.08'}
+toolchainopts = {'verbose': False}
+# repo is private (+ no official release)
+sources = [
+    {'filename': '/apps/common/UES/easybuild/sources/c/%(name)s/%(name)s_%(version)s.tar.gz'}
+]
+
+builddependencies = [ ('CMake', '3.12.0', '', True), ]
+
+dependencies = [
+    ('STELLA_CRCLIM', '4a5f9c53d3b159cbdf9cfaa2eb4450181780f594', '%(versionsuffix)s'),
+    ('cudatoolkit/9.1.85_3.18-6.0.7.0_5.1__g2eb7c52', EXTERNAL_MODULE),
+    ('craype-accel-nvidia60', EXTERNAL_MODULE),
+]
+
+srcdir = "../dycore"
+configopts  = "-DCMAKE_BUILD_TYPE=Release "
+configopts += "-DSINGLEPRECISION=OFF "
+configopts += "-DCUDA_BACKEND=ON "
+configopts += "-DSTELLA_DIR=${EBROOTSTELLA_CRCLIM} " 
+configopts += "-DBITREPRO=OFF "
+
+separate_build_dir = True
+
+moduleclass = 'devel'
+

--- a/easybuild/easyconfigs/g/grib_api/grib_api-1.24.0-CrayGNU-18.08.eb
+++ b/easybuild/easyconfigs/g/grib_api/grib_api-1.24.0-CrayGNU-18.08.eb
@@ -1,0 +1,26 @@
+# File modified by MaKra - August 2017 (CSCS); adapted by @omlins (09.2018)
+easyblock = 'ConfigureMake'
+
+name = 'grib_api'
+version = '1.24.0'
+
+homepage = 'https://software.ecmwf.int/wiki/display/GRIB/Home'
+description = """The ECMWF GRIB API is an application program interface accessible from C, FORTRAN and Python
+ programs developed for encoding and decoding WMO FM-92 GRIB edition 1 and edition 2 messages. A useful set of
+ command line tools is also provided to give quick access to GRIB messages."""
+
+toolchain = {'name': 'CrayGNU', 'version': '18.08'}
+
+source_urls = ['https://software.ecmwf.int/wiki/download/attachments/3473437/']
+sources = ['grib_api-%(version)s-Source.tar.gz']
+checksums = ['6b0d443cb0802c5de652e5816c5b88734cb3ead454eb932c5ec12ef8d4f77bcd']
+
+dependencies = [
+    ('JasPer', '1.900.1'), #2.x doesn't work (at least 2.0.14 doesn't)
+]
+
+configopts = '--with-jasper=$EBROOTJASPER'
+
+parallel = 1
+
+moduleclass = 'data'

--- a/easybuild/easyconfigs/j/JasPer/JasPer-1.900.1-CrayGNU-18.08.eb
+++ b/easybuild/easyconfigs/j/JasPer/JasPer-1.900.1-CrayGNU-18.08.eb
@@ -1,0 +1,19 @@
+easyblock = 'ConfigureMake'
+
+name = 'JasPer'
+version = '1.900.1'
+
+homepage = 'http://www.ece.uvic.ca/~frodo/jasper/'
+description = "gzip (GNU zip) is a popular data compression program as a replacement for compress"
+toolchain = {'name': 'CrayGNU', 'version': '18.08'}
+toolchainopts = {'pic': True}
+
+sources = [SOURCELOWER_ZIP]
+source_urls = ['http://www.ece.uvic.ca/~frodo/jasper/software/']
+
+sanity_check_paths = {
+    'files': ["bin/jasper", "lib/libjasper.a"],
+    'dirs': ["include"],
+}
+
+moduleclass = 'vis'


### PR DESCRIPTION
1. grib_api-1.24.0 can unfortunately not be built with Jasper 2.x; this is why I added the recipe for JasPer-1.900.1. I think that some of the dependencies use however Jasper 2.x (maybe Serialbox - to be checked); this could be a problem and maybe we must make sure that all recipes use the same JasPer, i.e. 1.900.1.
2. I think first we should try to build the double precision version of COSMO; thus I added a 'double' variant of the dycore recipe
