### PR TITLE
[dom,daint] Create ipyparallel-6.2.3-CrayGNU-18.08-python3.eb

### DIFF
--- a/easybuild/easyconfigs/i/ipyparallel/ipyparallel-6.2.3-CrayGNU-18.08-python3.eb
+++ b/easybuild/easyconfigs/i/ipyparallel/ipyparallel-6.2.3-CrayGNU-18.08-python3.eb
@@ -1,0 +1,33 @@
+easyblock = 'PythonPackage'
+
+name = 'ipyparallel'
+version = '6.2.3'
+
+py_maj_ver = '3'
+py_min_ver = '6'
+py_rev_ver = '5.1'
+
+pyver = '%s.%s.%s' % (py_maj_ver, py_min_ver, py_rev_ver)
+versionsuffix = '-python%s' % (py_maj_ver)
+
+homepage = 'https://pypi.org/project/ipyparallel'
+description = """Use multiple instances of IPython in parallel, interactively."""
+
+toolchain = {'name': 'CrayGNU', 'version': '18.08'}
+toolchainopts = { 'verbose' : False }
+
+source_urls = [PYPI_SOURCE]
+sources = [SOURCE_TAR_GZ]
+use_pip = True
+
+dependencies = [
+    ('cray-python/%s' % pyver, EXTERNAL_MODULE), 
+    ('jupyter', '1.0.0')
+]
+
+sanity_check_paths = {
+    'files': [],
+    'dirs': ['lib/python%s.%s/site-packages' % (py_maj_ver, py_min_ver)],
+}
+
+moduleclass = 'devel'

--- a/jenkins-builds/6.0.UP07-18.08-gpu
+++ b/jenkins-builds/6.0.UP07-18.08-gpu
@@ -21,6 +21,7 @@
  HPX-1.1.0-CrayGNU-18.08.eb                         --set-default-module
  IDL-8.5.1.eb                                       --set-default-module
  ipykernel-4.8.2-CrayGNU-18.08-python2.eb
+ ipyparallel-6.2.3-CrayGNU-18.08-python3.eb
  jupyter-1.0.0-CrayGNU-18.08.eb
  jupyterhub-0.9.4-CrayGNU-18.08.eb
  jupyterlab-0.35.2-CrayGNU-18.08.eb

--- a/jenkins-builds/6.0.UP07-18.08-mc
+++ b/jenkins-builds/6.0.UP07-18.08-mc
@@ -22,6 +22,7 @@
  HPX-1.1.0-CrayGNU-18.08.eb                         --set-default-module
  IDL-8.5.1.eb                                       --set-default-module
  ipykernel-4.8.2-CrayGNU-18.08-python2.eb
+ ipyparallel-6.2.3-CrayGNU-18.08-python3.eb
  jupyter-1.0.0-CrayGNU-18.08.eb
  jupyterhub-0.9.4-CrayGNU-18.08.eb
  jupyterlab-0.35.2-CrayGNU-18.08.eb


### PR DESCRIPTION
ipyparallel when a user requests MPI to be set up automatically in their notebook from the jupyterhub spawner page (development).