### PR TITLE
[daint] Update cftime dependency on netcdf-python-1.4.1

### DIFF
--- a/easybuild/easyconfigs/c/cftime/cftime-1.0.2.1-CrayGNU-18.08-python3.eb
+++ b/easybuild/easyconfigs/c/cftime/cftime-1.0.2.1-CrayGNU-18.08-python3.eb
@@ -1,0 +1,34 @@
+easyblock = 'PythonPackage'
+
+name = 'cftime'
+version = '1.0.2.1'
+
+homepage = 'https://github.com/Unidata/cftime'
+description = """Time-handling functionality from netcdf4-python"""
+
+toolchain = {'name': 'CrayGNU', 'version': '18.08'}
+toolchainopts = {'verbose': False}
+
+source_urls = [PYPI_SOURCE]
+sources = [SOURCE_TAR_GZ]
+checksums = ['2c81d4879a2c1753961d647e55e0125039ddeda195944c3d526f2cf087dfb7bb']
+
+py_maj_ver = '3'
+py_min_ver = '6'
+py_rev_ver = '5.1'
+pyver = '%s.%s.%s' % (py_maj_ver, py_min_ver, py_rev_ver)
+pyshortver = '%s.%s' % (py_maj_ver, py_min_ver)
+pysuff = '-python%s' % py_maj_ver
+
+versionsuffix = pysuff
+dependencies = [
+    ('cray-python/%s' % pyver, EXTERNAL_MODULE),
+    ('cURL', '7.61.1'),
+]
+
+sanity_check_paths = {
+    'files':  [],
+    'dirs': ['lib/python%s/site-packages' % pyshortver],
+}
+
+moduleclass = 'data'

--- a/easybuild/easyconfigs/n/netcdf4-python/netcdf-python-1.4.1-CrayGNU-18.08-python3.eb
+++ b/easybuild/easyconfigs/n/netcdf4-python/netcdf-python-1.4.1-CrayGNU-18.08-python3.eb
@@ -21,9 +21,10 @@ pysuff = '-python%s' % py_maj_ver
 versionsuffix = pysuff
 dependencies = [
     ('cray-python/%s' % pyver, EXTERNAL_MODULE),
+    ('PyExtensions', '%s' % pyver),
     ('cray-netcdf/4.6.1.2', EXTERNAL_MODULE),
     ('cray-hdf5/1.10.2.0', EXTERNAL_MODULE),
-    ('cftime', '1.0.0', pysuff),
+    ('cftime', '1.0.2.1', pysuff),
 ]
 
 sanity_check_paths = {


### PR DESCRIPTION
`netcdf-python-1.4.1` needs a more recent version of `cftime`. Please, see [here](https://github.com/conda-forge/netcdf4-feedstock/issues/58).
This seems to solve [33413](https://webrt.cscs.ch/Ticket/Display.html?id=33413).