### PR TITLE
[fulen] Add extra dependencies to the list of extensions

### DIFF
--- a/easybuild/easyconfigs/p/Python/Python-2.7.15-gmvolf-18.05.eb
+++ b/easybuild/easyconfigs/p/Python/Python-2.7.15-gmvolf-18.05.eb
@@ -61,6 +61,28 @@ exts_list = [
     ('virtualenv', '15.2.0', {
         'source_urls': ['https://pypi.python.org/packages/source/v/virtualenv'],
     }),
+    ('pyparsing', '2.3.0', {
+        'source_urls': ['https://pypi.python.org/packages/source/p/pyparsing/'],
+    }),
+    ('backports.functools_lru_cache', '1.5', {
+        'source_urls': ['https://pypi.python.org/packages/source/b/backports.functools_lru_cache/'],
+    }),
+    ('subprocess32', '3.5.3', {
+        'source_urls': ['https://pypi.python.org/packages/source/s/subprocess32/'],
+    }),
+    ('python-dateutil', '2.7.5', {
+        'source_urls': ['https://pypi.python.org/packages/source/p/python-dateutil/'],
+        'modulename': 'dateutil',
+    }),
+    ('pytz', '2018.7', {
+        'source_urls': ['https://pypi.python.org/packages/source/p/pytz/'],
+    }),
+    ('kiwisolver', '1.0.1', {
+        'source_urls': ['https://pypi.python.org/packages/source/k/kiwisolver/'],
+    }),
+    ('cycler', '0.10.0', {
+        'source_urls': ['https://pypi.python.org/packages/source/c/cycler/'],
+    }),
     ('matplotlib', '2.2.2', {
         'source_urls': ['https://pypi.python.org/packages/source/m/matplotlib/'],
     }),


### PR DESCRIPTION
Following a discussion with @victorusu regarding #707 : we have seen that while building [Python-2.7.15-gmvolf-18.05.eb](https://github.com/eth-cscs/production/blob/master/easybuild/easyconfigs/p/Python/Python-2.7.15-gmvolf-18.05.eb), python still needs to download some requirements that are not listed on the easyconfig:
```bash
Downloading https://files.pythonhosted.org/packages/be/2b/beeba583e9877e64db10b52a96915afc0feabf7144dcbf2a0d0ea68bf73d/subprocess32-3.5.3.tar.gz#sha256=6bc82992316eef3ccff319b5033809801c0c3372709c5f6985299c88ac7225c3
Downloading https://files.pythonhosted.org/packages/03/8e/2424c0e65c4a066e28f539364deee49b6451f8fcd4f718fefa50cc3dcf48/backports.functools_lru_cache-1.5-py2.py3-none-any.whl#sha256=f0b0e4eba956de51238e17573b7087e852dfe9854afd2e9c873f73fc0ca0a6dd
Downloading https://files.pythonhosted.org/packages/3a/62/a8c9bef3059d55ab38e41fe9cba4fad773bfc04e47290bab84db1c18262e/kiwisolver-1.0.1-cp27-cp27mu-manylinux1_x86_64.whl#sha256=f923406e6b32c86309261b8195e24e18b6a8801df0cfc7814ac44017bfcb3939
Downloading https://files.pythonhosted.org/packages/f8/0e/2365ddc010afb3d79147f1dd544e5ee24bf4ece58ab99b16fbb465ce6dc0/pytz-2018.7-py2.py3-none-any.whl#sha256=8e0f8568c118d3077b46be7d654cc8167fa916092e28320cde048e54bfc9f1e6
Downloading https://files.pythonhosted.org/packages/74/68/d87d9b36af36f44254a8d512cbfc48369103a3b9e474be9bdfe536abfc45/python_dateutil-2.7.5-py2.py3-none-any.whl#sha256=063df5763652e21de43de7d9e00ccf239f953a832941e37be541614732cdfc93
Downloading https://files.pythonhosted.org/packages/71/e8/6777f6624681c8b9701a8a0a5654f3eb56919a01a78e12bf3c73f5a3c714/pyparsing-2.3.0-py2.py3-none-any.whl#sha256=40856e74d4987de5d01761a22d1621ae1c7f8774585acae358aa5c5936c6c90b
Downloading https://files.pythonhosted.org/packages/f7/d2/e07d3ebb2bd7af696440ce7e754c59dd546ffe1bbe732c8ab68b9c834e61/cycler-0.10.0-py2.py3-none-any.whl#sha256=1d8a5ae1ff6c5cf9b93e8811e581232ad8920aeec647c37316ceac982b08cb2d
```
These are the packages:
```bash
subprocess32-3.5.3
backports.functools_lru_cache-1.5
kiwisolver-1.0.1
pytz-2018.7
python_dateutil-2.7.5
pyparsing-2.3.0
cycler-0.10.0
```