### PR TITLE
[daint-gpu dom-gpu] reverting magma and CP2K to use only cudatoolkit 

### DIFF
--- a/easybuild/easyconfigs/c/CP2K/CP2K-6.1-CrayGNU-18.08-cuda-9.1.eb
+++ b/easybuild/easyconfigs/c/CP2K/CP2K-6.1-CrayGNU-18.08-cuda-9.1.eb
@@ -26,6 +26,7 @@ sources = [SOURCELOWER_TAR_BZ2]
 source_urls = [SOURCEFORGE_SOURCE]
 
 builddependencies = [
+    ('cudatoolkit/%s.85_3.18-6.0.7.0_5.1__g2eb7c52' % cudaversion, EXTERNAL_MODULE),
     ('cray-fftw/3.3.6.5', EXTERNAL_MODULE),
     ('cray-python/%s' % pyver, EXTERNAL_MODULE),
     ('flex', '2.6.4'),
@@ -33,7 +34,6 @@ builddependencies = [
 ]
 
 dependencies = [
-    ('cudatoolkit/%s.85_3.18-6.0.7.0_5.1__g2eb7c52' % cudaversion, EXTERNAL_MODULE),
     ('Libint', '1.1.4'),
     ('libxc', '4.2.3'),
 ]

--- a/easybuild/easyconfigs/c/CP2K/CP2K-6.1-CrayGNU-18.08-cuda-9.1.eb
+++ b/easybuild/easyconfigs/c/CP2K/CP2K-6.1-CrayGNU-18.08-cuda-9.1.eb
@@ -6,6 +6,12 @@ version = '6.1'
 cudaversion = '9.1'
 versionsuffix = '-cuda-%s' % cudaversion
 
+py_maj_ver = '2'
+py_min_ver = '7'
+py_rev_ver = '15.1'
+pyshortver = "%s.%s" % (py_maj_ver, py_min_ver)
+pyver      = "%s.%s.%s" % (py_maj_ver, py_min_ver, py_rev_ver)
+
 homepage = 'http://www.cp2k.org/'
 description = """CP2K is a freely available (GPL) program, written in Fortran 95, to perform atomistic and molecular
  simulations of solid state, liquid, molecular and biological systems. It provides a general framework for different
@@ -20,14 +26,15 @@ sources = [SOURCELOWER_TAR_BZ2]
 source_urls = [SOURCEFORGE_SOURCE]
 
 builddependencies = [
-    ('cudatoolkit/%s.85_3.18-6.0.7.0_5.1__g2eb7c52' %cudaversion, EXTERNAL_MODULE),
+    ('cudatoolkit/%s.85_3.18-6.0.7.0_5.1__g2eb7c52' % cudaversion, EXTERNAL_MODULE),
     ('cray-fftw/3.3.6.5', EXTERNAL_MODULE),
-    ('cray-python/2.7.15.1', EXTERNAL_MODULE),
+    ('cray-python/%s' % pyver, EXTERNAL_MODULE),
     ('flex', '2.6.4'),
     ('Bison', '3.0.5'),
 ]
 
 dependencies = [
+    ('craype-accel-nvidia60', EXTERNAL_MODULE),
     ('Libint', '1.1.4'),
     ('libxc', '4.2.3'),
 ]

--- a/easybuild/easyconfigs/c/CP2K/CP2K-6.1-CrayGNU-18.08-cuda-9.1.eb
+++ b/easybuild/easyconfigs/c/CP2K/CP2K-6.1-CrayGNU-18.08-cuda-9.1.eb
@@ -6,12 +6,6 @@ version = '6.1'
 cudaversion = '9.1'
 versionsuffix = '-cuda-%s' % cudaversion
 
-py_maj_ver = '2'
-py_min_ver = '7'
-py_rev_ver = '15.1'
-pyshortver = "%s.%s" % (py_maj_ver, py_min_ver)
-pyver      = "%s.%s.%s" % (py_maj_ver, py_min_ver, py_rev_ver)
-
 homepage = 'http://www.cp2k.org/'
 description = """CP2K is a freely available (GPL) program, written in Fortran 95, to perform atomistic and molecular
  simulations of solid state, liquid, molecular and biological systems. It provides a general framework for different
@@ -26,15 +20,14 @@ sources = [SOURCELOWER_TAR_BZ2]
 source_urls = [SOURCEFORGE_SOURCE]
 
 builddependencies = [
-    ('cudatoolkit/%s.85_3.18-6.0.7.0_5.1__g2eb7c52' % cudaversion, EXTERNAL_MODULE),
+    ('cudatoolkit/%s.85_3.18-6.0.7.0_5.1__g2eb7c52' %cudaversion, EXTERNAL_MODULE),
     ('cray-fftw/3.3.6.5', EXTERNAL_MODULE),
-    ('cray-python/%s' % pyver, EXTERNAL_MODULE),
+    ('cray-python/2.7.15.1', EXTERNAL_MODULE),
     ('flex', '2.6.4'),
     ('Bison', '3.0.5'),
 ]
 
 dependencies = [
-    ('craype-accel-nvidia60', EXTERNAL_MODULE),
     ('Libint', '1.1.4'),
     ('libxc', '4.2.3'),
 ]

--- a/easybuild/easyconfigs/c/CP2K/CP2K-6.1-CrayGNU-18.08-cuda-9.1.eb
+++ b/easybuild/easyconfigs/c/CP2K/CP2K-6.1-CrayGNU-18.08-cuda-9.1.eb
@@ -26,7 +26,6 @@ sources = [SOURCELOWER_TAR_BZ2]
 source_urls = [SOURCEFORGE_SOURCE]
 
 builddependencies = [
-    ('cudatoolkit/%s.85_3.18-6.0.7.0_5.1__g2eb7c52' % cudaversion, EXTERNAL_MODULE),
     ('cray-fftw/3.3.6.5', EXTERNAL_MODULE),
     ('cray-python/%s' % pyver, EXTERNAL_MODULE),
     ('flex', '2.6.4'),
@@ -34,7 +33,7 @@ builddependencies = [
 ]
 
 dependencies = [
-    ('craype-accel-nvidia60', EXTERNAL_MODULE),
+    ('cudatoolkit/%s.85_3.18-6.0.7.0_5.1__g2eb7c52' % cudaversion, EXTERNAL_MODULE),
     ('Libint', '1.1.4'),
     ('libxc', '4.2.3'),
 ]

--- a/easybuild/easyconfigs/m/magma/magma-2.2.0-CrayGNU-18.08-cuda-9.1.eb
+++ b/easybuild/easyconfigs/m/magma/magma-2.2.0-CrayGNU-18.08-cuda-9.1.eb
@@ -19,7 +19,7 @@ sources = [SOURCE_TAR_GZ]
 source_urls = ['http://icl.cs.utk.edu/projectsfiles/magma/downloads/']
 patches = [('magma-2.2.0-Cray-Pascal.patch')]
 
-dependencies = [
+builddependencies = [
   ('cudatoolkit/%s.85_3.18-6.0.7.0_5.1__g2eb7c52' % cudaversion, EXTERNAL_MODULE)
 ]
 

--- a/easybuild/easyconfigs/m/magma/magma-2.2.0-CrayGNU-18.08-cuda-9.1.eb
+++ b/easybuild/easyconfigs/m/magma/magma-2.2.0-CrayGNU-18.08-cuda-9.1.eb
@@ -4,6 +4,7 @@ easyblock = 'MakeCp'
 
 name = 'magma'
 version = '2.2.0'
+cudaversion = 9.1
 versionsuffix = '-cuda-9.1'
 
 homepage = 'http://icl.cs.utk.edu/magma/'
@@ -17,7 +18,10 @@ toolchainopts = {'pic': True}
 sources = [SOURCE_TAR_GZ]
 source_urls = ['http://icl.cs.utk.edu/projectsfiles/magma/downloads/']
 patches = [('magma-2.2.0-Cray-Pascal.patch')]
-dependencies = [ ('cudatoolkit/9.1.85_3.18-6.0.7.0_5.1__g2eb7c52', EXTERNAL_MODULE), ]
+
+dependencies = [
+  ('cudatoolkit/%s.85_3.18-6.0.7.0_5.1__g2eb7c52' % cudaversion, EXTERNAL_MODULE)
+]
 
 files_to_copy = ["lib", "include", "testing", "docs", "README"]
 

--- a/easybuild/easyconfigs/m/magma/magma-2.2.0-CrayGNU-18.08-cuda-9.1.eb
+++ b/easybuild/easyconfigs/m/magma/magma-2.2.0-CrayGNU-18.08-cuda-9.1.eb
@@ -4,7 +4,6 @@ easyblock = 'MakeCp'
 
 name = 'magma'
 version = '2.2.0'
-cudaversion = 9.1
 versionsuffix = '-cuda-9.1'
 
 homepage = 'http://icl.cs.utk.edu/magma/'
@@ -18,11 +17,7 @@ toolchainopts = {'pic': True}
 sources = [SOURCE_TAR_GZ]
 source_urls = ['http://icl.cs.utk.edu/projectsfiles/magma/downloads/']
 patches = [('magma-2.2.0-Cray-Pascal.patch')]
-dependencies = [('craype-accel-nvidia60', EXTERNAL_MODULE)]
-
-builddependencies = [
-  ('cudatoolkit/%s.85_3.18-6.0.7.0_5.1__g2eb7c52' % cudaversion, EXTERNAL_MODULE)
-]
+dependencies = [ ('cudatoolkit/9.1.85_3.18-6.0.7.0_5.1__g2eb7c52', EXTERNAL_MODULE), ]
 
 files_to_copy = ["lib", "include", "testing", "docs", "README"]
 


### PR DESCRIPTION
(instead of craype-acel-nvidia60)

Builds were failing (most probably because of the variable `CRAY_TCMALLOC_MEMFS_FORCE=1`, but the issue needs to be confirmed)
