### PR TITLE
[dom-gpu] Generic download link compatible with previous releases

### DIFF
--- a/easybuild/easyconfigs/q/QuantumESPRESSO/QuantumESPRESSO-6.3-CrayIntel-18.08.eb
+++ b/easybuild/easyconfigs/q/QuantumESPRESSO/QuantumESPRESSO-6.3-CrayIntel-18.08.eb
@@ -13,7 +13,7 @@ description = """Quantum ESPRESSO  is an integrated suite of computer codes
 toolchain = {'name': 'CrayIntel', 'version': '18.08'}
 toolchainopts = {'usempi': True, 'openmp': True}
 
-source_urls = ['https://github.com/QEF/q-e/releases/download/qe-6.3/']
+source_urls = ['https://github.com/QEF/q-e/archive']
 sources = ['qe-%(version)s.tar.gz']
 
 preconfigopts = ' module unload cray-libsci && module list && '


### PR DESCRIPTION
I'm setting in the EasyBuild recipe a different download link from `QuantumESPRESSO` GitHub project that is compatible with older releases: in this way, the EasyBuild flag `--try-software-version=...` would also download automatically with previous releases.