### PR TITLE
[dom-gpu] Improve the compilation flags setup

### DIFF
--- a/easybuild/easyconfigs/g/GROMACS/GROMACS-2018.3-CrayGNU-18.08-cuda-9.1.eb
+++ b/easybuild/easyconfigs/g/GROMACS/GROMACS-2018.3-CrayGNU-18.08-cuda-9.1.eb
@@ -21,14 +21,13 @@ description = """GROMACS is a versatile package to perform molecular dynamics,
  i.e. simulate the Newtonian equations of motion for systems with hundreds to millions of particles."""
 
 toolchain = {'name': 'CrayGNU', 'version': '18.08'}
-toolchainopts = {'usempi': 'True', 'openmp': 'True', 'pic': 'True', 'verbose': 'False', 'debug': 'True'}
+toolchainopts = {'usempi': True, 'openmp': True, 'pic': True, 'verbose': False, 'opt': True}
 
 source_urls = ['ftp://ftp.gromacs.org/pub/gromacs/']
 sources = [SOURCELOWER_TAR_GZ]
 
 patches = ['gromacs-2018.2.patch']
 
-configopts = ' -DCMAKE_C_FLAGS="-g -fPIC" -DCMAKE_CXX_FLAGS="-g -fPIC" -DGMX_CUDA_TARGET_SM=60'
 
 skipsteps = ['test']
 


### PR DESCRIPTION
This PR attempts to decrease the confusion created by adding the 'cojnfigopts' in order to identify which compilation flags are used by GROMACS. Now, we let EB set the variables.

There should be a small improvement of the CPU side of the code.