### PR TITLE
[daint] Adding Dycore and STELLA to production list

### DIFF
--- a/jenkins-builds/6.0.UP07-18.08-gpu
+++ b/jenkins-builds/6.0.UP07-18.08-gpu
@@ -50,12 +50,12 @@
  VMD-1.9.3-egl.eb
  VMD-1.9.3-ogl.eb
  VTK-8.1.1-EGL-CrayGNU-18.08-python3.eb                      --set-default-module
- Dycore/551f6b4-CrayGNU-18.08-crclim-double.eb               --hidden --installpath=${EASYBUILD_PREFIX}/MCH
- Dycore/551f6b4-CrayGNU-18.08-cordex-double.eb               --hidden --installpath=${EASYBUILD_PREFIX}/MCH
- Dycore/551f6b4-CrayGNU-18.08-cuda-9.1-crclim-double.eb      --hidden --installpath=${EASYBUILD_PREFIX}/MCH
- Dycore/551f6b4-CrayGNU-18.08-cuda-9.1-cordex-double.eb      --hidden --installpath=${EASYBUILD_PREFIX}/MCH
- STELLA-4a5f9c5-CrayGNU-18.08-crclim-double.eb               --hidden --installpath=${EASYBUILD_PREFIX}/MCH
- STELLA-4a5f9c5-CrayGNU-18.08-cordex-double.eb               --hidden --installpath=${EASYBUILD_PREFIX}/MCH
+ Dycore/551f6b4-CrayGNU-18.08-crclim-double.eb               --hidden --installpath=/apps/dom/UES/jenscscs/6.0.UP07/gpu/easybuild/MCH
+ Dycore/551f6b4-CrayGNU-18.08-cordex-double.eb               --hidden --installpath=/apps/dom/UES/jenscscs/6.0.UP07/gpu/easybuild/MCH
+ Dycore/551f6b4-CrayGNU-18.08-cuda-9.1-crclim-double.eb      --hidden --installpath=/apps/dom/UES/jenscscs/6.0.UP07/gpu/easybuild/MCH
+ Dycore/551f6b4-CrayGNU-18.08-cuda-9.1-cordex-double.eb      --hidden --installpath=/apps/dom/UES/jenscscs/6.0.UP07/gpu/easybuild/MCH
+ STELLA-4a5f9c5-CrayGNU-18.08-crclim-double.eb               --hidden --installpath=/apps/dom/UES/jenscscs/6.0.UP07/gpu/easybuild/MCH
+ STELLA-4a5f9c5-CrayGNU-18.08-cordex-double.eb               --hidden --installpath=/apps/dom/UES/jenscscs/6.0.UP07/gpu/easybuild/MCH
  advisor_2018.eb                                             --set-default-module --installpath=/apps/dom/UES/jenscscs/6.0.UP07/gpu/easybuild/tools
  advisor_2019.eb                                                                  --installpath=/apps/dom/UES/jenscscs/6.0.UP07/gpu/easybuild/tools
  bladeplugin-0.1.eb                                          --set-default-module --installpath=/apps/dom/UES/jenscscs/6.0.UP07/gpu/easybuild/tools

--- a/jenkins-builds/6.0.UP07-18.08-gpu
+++ b/jenkins-builds/6.0.UP07-18.08-gpu
@@ -1,86 +1,92 @@
- abcpy-0.5.1-CrayGNU-18.08-python3.eb               --set-default-module
- Amber-18-9-4-CrayGNU-18.08-cuda-9.1.eb             --set-default-module
+ abcpy-0.5.1-CrayGNU-18.08-python3.eb                        --set-default-module
+ Amber-18-9-4-CrayGNU-18.08-cuda-9.1.eb                      --set-default-module
  Boost-1.67.0-CrayGNU-18.08-python2.eb
- Boost-1.67.0-CrayGNU-18.08-python3.eb              --set-default-module
+ Boost-1.67.0-CrayGNU-18.08-python3.eb                       --set-default-module
  Boost-1.67.0-CrayGNU-18.08.eb
- CDO-1.9.5-CrayGNU-18.08.eb                         --set-default-module
+ CDO-1.9.5-CrayGNU-18.08.eb                                  --set-default-module
  CDO-1.9.5-CrayIntel-18.08.eb
  CMake-3.12.0.eb
- CP2K-6.1-CrayGNU-18.08-cuda-9.1.eb                 --set-default-module
- CPMD-4.1-CrayIntel-18.08.eb                        --set-default-module
- GREASY-2.1-cscs-CrayGNU-18.08-gpu.eb               --set-default-module
- GROMACS-2018.3-CrayGNU-18.08-cuda-9.1.eb           --set-default-module
- GSL-2.5-CrayGNU-18.08.eb                           --set-default-module
+ CP2K-6.1-CrayGNU-18.08-cuda-9.1.eb                          --set-default-module
+ CPMD-4.1-CrayIntel-18.08.eb                                 --set-default-module
+ GREASY-2.1-cscs-CrayGNU-18.08-gpu.eb                        --set-default-module
+ GROMACS-2018.3-CrayGNU-18.08-cuda-9.1.eb                    --set-default-module
+ GSL-2.5-CrayGNU-18.08.eb                                    --set-default-module
  GSL-2.5-CrayCCE-18.08.eb
  GSL-2.5-CrayIntel-18.08.eb
- HDFView-2.14.eb                                    --set-default-module
+ HDFView-2.14.eb                                             --set-default-module
  h5py-2.8.0-CrayGNU-18.08-python2-parallel.eb
  h5py-2.8.0-CrayGNU-18.08-python2-serial.eb
- h5py-2.8.0-CrayGNU-18.08-python3-parallel.eb       --set-default-module
+ h5py-2.8.0-CrayGNU-18.08-python3-parallel.eb                --set-default-module
  h5py-2.8.0-CrayGNU-18.08-python3-serial.eb
- HPX-1.1.0-CrayGNU-18.08.eb                         --set-default-module
- IDL-8.5.1.eb                                       --set-default-module
+ HPX-1.1.0-CrayGNU-18.08.eb                                  --set-default-module
+ IDL-8.5.1.eb                                                --set-default-module
  ipykernel-4.8.2-CrayGNU-18.08-python2.eb
  jupyter-1.0.0-CrayGNU-18.08.eb
  jupyterhub-0.9.4-CrayGNU-18.08.eb
- LAMMPS-22Aug2018-CrayGNU-18.08-cuda-9.1.eb         --set-default-module
- Lmod-7.8.2.eb                                      --set-default-module --hidden
- magma-2.2.0-CrayGNU-18.08-cuda-9.1.eb              --set-default-module
+ LAMMPS-22Aug2018-CrayGNU-18.08-cuda-9.1.eb                  --set-default-module
+ Lmod-7.8.2.eb                                               --set-default-module --hidden
+ magma-2.2.0-CrayGNU-18.08-cuda-9.1.eb                       --set-default-module
  magma-2.3.0-CrayIntel-18.08-cuda-9.1.eb
  magma-2.4.0-CrayIntel-18.08-cuda-9.1.eb
- NAMD-2.12-CrayIntel-18.08-cuda-9.1.eb              --set-default-module
- NCO-4.7.5-CrayGNU-18.08.eb                         --set-default-module
- NCL-6.4.0.eb                                       --set-default-module
- ncview-2.1.7-CrayGNU-18.08.eb                      --set-default-module
+ NAMD-2.12-CrayIntel-18.08-cuda-9.1.eb                       --set-default-module
+ NCO-4.7.5-CrayGNU-18.08.eb                                  --set-default-module
+ NCL-6.4.0.eb                                                --set-default-module
+ ncview-2.1.7-CrayGNU-18.08.eb                               --set-default-module
  netcdf-python-1.4.1-CrayGNU-18.08-python2.eb
- netcdf-python-1.4.1-CrayGNU-18.08-python3.eb       --set-default-module
- ParaView-5.5.2-EGL-CrayGNU-18.08.eb                --set-default-module
- PLUMED-2.4.3-CrayGNU-18.08.eb                      --set-default-module
- Python-bare-3.6.2.eb                               --hidden
+ netcdf-python-1.4.1-CrayGNU-18.08-python3.eb                --set-default-module
+ ParaView-5.5.2-EGL-CrayGNU-18.08.eb                         --set-default-module
+ PLUMED-2.4.3-CrayGNU-18.08.eb                               --set-default-module
+ Python-bare-3.6.2.eb                                        --hidden
  pycuda-2017.1.1-CrayGNU-18.08-python2-cuda-9.1.eb
- pycuda-2017.1.1-CrayGNU-18.08-python3-cuda-9.1.eb  --set-default-module
+ pycuda-2017.1.1-CrayGNU-18.08-python3-cuda-9.1.eb           --set-default-module
  PyExtensions-2.7.15.1-CrayGNU-18.08.eb
  PyExtensions-3.6.5.1-CrayGNU-18.08.eb
- QuantumESPRESSO-6.3-CrayIntel-18.08.eb             --set-default-module
+ QuantumESPRESSO-6.3-CrayIntel-18.08.eb                      --set-default-module
  Spark-2.3.1-CrayGNU-18.08-Hadoop-2.7.eb
- TensorFlow-1.7.0-CrayGNU-18.08-cuda-9.1-python3.eb --set-default-module
+ TensorFlow-1.7.0-CrayGNU-18.08-cuda-9.1-python3.eb          --set-default-module
  Theano-1.0.2-CrayGNU-18.08-cuda-9.1-python2.eb
- Theano-1.0.2-CrayGNU-18.08-cuda-9.1-python3.eb     --set-default-module
- VASP-5.4.4-CrayIntel-18.08-cuda-9.1.eb             --set-default-module
+ Theano-1.0.2-CrayGNU-18.08-cuda-9.1-python3.eb              --set-default-module
+ VASP-5.4.4-CrayIntel-18.08-cuda-9.1.eb                      --set-default-module
  VMD-1.9.3-egl.eb
  VMD-1.9.3-ogl.eb
- VTK-8.1.1-EGL-CrayGNU-18.08-python3.eb             --set-default-module
- advisor_2018.eb                                    --set-default-module --installpath=/apps/dom/UES/jenscscs/6.0.UP07/gpu/easybuild/tools
- advisor_2019.eb                                                         --installpath=/apps/dom/UES/jenscscs/6.0.UP07/gpu/easybuild/tools
- bladeplugin-0.1.eb                                 --set-default-module --installpath=/apps/dom/UES/jenscscs/6.0.UP07/gpu/easybuild/tools
- callgraphplugin-0.1.eb                             --set-default-module --installpath=/apps/dom/UES/jenscscs/6.0.UP07/gpu/easybuild/tools
- CubeGUI-4.4.eb                                     --set-default-module --installpath=/apps/dom/UES/jenscscs/6.0.UP07/gpu/easybuild/tools
- ddt-18.2.1-Suse-12.eb                              --set-default-module --installpath=/apps/dom/UES/jenscscs/6.0.UP07/gpu/easybuild/tools
- Extrae-3.5.4-CrayGNU-18.08.eb                      --set-default-module --installpath=/apps/dom/UES/jenscscs/6.0.UP07/gpu/easybuild/tools
- inspector_2018.eb                                  --set-default-module --installpath=/apps/dom/UES/jenscscs/6.0.UP07/gpu/easybuild/tools
- inspector_2019.eb                                                       --installpath=/apps/dom/UES/jenscscs/6.0.UP07/gpu/easybuild/tools
- IPM-2.0.6-CrayCCE-18.08.eb                                              --installpath=/apps/dom/UES/jenscscs/6.0.UP07/gpu/easybuild/tools
- IPM-2.0.6-CrayGNU-18.08.eb                         --set-default-module --installpath=/apps/dom/UES/jenscscs/6.0.UP07/gpu/easybuild/tools
- IPM-2.0.6-CrayIntel-18.08.eb                                            --installpath=/apps/dom/UES/jenscscs/6.0.UP07/gpu/easybuild/tools
- IPM-2.0.6-CrayPGI-18.08.eb                                              --installpath=/apps/dom/UES/jenscscs/6.0.UP07/gpu/easybuild/tools
- jengafettplugin-0.1.eb                             --set-default-module --installpath=/apps/dom/UES/jenscscs/6.0.UP07/gpu/easybuild/tools
- line_profiler-2.1-CrayGNU-18.08-python3.eb         --set-default-module --installpath=/apps/dom/UES/jenscscs/6.0.UP07/gpu/easybuild/tools
- MUST-v1.6-rc1-CrayGNU-18.08.eb                     --set-default-module --installpath=/apps/dom/UES/jenscscs/6.0.UP07/gpu/easybuild/tools
- oq-engine-3.2.0-CrayGNU-18.08.eb                   --hidden
- otfprofile-6e2022d-CrayGNU-18.08.eb                --set-default-module --installpath=/apps/dom/UES/jenscscs/6.0.UP07/gpu/easybuild/tools
- papi-wrap-1.0-CrayGNU-18.08.eb                     --set-default-module --installpath=/apps/dom/UES/jenscscs/6.0.UP07/gpu/easybuild/tools
- papi-wrap-1.0-CrayCCE-18.08.eb                                          --installpath=/apps/dom/UES/jenscscs/6.0.UP07/gpu/easybuild/tools
- papi-wrap-1.0-CrayIntel-18.08.eb                                        --installpath=/apps/dom/UES/jenscscs/6.0.UP07/gpu/easybuild/tools
- pudb-2018.1-CrayGNU-18.08-python3.eb               --set-default-module --installpath=/apps/dom/UES/jenscscs/6.0.UP07/gpu/easybuild/tools
- Scalasca-2.4-CrayGNU-18.08.eb                      --set-default-module --installpath=/apps/dom/UES/jenscscs/6.0.UP07/gpu/easybuild/tools
- Scalasca-2.4-CrayIntel-18.08.eb                                         --installpath=/apps/dom/UES/jenscscs/6.0.UP07/gpu/easybuild/tools
- Scalasca-2.4-CrayPGI-18.08.eb                                           --installpath=/apps/dom/UES/jenscscs/6.0.UP07/gpu/easybuild/tools
- Scalasca-2.4-CrayCCE-18.08.eb                                           --installpath=/apps/dom/UES/jenscscs/6.0.UP07/gpu/easybuild/tools
- Score-P-4.0-CrayGNU-18.08-cuda-9.1.eb              --set-default-module --installpath=/apps/dom/UES/jenscscs/6.0.UP07/gpu/easybuild/tools
- Score-P-4.0-CrayIntel-18.08.eb                                          --installpath=/apps/dom/UES/jenscscs/6.0.UP07/gpu/easybuild/tools
- Score-P-4.0-CrayPGI-18.08.eb                                            --installpath=/apps/dom/UES/jenscscs/6.0.UP07/gpu/easybuild/tools
- Score-P-4.0-CrayCCE-18.08.eb                                            --installpath=/apps/dom/UES/jenscscs/6.0.UP07/gpu/easybuild/tools
- Understand-4.0.926.eb                              --set-default-module --installpath=/apps/dom/UES/jenscscs/6.0.UP07/gpu/easybuild/tools
- vampir-9.5.0.eb                                    --set-default-module --installpath=/apps/dom/UES/jenscscs/6.0.UP07/gpu/easybuild/tools
- vtune_amplifier_2018.eb                            --set-default-module --installpath=/apps/dom/UES/jenscscs/6.0.UP07/gpu/easybuild/tools
- vtune_amplifier_2019.eb                                                 --installpath=/apps/dom/UES/jenscscs/6.0.UP07/gpu/easybuild/tools
+ VTK-8.1.1-EGL-CrayGNU-18.08-python3.eb                      --set-default-module
+ Dycore/551f6b4-CrayGNU-18.08-crclim-double.eb               --hidden --installpath=${EASYBUILD_PREFIX}/MCH
+ Dycore/551f6b4-CrayGNU-18.08-cordex-double.eb               --hidden --installpath=${EASYBUILD_PREFIX}/MCH
+ Dycore/551f6b4-CrayGNU-18.08-cuda-9.1-crclim-double.eb      --hidden --installpath=${EASYBUILD_PREFIX}/MCH
+ Dycore/551f6b4-CrayGNU-18.08-cuda-9.1-cordex-double.eb      --hidden --installpath=${EASYBUILD_PREFIX}/MCH
+ STELLA-4a5f9c5-CrayGNU-18.08-crclim-double.eb               --hidden --installpath=${EASYBUILD_PREFIX}/MCH
+ STELLA-4a5f9c5-CrayGNU-18.08-cordex-double.eb               --hidden --installpath=${EASYBUILD_PREFIX}/MCH
+ advisor_2018.eb                                             --set-default-module --installpath=/apps/dom/UES/jenscscs/6.0.UP07/gpu/easybuild/tools
+ advisor_2019.eb                                                                  --installpath=/apps/dom/UES/jenscscs/6.0.UP07/gpu/easybuild/tools
+ bladeplugin-0.1.eb                                          --set-default-module --installpath=/apps/dom/UES/jenscscs/6.0.UP07/gpu/easybuild/tools
+ callgraphplugin-0.1.eb                                      --set-default-module --installpath=/apps/dom/UES/jenscscs/6.0.UP07/gpu/easybuild/tools
+ CubeGUI-4.4.eb                                              --set-default-module --installpath=/apps/dom/UES/jenscscs/6.0.UP07/gpu/easybuild/tools
+ ddt-18.2.1-Suse-12.eb                                       --set-default-module --installpath=/apps/dom/UES/jenscscs/6.0.UP07/gpu/easybuild/tools
+ Extrae-3.5.4-CrayGNU-18.08.eb                               --set-default-module --installpath=/apps/dom/UES/jenscscs/6.0.UP07/gpu/easybuild/tools
+ inspector_2018.eb                                           --set-default-module --installpath=/apps/dom/UES/jenscscs/6.0.UP07/gpu/easybuild/tools
+ inspector_2019.eb                                                                --installpath=/apps/dom/UES/jenscscs/6.0.UP07/gpu/easybuild/tools
+ IPM-2.0.6-CrayCCE-18.08.eb                                                       --installpath=/apps/dom/UES/jenscscs/6.0.UP07/gpu/easybuild/tools
+ IPM-2.0.6-CrayGNU-18.08.eb                                  --set-default-module --installpath=/apps/dom/UES/jenscscs/6.0.UP07/gpu/easybuild/tools
+ IPM-2.0.6-CrayIntel-18.08.eb                                                     --installpath=/apps/dom/UES/jenscscs/6.0.UP07/gpu/easybuild/tools
+ IPM-2.0.6-CrayPGI-18.08.eb                                                       --installpath=/apps/dom/UES/jenscscs/6.0.UP07/gpu/easybuild/tools
+ jengafettplugin-0.1.eb                                      --set-default-module --installpath=/apps/dom/UES/jenscscs/6.0.UP07/gpu/easybuild/tools
+ line_profiler-2.1-CrayGNU-18.08-python3.eb                  --set-default-module --installpath=/apps/dom/UES/jenscscs/6.0.UP07/gpu/easybuild/tools
+ MUST-v1.6-rc1-CrayGNU-18.08.eb                              --set-default-module --installpath=/apps/dom/UES/jenscscs/6.0.UP07/gpu/easybuild/tools
+ oq-engine-3.2.0-CrayGNU-18.08.eb                            --hidden
+ otfprofile-6e2022d-CrayGNU-18.08.eb                         --set-default-module --installpath=/apps/dom/UES/jenscscs/6.0.UP07/gpu/easybuild/tools
+ papi-wrap-1.0-CrayGNU-18.08.eb                              --set-default-module --installpath=/apps/dom/UES/jenscscs/6.0.UP07/gpu/easybuild/tools
+ papi-wrap-1.0-CrayCCE-18.08.eb                                                   --installpath=/apps/dom/UES/jenscscs/6.0.UP07/gpu/easybuild/tools
+ papi-wrap-1.0-CrayIntel-18.08.eb                                                 --installpath=/apps/dom/UES/jenscscs/6.0.UP07/gpu/easybuild/tools
+ pudb-2018.1-CrayGNU-18.08-python3.eb                        --set-default-module --installpath=/apps/dom/UES/jenscscs/6.0.UP07/gpu/easybuild/tools
+ Scalasca-2.4-CrayGNU-18.08.eb                               --set-default-module --installpath=/apps/dom/UES/jenscscs/6.0.UP07/gpu/easybuild/tools
+ Scalasca-2.4-CrayIntel-18.08.eb                                                  --installpath=/apps/dom/UES/jenscscs/6.0.UP07/gpu/easybuild/tools
+ Scalasca-2.4-CrayPGI-18.08.eb                                                    --installpath=/apps/dom/UES/jenscscs/6.0.UP07/gpu/easybuild/tools
+ Scalasca-2.4-CrayCCE-18.08.eb                                                    --installpath=/apps/dom/UES/jenscscs/6.0.UP07/gpu/easybuild/tools
+ Score-P-4.0-CrayGNU-18.08-cuda-9.1.eb                       --set-default-module --installpath=/apps/dom/UES/jenscscs/6.0.UP07/gpu/easybuild/tools
+ Score-P-4.0-CrayIntel-18.08.eb                                                   --installpath=/apps/dom/UES/jenscscs/6.0.UP07/gpu/easybuild/tools
+ Score-P-4.0-CrayPGI-18.08.eb                                                     --installpath=/apps/dom/UES/jenscscs/6.0.UP07/gpu/easybuild/tools
+ Score-P-4.0-CrayCCE-18.08.eb                                                     --installpath=/apps/dom/UES/jenscscs/6.0.UP07/gpu/easybuild/tools
+ Understand-4.0.926.eb                                       --set-default-module --installpath=/apps/dom/UES/jenscscs/6.0.UP07/gpu/easybuild/tools
+ vampir-9.5.0.eb                                             --set-default-module --installpath=/apps/dom/UES/jenscscs/6.0.UP07/gpu/easybuild/tools
+ vtune_amplifier_2018.eb                                     --set-default-module --installpath=/apps/dom/UES/jenscscs/6.0.UP07/gpu/easybuild/tools
+ vtune_amplifier_2019.eb                                                          --installpath=/apps/dom/UES/jenscscs/6.0.UP07/gpu/easybuild/tools


### PR DESCRIPTION
COSMO recipes include Dycore and STELLA as EXTERNAL_MODULE, since
(based on the recommendation by MCH) both dependencies are built
for the CrayGNU toolchain, whereas COSMO is built for CrayCCE.