### PR TITLE
[daint-gpu] VASP without craype-accel-nvidia60

### DIFF
--- a/easybuild/easyconfigs/v/VASP/VASP-5.4.4-CrayIntel-18.08-cuda-9.1-pat-7.0.2.eb
+++ b/easybuild/easyconfigs/v/VASP/VASP-5.4.4-CrayIntel-18.08-cuda-9.1-pat-7.0.2.eb
@@ -23,10 +23,6 @@ builddependencies = [
     ('perftools-lite/%s' % patversion, EXTERNAL_MODULE)
 ]
 
-dependencies = [
-    ('craype-accel-nvidia60', EXTERNAL_MODULE)
-]
-
 prebuildopts = ' mv %(name)s-%(version)s-%(toolchain_name)s-%(toolchain_version)s-cuda-{0}.makefile.include makefile.include && '.format(cudaversion) 
 
 # don't use parallel make, results in compilation failure

--- a/easybuild/easyconfigs/v/VASP/VASP-5.4.4-CrayIntel-18.08-cuda-9.1.eb
+++ b/easybuild/easyconfigs/v/VASP/VASP-5.4.4-CrayIntel-18.08-cuda-9.1.eb
@@ -21,10 +21,6 @@ builddependencies = [
     ('cray-fftw/3.3.6.5', EXTERNAL_MODULE),
 ]
 
-dependencies = [
-    ('craype-accel-nvidia60', EXTERNAL_MODULE)
-]
-
 prebuildopts = ' mv %(name)s-%(version)s-%(toolchain_name)s-%(toolchain_version)s%(versionsuffix)s.makefile.include makefile.include && ' 
 
 # don't use parallel make, results in compilation failure


### PR DESCRIPTION
According to #893 , I'm adapting the recipe that builds the instrumented executable of `VASP` too.