### PR TITLE
[dom-gpu daint-gpu] added module cudatoolkit to magma recipe

### DIFF
--- a/easybuild/easyconfigs/m/magma/magma-2.2.0-CrayGNU-18.08-cuda-9.1.eb
+++ b/easybuild/easyconfigs/m/magma/magma-2.2.0-CrayGNU-18.08-cuda-9.1.eb
@@ -19,7 +19,7 @@ sources = [SOURCE_TAR_GZ]
 source_urls = ['http://icl.cs.utk.edu/projectsfiles/magma/downloads/']
 patches = [('magma-2.2.0-Cray-Pascal.patch')]
 
-builddependencies = [
+dependencies = [
   ('cudatoolkit/%s.85_3.18-6.0.7.0_5.1__g2eb7c52' % cudaversion, EXTERNAL_MODULE)
 ]
 

--- a/easybuild/easyconfigs/m/magma/magma-2.4.0-CrayIntel-18.08-cuda-9.1.eb
+++ b/easybuild/easyconfigs/m/magma/magma-2.4.0-CrayIntel-18.08-cuda-9.1.eb
@@ -18,9 +18,8 @@ toolchainopts = {'pic': True}
 sources = [SOURCE_TAR_GZ]
 source_urls = ['http://icl.cs.utk.edu/projectsfiles/magma/downloads/']
 patches = [('make.inc-2.4.0', './')]
-dependencies = [('craype-accel-nvidia60', EXTERNAL_MODULE)]
 
-builddependencies = [
+dependencies = [
   ('cudatoolkit/%s.85_3.18-6.0.7.0_5.1__g2eb7c52' % cudaversion, EXTERNAL_MODULE)
 ]
 


### PR DESCRIPTION
@toxa81 why do we use magma 2.2 with GNU and magma 2.4 with Intel ? Is this inconsistency wanted?

The pull request will avoid a separate loading of cudatoolkit.