### PR TITLE
[daint-gpu] Add GROMACS 2018.3

### DIFF
--- a/easybuild/easyconfigs/g/GROMACS/GROMACS-2018.3-CrayGNU-17.08-cuda-8.0.eb
+++ b/easybuild/easyconfigs/g/GROMACS/GROMACS-2018.3-CrayGNU-17.08-cuda-8.0.eb
@@ -1,0 +1,41 @@
+# contributed by Luca Marsella (CSCS)
+#
+# This file is an EasyBuild reciPY as per https://github.com/hpcugent/easybuild
+#
+# Copyright:: Copyright 2012-2013 University of Luxembourg / LCSB, Cyprus Institute / CaSToRC, Ghent University
+# Authors::   Wiktor Jurkowski <wiktor.jurkowski@uni.lu>, Fotis Georgatos <fotis.georgatos@uni.lu>, \
+#             George Tsouloupas <g.tsouloupas@cyi.ac.cy>, Kenneth Hoste
+# License::   MIT/GPL
+# $Id$
+#
+# This work implements a part of the HPCBIOS project and is a component of the policy:
+# http://hpcbios.readthedocs.org/en/latest/HPCBIOS_2012-93.html
+#
+name = 'GROMACS'
+version = "2018.3"
+cudaversion = '8.0'
+versionsuffix = '-cuda-%s' % cudaversion
+
+homepage = 'http://www.gromacs.org'
+description = """GROMACS is a versatile package to perform molecular dynamics,
+ i.e. simulate the Newtonian equations of motion for systems with hundreds to millions of particles."""
+
+toolchain = {'name': 'CrayGNU', 'version': '17.08'}
+toolchainopts = {'usempi': 'True', 'openmp': 'True', 'pic': 'True', 'verbose': 'False', 'debug': 'True'}
+
+source_urls = ['ftp://ftp.gromacs.org/pub/gromacs/']
+sources = [SOURCELOWER_TAR_GZ]
+
+configopts = ' -DCMAKE_C_FLAGS="-g -fPIC" -DCMAKE_CXX_FLAGS="-g -fPIC" '
+
+skipsteps = ['test']
+
+# CMake dependency with dummy toolchain
+builddependencies = [
+    ('CMake', '3.9.1', '', True),
+    ('cray-fftw/3.3.6.2', EXTERNAL_MODULE),
+    ('cudatoolkit/%s.61_2.4.3-6.0.4.0_3.1__gb475d12' %cudaversion, EXTERNAL_MODULE),
+    ('libxml2', '2.9.4'),
+]
+
+moduleclass = 'bio'

--- a/easybuild/easyconfigs/g/GROMACS/GROMACS-2018.3-CrayGNU-17.08.eb
+++ b/easybuild/easyconfigs/g/GROMACS/GROMACS-2018.3-CrayGNU-17.08.eb
@@ -1,0 +1,39 @@
+# contributed by Luca Marsella, Victor Holanda Rusu (CSCS)
+#
+# This file is an EasyBuild reciPY as per https://github.com/hpcugent/easybuild
+#
+# Copyright:: Copyright 2012-2013 University of Luxembourg / LCSB, Cyprus Institute / CaSToRC, Ghent University
+# Authors::   Wiktor Jurkowski <wiktor.jurkowski@uni.lu>, Fotis Georgatos <fotis.georgatos@uni.lu>, \
+#             George Tsouloupas <g.tsouloupas@cyi.ac.cy>, Kenneth Hoste
+# License::   MIT/GPL
+# $Id$
+#
+# This work implements a part of the HPCBIOS project and is a component of the policy:
+# http://hpcbios.readthedocs.org/en/latest/HPCBIOS_2012-93.html
+#
+name = 'GROMACS'
+version = "2018.3"
+cudaversion = '8.0'
+
+homepage = 'http://www.gromacs.org'
+description = """GROMACS is a versatile package to perform molecular dynamics,
+ i.e. simulate the Newtonian equations of motion for systems with hundreds to millions of particles."""
+
+toolchain = {'name': 'CrayGNU', 'version': '17.08'}
+toolchainopts = {'usempi': 'True', 'openmp': 'True', 'pic': 'True', 'verbose': 'False', 'debug': 'True'}
+
+source_urls = ['ftp://ftp.gromacs.org/pub/gromacs/']
+sources = [SOURCELOWER_TAR_GZ]
+
+configopts = ' -DCMAKE_C_FLAGS="-g -fPIC" -DCMAKE_CXX_FLAGS="-g -fPIC" '
+
+skipsteps = ['test']
+
+# CMake dependency with dummy toolchain
+builddependencies = [
+    ('CMake', '3.9.1', '', True),
+    ('cray-fftw/3.3.6.2', EXTERNAL_MODULE),
+    ('libxml2', '2.9.4'),
+]
+
+moduleclass = 'bio'

--- a/jenkins-builds/6.0.UP04-17.08-gpu
+++ b/jenkins-builds/6.0.UP04-17.08-gpu
@@ -14,13 +14,14 @@
  CDO-1.9.5-CrayIntel-17.08.eb
  CPMD-4.1-CrayIntel-17.08g.eb                       --set-default-module
  CPMD-4.1-CrayIntel-17.12.eb
- ddt-18.0.1.eb                                      
+ ddt-18.0.1.eb
  ddt-18.1.1.eb                                      --set-default-module
  Extrae-3.5.2-CrayGNU-17.08.eb                      --set-default-module
  Extrae-3.5.2-CrayIntel-17.08.eb
  GREASY-2.1-cscs-CrayGNU-17.08.eb                   --set-default-module
- GROMACS-2016.3-CrayGNU-17.08-cuda-8.0.eb           
- GROMACS-2018-CrayGNU-17.08-cuda-8.0.eb             --set-default-module
+ GROMACS-2016.3-CrayGNU-17.08-cuda-8.0.eb
+ GROMACS-2018-CrayGNU-17.08-cuda-8.0.eb
+ GROMACS-2018.3-CrayGNU-17.08-cuda-8.0.eb           --set-default-module
  GSL-2.4-CrayGNU-17.08.eb                           --set-default-module
  GSL-2.4-CrayCCE-17.08.eb
  GSL-2.4-CrayIntel-17.08.eb

--- a/jenkins-builds/6.0.UP04-17.08-gpu
+++ b/jenkins-builds/6.0.UP04-17.08-gpu
@@ -20,8 +20,8 @@
  Extrae-3.5.2-CrayIntel-17.08.eb
  GREASY-2.1-cscs-CrayGNU-17.08.eb                   --set-default-module
  GROMACS-2016.3-CrayGNU-17.08-cuda-8.0.eb
- GROMACS-2018-CrayGNU-17.08-cuda-8.0.eb
- GROMACS-2018.3-CrayGNU-17.08-cuda-8.0.eb           --set-default-module
+ GROMACS-2018-CrayGNU-17.08-cuda-8.0.eb             --set-default-module
+ GROMACS-2018.3-CrayGNU-17.08-cuda-8.0.eb
  GSL-2.4-CrayGNU-17.08.eb                           --set-default-module
  GSL-2.4-CrayCCE-17.08.eb
  GSL-2.4-CrayIntel-17.08.eb

--- a/jenkins-builds/6.0.UP04-17.08-mc
+++ b/jenkins-builds/6.0.UP04-17.08-mc
@@ -5,7 +5,7 @@
  Boost-1.65.0-CrayGNU-17.08-python3.eb              --set-default-module
  Boost-1.65.0-CrayGNU-17.08.eb
  CMake-3.10.1.eb
- CP2K-5.0r18043-CrayGNU-17.08.eb                    
+ CP2K-5.0r18043-CrayGNU-17.08.eb
  CP2K-5.1-CrayGNU-17.08.eb                          --set-default-module
  CDO-1.9.0-CrayGNU-17.08.eb                         --set-default-module
  CDO-1.9.0-CrayIntel-17.08.eb
@@ -18,8 +18,9 @@
  Extrae-3.5.2-CrayGNU-17.08.eb                      --set-default-module
  Extrae-3.5.2-CrayIntel-17.08.eb
  GREASY-2.1-cscs-CrayGNU-17.08.eb                   --set-default-module
- GROMACS-2016.3-CrayGNU-17.08.eb                    
- GROMACS-2018-CrayGNU-17.08.eb                      --set-default-module
+ GROMACS-2016.3-CrayGNU-17.08.eb
+ GROMACS-2018-CrayGNU-17.08.eb
+ GROMACS-2018.3-CrayGNU-17.08.eb                    --set-default-module
  GSL-2.4-CrayGNU-17.08.eb                           --set-default-module
  GSL-2.4-CrayCCE-17.08.eb
  GSL-2.4-CrayIntel-17.08.eb

--- a/jenkins-builds/6.0.UP04-17.08-mc
+++ b/jenkins-builds/6.0.UP04-17.08-mc
@@ -19,8 +19,8 @@
  Extrae-3.5.2-CrayIntel-17.08.eb
  GREASY-2.1-cscs-CrayGNU-17.08.eb                   --set-default-module
  GROMACS-2016.3-CrayGNU-17.08.eb
- GROMACS-2018-CrayGNU-17.08.eb
- GROMACS-2018.3-CrayGNU-17.08.eb                    --set-default-module
+ GROMACS-2018-CrayGNU-17.08.eb                      --set-default-module
+ GROMACS-2018.3-CrayGNU-17.08.eb
  GSL-2.4-CrayGNU-17.08.eb                           --set-default-module
  GSL-2.4-CrayCCE-17.08.eb
  GSL-2.4-CrayIntel-17.08.eb


### PR DESCRIPTION
The reason why I am also changing the default is because the current
GROMACS 2018 has 5 major bugs fixed using version 2018.3

Especially the is a Replica Exchange bug that hinders users from using
RE with GROMACS 2018.