### PR TITLE
[dom,daint] Create dask-1.0.0-CrayGNU-18.08-python3.eb

### DIFF
--- a/easybuild/easyconfigs/d/dask/dask-1.0.0-CrayGNU-18.08-python3.eb
+++ b/easybuild/easyconfigs/d/dask/dask-1.0.0-CrayGNU-18.08-python3.eb
@@ -1,0 +1,113 @@
+easyblock = 'Bundle'
+
+name = 'dask'
+version = '1.0.0'
+
+py_maj_ver = '3'
+py_min_ver = '6'
+py_rev_ver = '5.1'
+
+pyver = '%s.%s.%s' % (py_maj_ver, py_min_ver, py_rev_ver)
+versionsuffix = '-python%s' % (py_maj_ver)
+
+homepage = 'http://github.com/dask/dask/'
+description = """Dask provides multi-core execution on larger-than-memory datasets using blocked algorithms
+ and task scheduling."""
+
+toolchain = {'name': 'CrayGNU', 'version': '18.08'}
+toolchainopts = {'verbose': False}
+
+# this is a bundle of Python packages
+exts_defaultclass = 'PythonPackage'
+
+dependencies = [
+    ('PyExtensions', '%s' % pyver),
+]
+
+
+exts_list = [
+    ('cloudpickle', '0.2.1', {
+        'req_py_majver': '3',
+        'req_py_minver': '6',
+        'source_urls': ['https://pypi.python.org/packages/source/c/cloudpickle'],
+    }),
+    ('distributed', '1.24.0', {
+        'req_py_majver': '3',
+        'req_py_minver': '6',
+        'source_urls': ['https://pypi.python.org/packages/source/d/distributed'],
+    }),
+    ('partd', '0.3.8', {
+        'req_py_majver': '3',
+        'req_py_minver': '6',
+        'source_urls': ['https://pypi.python.org/packages/source/p/partd'],
+    }),
+    ('click', '6.6', {
+        'req_py_majver': '3',
+        'req_py_minver': '6',
+        'source_urls': ['https://pypi.python.org/packages/source/c/click'],
+    }),
+    ('PyYAML', '3.13', {
+        'req_py_majver': '3',
+        'req_py_minver': '6',
+        'source_urls': ['https://pypi.python.org/packages/source/p/pyyaml'],
+        'modulename': 'yaml',
+    }),
+    ('zict', '0.1.3', {
+        'req_py_majver': '3',
+        'req_py_minver': '6',
+        'source_urls': ['https://pypi.python.org/packages/source/z/zict'],
+    }),
+    ('tornado', '4.5.1', {
+        'req_py_majver': '3',
+        'req_py_minver': '6',
+        'source_urls': ['https://pypi.python.org/packages/source/t/tornado'],
+    }),
+    ('msgpack', '0.5.6', {
+        'req_py_majver': '3',
+        'req_py_minver': '6',
+        'source_urls': ['https://pypi.python.org/packages/source/m/msgpack'],
+    }),
+    ('tblib', '1.3.2', {
+        'req_py_majver': '3',
+        'req_py_minver': '6',
+        'source_urls': ['https://pypi.python.org/packages/source/t/tblib'],
+    }),
+    ('psutil', '5.4.8', {
+        'req_py_majver': '3',
+        'req_py_minver': '6',
+        'source_urls': ['https://pypi.python.org/packages/source/p/psutil'],
+    }),
+    ('sortedcontainers', '2.0.5', {
+        'req_py_majver': '3',
+        'req_py_minver': '6',
+        'source_urls': ['https://pypi.python.org/packages/source/s/sortedcontainers'],
+    }),
+    ('locket', '0.2.0', {
+        'req_py_majver': '3',
+        'req_py_minver': '6',
+        'source_urls': ['https://pypi.python.org/packages/source/l/locket'],
+    }),
+    ('HeapDict', '1.0.0', {
+        'req_py_majver': '3',
+        'req_py_minver': '6',
+        'source_urls': ['https://pypi.python.org/packages/source/h/heapdict'],
+    }),
+   (name, version, {
+        'req_py_majver': '3',
+        'req_py_minver': '6',
+        'source_urls': ['https://pypi.python.org/packages/source/d/dask'],
+        'checksums': ['a1fa4a3b2d7ce4dd0c68db4b68dadf2c283ff54d98bd72c556fc462000449ff7'],
+    }),
+]
+
+# specify that Bundle easyblock should run a full sanity check, rather than just trying to load the module
+full_sanity_check = True
+
+sanity_check_paths = {
+    'files': [],
+    'dirs': ['lib/python%s.%s/site-packages' % (py_maj_ver, py_min_ver)],
+}
+
+modextrapaths = {'PYTHONPATH': ['lib/python%s.%s/site-packages' % (py_maj_ver, py_min_ver)]}
+
+moduleclass = 'data'


### PR DESCRIPTION
Dask has released version 1.0.0. This easybuild is a dask[complete] which installs everything required for most common uses of Dask (arrays, dataframes, distributed, and so on)