### PR TITLE
[dom-gpu] CP2K with perftools-lite

### DIFF
--- a/easybuild/easyconfigs/c/CP2K/CP2K-6.1-CrayGNU-18.08-cuda-9.1-pat-7.0.2.eb
+++ b/easybuild/easyconfigs/c/CP2K/CP2K-6.1-CrayGNU-18.08-cuda-9.1-pat-7.0.2.eb
@@ -38,15 +38,15 @@ dependencies = [
 # use the non-threaded version of BLAS provided by cray-libsci and go to folder makefiles
 prebuildopts = " export PE_LIBSCI_OMP_REQUIRES_openmp="" && pushd makefiles && "
 # build type
-buildopts = 'ARCH=%(name)s-%(version)s-%(toolchain_name)s-%(toolchain_version)s%(versionsuffix)s VERSION=psmp'
+buildopts = 'ARCH=%(name)s-%(version)s-%(toolchain_name)s-%(toolchain_version)s-cuda-{0} VERSION=psmp'.format(cudaversion)
  
-files_to_copy = [(['./arch/%(name)s-%(version)s-%(toolchain_name)s-%(toolchain_version)s%(versionsuffix)s.psmp'],'arch'),
-                 (['./exe/%(name)s-%(version)s-%(toolchain_name)s-%(toolchain_version)s%(versionsuffix)s/*'],'bin'), 
+files_to_copy = [(['./arch/%(name)s-%(version)s-%(toolchain_name)s-%(toolchain_version)s-cuda-{0}.psmp'.format(cudaversion)],'arch'),
+                 (['./exe/%(name)s-%(version)s-%(toolchain_name)s-%(toolchain_version)s-cuda-{0}/*'.format(cudaversion)],'bin'), 
                  (['./data'],'.'),
                  (['./tests'],'.')]
 
 sanity_check_paths = {
-    'files': ['arch/%(name)s-%(version)s-%(toolchain_name)s-%(toolchain_version)s%(versionsuffix)s.psmp', 
+    'files': ['arch/%(name)s-%(version)s-%(toolchain_name)s-%(toolchain_version)s-cuda-{0}.psmp'.format(cudaversion), 
               'bin/cp2k.psmp'],
     'dirs': ['data','tests'],
 }

--- a/easybuild/easyconfigs/c/CP2K/CP2K-6.1-CrayGNU-18.08-cuda-9.1-pat-7.0.2.eb
+++ b/easybuild/easyconfigs/c/CP2K/CP2K-6.1-CrayGNU-18.08-cuda-9.1-pat-7.0.2.eb
@@ -7,6 +7,12 @@ cudaversion = '9.1'
 patversion = '7.0.2'
 versionsuffix = '-cuda-%s-pat-%s' % (cudaversion, patversion)
 
+py_maj_ver = '2'
+py_min_ver = '7'
+py_rev_ver = '15.1'
+pyshortver = "%s.%s" % (py_maj_ver, py_min_ver)
+pyver      = "%s.%s.%s" % (py_maj_ver, py_min_ver, py_rev_ver)
+
 homepage = 'http://www.cp2k.org/'
 description = """CP2K is a freely available (GPL) program, written in Fortran 95, to perform atomistic and molecular
  simulations of solid state, liquid, molecular and biological systems. It provides a general framework for different
@@ -23,7 +29,7 @@ source_urls = [SOURCEFORGE_SOURCE]
 builddependencies = [
     ('cudatoolkit/%s.85_3.18-6.0.7.0_5.1__g2eb7c52' % cudaversion, EXTERNAL_MODULE),
     ('cray-fftw/3.3.6.5', EXTERNAL_MODULE),
-    ('cray-python/2.7.15.1', EXTERNAL_MODULE),
+    ('cray-python/%s' % pyver, EXTERNAL_MODULE),
     ('flex', '2.6.4'),
     ('Bison', '3.0.5'),
     ('perftools-lite/%s' % patversion, EXTERNAL_MODULE)

--- a/easybuild/easyconfigs/c/CP2K/CP2K-6.1-CrayGNU-18.08-cuda-9.1-pat-7.0.2.eb
+++ b/easybuild/easyconfigs/c/CP2K/CP2K-6.1-CrayGNU-18.08-cuda-9.1-pat-7.0.2.eb
@@ -21,7 +21,7 @@ sources = [SOURCELOWER_TAR_BZ2]
 source_urls = [SOURCEFORGE_SOURCE]
 
 builddependencies = [
-    ('craype-accel-nvidia60', EXTERNAL_MODULE),
+    ('cudatoolkit/%s.85_3.18-6.0.7.0_5.1__g2eb7c52' % cudaversion, EXTERNAL_MODULE),
     ('cray-fftw/3.3.6.5', EXTERNAL_MODULE),
     ('cray-python/2.7.15.1', EXTERNAL_MODULE),
     ('flex', '2.6.4'),
@@ -30,6 +30,7 @@ builddependencies = [
 ]
 
 dependencies = [
+    ('craype-accel-nvidia60', EXTERNAL_MODULE),
     ('Libint', '1.1.4'),
     ('libxc', '4.2.3'),
 ]

--- a/easybuild/easyconfigs/c/CP2K/CP2K-6.1-CrayGNU-18.08-cuda-9.1-pat-7.0.2.eb
+++ b/easybuild/easyconfigs/c/CP2K/CP2K-6.1-CrayGNU-18.08-cuda-9.1-pat-7.0.2.eb
@@ -1,0 +1,56 @@
+# contributed by Luca Marsella (CSCS)
+easyblock = 'MakeCp'
+
+name = 'CP2K'
+version = '6.1'
+cudaversion = '9.1'
+patversion = '7.0.2'
+versionsuffix = '-cuda-%s-pat-%s' % (cudaversion, patversion)
+
+homepage = 'http://www.cp2k.org/'
+description = """CP2K is a freely available (GPL) program, written in Fortran 95, to perform atomistic and molecular
+ simulations of solid state, liquid, molecular and biological systems. It provides a general framework for different
+ methods such as e.g. density functional theory (DFT) using a mixed Gaussian and plane waves approach (GPW), and
+ classical pair and many-body potentials. """
+
+toolchain = {'name': 'CrayGNU', 'version': '18.08'}
+toolchainopts = { 'usempi': True, 'openmp': True }
+
+patches = [('%(name)s-%(version)s-%(toolchain_name)s-%(toolchain_version)s-cuda-{0}.psmp'.format(cudaversion), '%(builddir)s/%(namelower)s-%(version)s/arch')]
+sources = [SOURCELOWER_TAR_BZ2]
+source_urls = [SOURCEFORGE_SOURCE]
+
+builddependencies = [
+    ('craype-accel-nvidia60', EXTERNAL_MODULE),
+    ('cray-fftw/3.3.6.5', EXTERNAL_MODULE),
+    ('cray-python/2.7.15.1', EXTERNAL_MODULE),
+    ('flex', '2.6.4'),
+    ('Bison', '3.0.5'),
+    ('perftools-lite/%s' % patversion, EXTERNAL_MODULE)
+]
+
+dependencies = [
+    ('Libint', '1.1.4'),
+    ('libxc', '4.2.3'),
+]
+
+# use the non-threaded version of BLAS provided by cray-libsci and go to folder makefiles
+prebuildopts = " export PE_LIBSCI_OMP_REQUIRES_openmp="" && pushd makefiles && "
+# build type
+buildopts = 'ARCH=%(name)s-%(version)s-%(toolchain_name)s-%(toolchain_version)s%(versionsuffix)s VERSION=psmp'
+ 
+files_to_copy = [(['./arch/%(name)s-%(version)s-%(toolchain_name)s-%(toolchain_version)s%(versionsuffix)s.psmp'],'arch'),
+                 (['./exe/%(name)s-%(version)s-%(toolchain_name)s-%(toolchain_version)s%(versionsuffix)s/*'],'bin'), 
+                 (['./data'],'.'),
+                 (['./tests'],'.')]
+
+sanity_check_paths = {
+    'files': ['arch/%(name)s-%(version)s-%(toolchain_name)s-%(toolchain_version)s%(versionsuffix)s.psmp', 
+              'bin/cp2k.psmp'],
+    'dirs': ['data','tests'],
+}
+
+# set custom CP2K_DATA_DIR
+modextravars = {'CP2K_DATA_DIR': '%(installdir)s/data'}
+
+moduleclass = 'chem'

--- a/easybuild/easyconfigs/c/CP2K/CP2K-6.1-CrayGNU-18.08-cuda-9.1.eb
+++ b/easybuild/easyconfigs/c/CP2K/CP2K-6.1-CrayGNU-18.08-cuda-9.1.eb
@@ -20,7 +20,7 @@ sources = [SOURCELOWER_TAR_BZ2]
 source_urls = [SOURCEFORGE_SOURCE]
 
 builddependencies = [
-    ('craype-accel-nvidia60', EXTERNAL_MODULE),
+    ('cudatoolkit/%s.85_3.18-6.0.7.0_5.1__g2eb7c52' % cudaversion, EXTERNAL_MODULE),
     ('cray-fftw/3.3.6.5', EXTERNAL_MODULE),
     ('cray-python/2.7.15.1', EXTERNAL_MODULE),
     ('flex', '2.6.4'),
@@ -28,6 +28,7 @@ builddependencies = [
 ]
 
 dependencies = [
+    ('craype-accel-nvidia60', EXTERNAL_MODULE),
     ('Libint', '1.1.4'),
     ('libxc', '4.2.3'),
 ]

--- a/easybuild/easyconfigs/c/CP2K/CP2K-6.1-CrayGNU-18.08-cuda-9.1.eb
+++ b/easybuild/easyconfigs/c/CP2K/CP2K-6.1-CrayGNU-18.08-cuda-9.1.eb
@@ -6,6 +6,12 @@ version = '6.1'
 cudaversion = '9.1'
 versionsuffix = '-cuda-%s' % cudaversion
 
+py_maj_ver = '2'
+py_min_ver = '7'
+py_rev_ver = '15.1'
+pyshortver = "%s.%s" % (py_maj_ver, py_min_ver)
+pyver      = "%s.%s.%s" % (py_maj_ver, py_min_ver, py_rev_ver)
+
 homepage = 'http://www.cp2k.org/'
 description = """CP2K is a freely available (GPL) program, written in Fortran 95, to perform atomistic and molecular
  simulations of solid state, liquid, molecular and biological systems. It provides a general framework for different
@@ -22,7 +28,7 @@ source_urls = [SOURCEFORGE_SOURCE]
 builddependencies = [
     ('cudatoolkit/%s.85_3.18-6.0.7.0_5.1__g2eb7c52' % cudaversion, EXTERNAL_MODULE),
     ('cray-fftw/3.3.6.5', EXTERNAL_MODULE),
-    ('cray-python/2.7.15.1', EXTERNAL_MODULE),
+    ('cray-python/%s' % pyver, EXTERNAL_MODULE),
     ('flex', '2.6.4'),
     ('Bison', '3.0.5'),
 ]

--- a/easybuild/easyconfigs/c/CP2K/CP2K-6.1-CrayGNU-18.08-pat-7.0.2.eb
+++ b/easybuild/easyconfigs/c/CP2K/CP2K-6.1-CrayGNU-18.08-pat-7.0.2.eb
@@ -6,6 +6,12 @@ version = '6.1'
 patversion = '7.0.2'
 versionsuffix = '-pat-%s' % patversion
 
+py_maj_ver = '2'
+py_min_ver = '7'
+py_rev_ver = '15.1'
+pyshortver = "%s.%s" % (py_maj_ver, py_min_ver)
+pyver      = "%s.%s.%s" % (py_maj_ver, py_min_ver, py_rev_ver)
+
 homepage = 'http://www.cp2k.org/'
 description = """CP2K is a freely available (GPL) program, written in Fortran 95, to perform atomistic and molecular
  simulations of solid state, liquid, molecular and biological systems. It provides a general framework for different
@@ -21,7 +27,7 @@ source_urls = [SOURCEFORGE_SOURCE]
 
 builddependencies = [
     ('cray-fftw/3.3.6.5', EXTERNAL_MODULE),
-    ('cray-python/2.7.15.1', EXTERNAL_MODULE),
+    ('cray-python/%s' % pyver, EXTERNAL_MODULE),
     ('flex', '2.6.4'),
     ('Bison', '3.0.5'),
     ('perftools-lite/%s' % patversion, EXTERNAL_MODULE)

--- a/easybuild/easyconfigs/c/CP2K/CP2K-6.1-CrayGNU-18.08-pat-7.0.2.eb
+++ b/easybuild/easyconfigs/c/CP2K/CP2K-6.1-CrayGNU-18.08-pat-7.0.2.eb
@@ -1,0 +1,54 @@
+# contributed by Luca Marsella (CSCS)
+easyblock = 'MakeCp'
+
+name = 'CP2K'
+version = '6.1'
+patversion = '7.0.2'
+versionsuffix = '-pat-%s' % patversion
+
+homepage = 'http://www.cp2k.org/'
+description = """CP2K is a freely available (GPL) program, written in Fortran 95, to perform atomistic and molecular
+ simulations of solid state, liquid, molecular and biological systems. It provides a general framework for different
+ methods such as e.g. density functional theory (DFT) using a mixed Gaussian and plane waves approach (GPW), and
+ classical pair and many-body potentials. """
+
+toolchain = {'name': 'CrayGNU', 'version': '18.08'}
+toolchainopts = { 'usempi': True, 'openmp': True }
+
+patches = [('%(name)s-%(version)s-%(toolchain_name)s-%(toolchain_version)s.psmp', '%(builddir)s/%(namelower)s-%(version)s/arch')]
+sources = [SOURCELOWER_TAR_BZ2]
+source_urls = [SOURCEFORGE_SOURCE]
+
+builddependencies = [
+    ('cray-fftw/3.3.6.5', EXTERNAL_MODULE),
+    ('cray-python/2.7.15.1', EXTERNAL_MODULE),
+    ('flex', '2.6.4'),
+    ('Bison', '3.0.5'),
+    ('perftools-lite/%s' % patversion, EXTERNAL_MODULE)
+]
+
+dependencies = [
+    ('Libint', '1.1.4'),
+    ('libxc', '4.2.3'),
+]
+
+# use the non-threaded version of BLAS provided by cray-libsci and go to folder makefiles
+prebuildopts = " export PE_LIBSCI_OMP_REQUIRES_openmp="" && pushd makefiles && "
+# build type
+buildopts = 'ARCH=%(name)s-%(version)s-%(toolchain_name)s-%(toolchain_version)s VERSION=psmp'
+ 
+files_to_copy = [(['./arch/%(name)s-%(version)s-%(toolchain_name)s-%(toolchain_version)s.psmp'],'arch'),
+                 (['./exe/%(name)s-%(version)s-%(toolchain_name)s-%(toolchain_version)s/*'],'bin'),
+                 (['./data'],'.'),
+                 (['./tests'],'.')]
+
+sanity_check_paths = {
+    'files': ['arch/%(name)s-%(version)s-%(toolchain_name)s-%(toolchain_version)s.psmp',
+              'bin/cp2k.psmp'],
+    'dirs': ['data','tests'],
+}
+
+# set custom CP2K_DATA_DIR
+modextravars = {'CP2K_DATA_DIR': '%(installdir)s/data'}
+
+moduleclass = 'chem'

--- a/easybuild/easyconfigs/c/CP2K/CP2K-6.1-CrayGNU-18.08.eb
+++ b/easybuild/easyconfigs/c/CP2K/CP2K-6.1-CrayGNU-18.08.eb
@@ -4,6 +4,12 @@ easyblock = 'MakeCp'
 name = 'CP2K'
 version = '6.1'
 
+py_maj_ver = '2'
+py_min_ver = '7'
+py_rev_ver = '15.1'
+pyshortver = "%s.%s" % (py_maj_ver, py_min_ver)
+pyver      = "%s.%s.%s" % (py_maj_ver, py_min_ver, py_rev_ver)
+
 homepage = 'http://www.cp2k.org/'
 description = """CP2K is a freely available (GPL) program, written in Fortran 95, to perform atomistic and molecular
  simulations of solid state, liquid, molecular and biological systems. It provides a general framework for different
@@ -19,7 +25,7 @@ source_urls = [SOURCEFORGE_SOURCE]
 
 builddependencies = [
     ('cray-fftw/3.3.6.5', EXTERNAL_MODULE),
-    ('cray-python/2.7.15.1', EXTERNAL_MODULE),
+    ('cray-python/%s' % pyver, EXTERNAL_MODULE),
     ('flex', '2.6.4'),
     ('Bison', '3.0.5'),
 ]


### PR DESCRIPTION
New EasyBuild recipes for `CP2K` with `perftools-lite/7.0.2` as `EXTERNAL_MODULE`.