### PR TITLE
[dom-gpu] scorep+python

### DIFF
--- a/easybuild/easyconfigs/s/scorep_binding_python/scorep_binding_python-b308ab7-CrayGNU-18.08-python3.eb
+++ b/easybuild/easyconfigs/s/scorep_binding_python/scorep_binding_python-b308ab7-CrayGNU-18.08-python3.eb
@@ -1,0 +1,43 @@
+# jg (cscs)
+easyblock = 'PythonPackage'
+
+name = 'scorep_binding_python'
+version = 'b308ab7'
+py_maj_ver = '3'
+py_min_ver = '6'
+py_rev_ver = '5.1'
+pyver = '%s.%s.%s' % (py_maj_ver, py_min_ver, py_rev_ver)
+pyshortver = '%s.%s' % (py_maj_ver, py_min_ver)
+versionsuffix = '-python%s' % py_maj_ver
+
+homepage = 'https://github.com/score-p/scorep_binding_python'
+description = """Allows tracing of python code using Score-P"""
+
+toolchain = {'name': 'CrayGNU', 'version': '18.08'}
+toolchainopts = {'pic': True, 'verbose': False}
+
+source_urls = ['https://github.com/score-p/%(name)s/archive']
+sources = ['master.zip']
+patches = ['%(name)s-%(version)s.patch']
+
+dependencies = [
+    ('cray-python/%s' % pyver, EXTERNAL_MODULE),
+    ('Score-P','4.0','-cuda-9.1'),
+]
+
+builddependencies = [
+    ('CMake', '3.12.0', '', True),
+    ('PyExtensions', '%s' % pyver),
+]
+
+options = {'modulename': 'scorep_bindings'}
+#skip = ['sanity']
+
+sanity_check_paths = {
+    'files': ['lib/python%(pv)s/site-packages/scorep/scorep_bindings_mpi.cpython-36m-x86_64-linux-gnu.so' % {'pv': pyshortver}],
+    'dirs': [''],
+}
+
+modextrapaths = {'PYTHONPATH': 'lib/python%s/site-packages' % pyshortver}
+
+moduleclass = 'lib'

--- a/easybuild/easyconfigs/s/scorep_binding_python/scorep_binding_python-b308ab7-CrayGNU-18.08-python3.eb
+++ b/easybuild/easyconfigs/s/scorep_binding_python/scorep_binding_python-b308ab7-CrayGNU-18.08-python3.eb
@@ -30,8 +30,7 @@ builddependencies = [
     ('PyExtensions', '%s' % pyver),
 ]
 
-options = {'modulename': 'scorep_bindings'}
-#skip = ['sanity']
+options = {'modulename': 'scorep'}
 
 sanity_check_paths = {
     'files': ['lib/python%(pv)s/site-packages/scorep/scorep_bindings_mpi.cpython-36m-x86_64-linux-gnu.so' % {'pv': pyshortver}],

--- a/easybuild/easyconfigs/s/scorep_binding_python/scorep_binding_python-b308ab7.patch
+++ b/easybuild/easyconfigs/s/scorep_binding_python/scorep_binding_python-b308ab7.patch
@@ -1,0 +1,41 @@
+diff --git a/setup.py b/setup.py
+index 74906ab..5844c55 100644
+--- a/setup.py
++++ b/setup.py
+@@ -83,7 +83,8 @@ def get_config(scorep_config):
+ 
+ def get_mpi_config():
+     (_, mpi_version, mpi_version2) = scorep.helper.call(
+-        ["mpiexec", "--version"])
++        ["srun", "--version"])
++        #["mpiexec", "--version"])
+     mpi_version = mpi_version + mpi_version2
+     if "OpenRTE" in mpi_version:
+         print("OpenMPI detected")
+@@ -96,17 +97,17 @@ def get_mpi_config():
+         (_, compile_flags, _) = scorep.helper.call(["mpicc", "-compile_info"])
+     else:
+         print("cannot determine mpi version: \"{}\"".format(mpi_version))
+-        exit(-1)
++        #exit(-1)
+ 
+-    ldflags = " " + ldflags
+-    compile_flags = " " + compile_flags
++    ldflags = " "
++    compile_flags = " "
+ 
+-    lib_dir = re.findall(" -L[/+-@.\w]*", ldflags)
+-    lib = re.findall(" -l[/+-@.\w]*", ldflags)
+-    include = re.findall(" -I[/+-@.\w]*", compile_flags)
+-    macro = re.findall(" -D[/+-@.\w]*", compile_flags)
+-    linker_flags = re.findall(" -Wl[/+-@.\w]*", ldflags)
+-    linker_flags_2 = re.findall(" -Xlinker [/+-@.\w]*", ldflags)
++    lib_dir = ""
++    lib = ""
++    include = ""
++    macro = ""
++    linker_flags = ""
++    linker_flags_2 = ""
+ 
+     def remove_flag3(x): return x[3:]
+ 


### PR DESCRIPTION
```
Sanity check failed: 
 "/opt/python/3.6.5.1/bin/python -c "import scorep_bindings"
```

lib/python3.6/site-packages/scorep/__init__.py
lib/python3.6/site-packages/scorep/__main__.py
lib/python3.6/site-packages/scorep/helper.py
lib/python3.6/site-packages/scorep/trace.py
lib/python3.6/site-packages/scorep/user.py
lib/python3.6/site-packages/scorep/scorep_bindings.cpython-36m-x86_64-linux-gnu.so
lib/python3.6/site-packages/scorep/scorep_bindings_mpi.cpython-36m-x86_64-linux-gnu.so

