### PR TITLE
[kesch] GREASY on Kesch

### DIFF
--- a/easybuild/easyconfigs/g/GREASY/GREASY-2.1-cscs-gmvolf-17.02.eb
+++ b/easybuild/easyconfigs/g/GREASY/GREASY-2.1-cscs-gmvolf-17.02.eb
@@ -1,0 +1,24 @@
+# contributed by Victor Holanda Rusu (CSCS)
+easyblock = 'ConfigureMake'
+
+name = 'GREASY'
+version = '2.1-cscs'
+
+homepage = 'https://github.com/jonarbo/GREASY'
+description = """Greasy is a tool designed to make easier the deployment of
+embarrassingly parallel simulations in any environment. It is able to run in
+parallel a list of different tasks."""
+
+toolchain = {'name': 'gmvolf', 'version': '17.02'}
+toolchainopts = {'opt': True, 'pic': True}
+
+sources = ['/apps/common/easybuild/sources/g/GREASY/greasy-2.1-kesch.tar.gz']
+
+preconfigopts = './autogen.sh && '
+
+sanity_check_paths = {
+    'files': ["bin/greasy"],
+    'dirs': [],
+}
+
+moduleclass = 'data'


### PR DESCRIPTION
I keep a different source file `greasy-2.1-kesch.tar.gz` until we clarify the differences with respect to the tarball for `Piz Daint`.