### PR TITLE
[leone] PV5.6 comes to Leone with Qt5.9

### DIFF
--- a/easybuild/easyconfigs/p/ParaView/ParaView-5.6.0-foss-2016b.eb
+++ b/easybuild/easyconfigs/p/ParaView/ParaView-5.6.0-foss-2016b.eb
@@ -1,0 +1,54 @@
+# Leone version by Jean Favre (CSCS)
+# 
+
+easyblock = 'CMakeMake'
+
+name = 'ParaView'
+version = '5.6.0'
+versionsuffix=''
+
+homepage = "http://www.paraview.org"
+description = "ParaView is a scientific parallel visualizer."
+
+toolchain = {'name': 'foss', 'version': '2016b'}
+#toolchainopts = {'pic': True, 'usempi': True, 'verbose': False, 'optarch' : False, 'noopt' : True, 'debug' : True}
+
+download_suffix = 'download.php?submit=Download&version=v%(version_major_minor)s&type=source&os=all&downloadFile='
+source_urls = ['http://www.paraview.org/paraview-downloads/%s' % download_suffix]
+sources = ["ParaView-v%(version)s.tar.gz"]
+
+python = 'Python'
+pyver = '2.7.12'
+pysuff = '-%s-%s' % (python, pyver)
+dependencies = [
+    (python, pyver),
+    ('Qt', '5.9.0')
+]
+
+builddependencies = [('CMake', '3.4.1', '', True)]
+
+#patches = [ 'ParaView-5.4.0-leone-patch' ]
+
+separate_build_dir = True
+
+maxparallel = 8
+
+configopts  = '-DCMAKE_CXX_COMPILER=g++ -DCMAKE_C_COMPILER=gcc '
+#configopts += '-DCMAKE_C_FLAGS=\"-fno-math-errno -fPIC\" -DCMAKE_CXX_FLAGS=\"-fno-math-errno -fPIC\" '
+configopts += '-DBUILD_TESTING:BOOL=OFF -DBUILD_EXAMPLES:BOOL=OFF -DPARAVIEW_ENABLE_CATALYST:BOOL=OFF -DPARAVIEW_BUILD_PLUGIN_SierraPlotTools=OFF '
+configopts += '-DPARAVIEW_ENABLE_PYTHON:BOOL=ON -DPYTHON_EXECUTABLE=${EBROOTPYTHON}/bin/python -DPARAVIEW_USE_MPI:BOOL=OFF '
+configopts += '-DCMAKE_BUILD_TYPE=Release -DBUILD_SHARED_LIBS:BOOL=ON '
+configopts += '-DPARAVIEW_USE_VTKM:BOOL=OFF '
+configopts += '-DPARAVIEW_ENABLE_PYTHON:BOOL=ON -DPYTHON_EXECUTABLE=${EBROOTPYTHON}/bin/python2 '
+configopts += '-DVTK_RENDERING_BACKEND:STRING=OpenGL2 -DOPENGL_gl_LIBRARY=/usr/lib64/libGL.so '
+configopts += '-DOPENGL_INCLUDE_DIR=/usr/include '
+configopts += '-DQt5_DIR:FILEPATH=${EBROOTQT}/lib/cmake/Qt5 '
+configopts += '-DPARAVIEW_ENABLE_WEB:BOOL=OFF '
+
+#modextravars = {'PV_DEBUG_SKIP_OPENGL_VERSION_CHECK': '1'}
+sanity_check_paths = {
+    'files': ['bin/pvbatch', 'bin/pvserver'],
+    'dirs': [],
+}
+
+moduleclass = 'vis'

--- a/easybuild/easyconfigs/q/Qt/Qt-5.9.0-foss-2016b-Python-2.7.12.eb
+++ b/easybuild/easyconfigs/q/Qt/Qt-5.9.0-foss-2016b-Python-2.7.12.eb
@@ -1,0 +1,32 @@
+name = 'Qt'
+version = '5.9.0'
+
+homepage = 'http://qt-project.org/'
+description = "Qt is a comprehensive cross-platform C++ application framework."
+
+toolchain = {'name': 'foss', 'version': '2016b'}
+toolchainopts = {'pic': True}
+
+source_urls = [
+    'http://download.qt.io/official_releases/qt/%(version_major_minor)s/%(version)s/',
+    'http://download.qt.io/archive/qt/%(version_major_minor)s/%(version)s/single/'
+]
+
+sources = ['%(namelower)s-everywhere-opensource-src-%(version)s.tar.xz']
+
+python = 'Python'
+pyver = '2.7.12'
+pysuff = '-%s-%s' % (python, pyver)
+dependencies = [
+    (python, pyver)
+]
+
+configopts  = ' -opensource -confirm-license -release -skip qtconnectivity '
+configopts += ' -skip qtgamepad -skip qtlocation -skip qtmultimedia -skip qtsensors '
+configopts += ' -skip qtserialport -skip qtwayland -skip qtwebchannel -skip qtwebengine '
+configopts += ' -skip qtwebsockets -nomake examples -nomake tests -no-dbus -qt-libjpeg '
+configopts += ' -qt-pcre -system-zlib -no-openssl -skip qtsvg -qt-xcb -system-libpng -fontconfig '
+
+maxparallel = 8
+
+moduleclass = 'devel'

--- a/easybuild/easyconfigs/q/Qt/Qt-5.9.0-foss-2016b.eb
+++ b/easybuild/easyconfigs/q/Qt/Qt-5.9.0-foss-2016b.eb
@@ -14,12 +14,12 @@ source_urls = [
 
 sources = ['%(namelower)s-everywhere-opensource-src-%(version)s.tar.xz']
 
-python = 'Python'
-pyver = '2.7.12'
-pysuff = '-%s-%s' % (python, pyver)
-dependencies = [
-    (python, pyver)
-]
+#python = 'Python'
+#pyver = '2.7.12'
+#pysuff = '-%s-%s' % (python, pyver)
+#dependencies = [
+#    (python, pyver)
+#]
 
 configopts  = ' -opensource -confirm-license -release -skip qtconnectivity '
 configopts += ' -skip qtgamepad -skip qtlocation -skip qtmultimedia -skip qtsensors '
@@ -27,6 +27,6 @@ configopts += ' -skip qtserialport -skip qtwayland -skip qtwebchannel -skip qtwe
 configopts += ' -skip qtwebsockets -nomake examples -nomake tests -no-dbus -qt-libjpeg '
 configopts += ' -qt-pcre -system-zlib -no-openssl -skip qtsvg -qt-xcb -system-libpng -fontconfig '
 
-maxparallel = 8
+maxparallel = 12
 
 moduleclass = 'devel'

--- a/jenkins-builds/leone-RHEL6.7EUS-17.06
+++ b/jenkins-builds/leone-RHEL6.7EUS-17.06
@@ -6,7 +6,8 @@
  OpenFOAM-4.1-foss-2016b.eb                 --set-default-module 
  OpenFOAM-5.0-20180108-foss-2016b.eb
  OpenFOAM-Extend-4.0-foss-2016b.eb
- ParaView-5.4.0-foss-2016b.eb
+ ParaView-5.4.0-foss-2016b.eb               --set-default-module
+ ParaView-5.6.0-foss-2016b.eb
  PrgEnv-gnu-leone-foss-2016b.eb
  Python-2.7.12-foss-2016b.eb
  reframe-2.14.eb                            --set-default-module


### PR DESCRIPTION
The commit includes a new Qt necessary for PV5.6

== COMPLETED: Installation ended successfully
== Results of the build can be found in the log file(s) /scratch/leone/jfavre/leone/software/Qt/5.9.0-foss-2016b/easybuild/easybuild-Qt-5.9.0-20181206.150735.log
== Build succeeded for 1 out of 1

and PV5.6 itself

== COMPLETED: Installation ended successfully
== Results of the build can be found in the log file(s) /scratch/leone/jfavre/leone/software/ParaView/5.6.0-foss-2016b/easybuild/easybuild-ParaView-5.6.0-20181206.155127.log
== Build succeeded for 1 out of 1

I have tested inside a VNC desktop and things were running fine.