### PR TITLE
[daint-mc] Add netcdf-python in daint-mc

### DIFF
--- a/jenkins-builds/6.0.UP07-18.08-mc
+++ b/jenkins-builds/6.0.UP07-18.08-mc
@@ -30,6 +30,8 @@
  NCO-4.7.5-CrayGNU-18.08.eb                         --set-default-module
  NCL-6.4.0.eb                                       --set-default-module
  ncview-2.1.7-CrayGNU-18.08.eb                      --set-default-module
+ netcdf-python-1.4.1-CrayGNU-18.08-python2.eb
+ netcdf-python-1.4.1-CrayGNU-18.08-python3.eb       --set-default-module
  ParaView-5.5.2-OSMesa-CrayGNU-18.08.eb             --set-default-module
  Python-bare-3.6.2.eb                               --hidden
  PyExtensions-2.7.15.1-CrayGNU-18.08.eb


### PR DESCRIPTION
Adding missing recipes in `daint-mc` software stack.