### PR TITLE
[daint-gpu] CP2K with perftools and without craype-accel-nvidia60

### DIFF
--- a/easybuild/easyconfigs/c/CP2K/CP2K-6.1-CrayGNU-18.08-cuda-9.1-pat-7.0.2.eb
+++ b/easybuild/easyconfigs/c/CP2K/CP2K-6.1-CrayGNU-18.08-cuda-9.1-pat-7.0.2.eb
@@ -36,7 +36,6 @@ builddependencies = [
 ]
 
 dependencies = [
-    ('craype-accel-nvidia60', EXTERNAL_MODULE),
     ('Libint', '1.1.4'),
     ('libxc', '4.2.3'),
 ]


### PR DESCRIPTION
According to #893 , I'm adapting the recipe that builds the instrumented executable of `CP2K`.