### PR TITLE
[leone] zero length field name in format

### DIFF
--- a/jenkins-builds/leone-RHEL6.7EUS-17.06
+++ b/jenkins-builds/leone-RHEL6.7EUS-17.06
@@ -1,7 +1,6 @@
  Boost-1.61.0-foss-2016b-Python-2.7.12.eb
  ddt-18.0.1.eb
  ddt-18.1.1.eb                              --set-default-module
- ddt-18.3-Redhat-6.0.eb
  h-yade-2017.01a-foss-2016b-Python-2.7.12.eb
  LIGGGHTS-4.0.eb                            --set-default-module
  OpenFOAM-4.1-foss-2016b.eb                 --set-default-module 


### PR DESCRIPTION
On leone, python default/system version is 2.6.6, which will give:
`ValueError: zero length field name in format`
Using python>=2.7 fixes the issue.
