### PR TITLE
[daint-gpu] ParaView enable NVIDIA IndeX for all users

### DIFF
--- a/easybuild/easyconfigs/p/ParaView/ParaView-5.6.0-EGL-CrayGNU-18.08.eb
+++ b/easybuild/easyconfigs/p/ParaView/ParaView-5.6.0-EGL-CrayGNU-18.08.eb
@@ -73,7 +73,8 @@ configopts += '-DPARAVIEW_BUILD_PLUGIN_pvNVIDIAIndeX:BOOL=ON '
 # first serial attempt would fail.
 #prebuildopts = 'make VTKData ;'
 
-modextravars = { 'LD_LIBRARY_PATH':'/opt/python/%s/lib:$::env(LD_LIBRARY_PATH)' % pyver}
+modextravars = { 'LD_LIBRARY_PATH':'/apps/common/UES/easybuild/sources/p/ParaView/nvindex_default/linux-x86-64/lib:/opt/python/%s/lib:$::env(LD_LIBRARY_PATH)' % pyver, 
+                 'NVINDEX_PVPLUGIN_HOME':'/apps/common/UES/easybuild/sources/p/ParaView'}
 
 sanity_check_paths = {
     'files': ['bin/pvbatch', 'bin/pvserver'],


### PR DESCRIPTION
All users are enabled to use NVIDIA IndeX. We provide the license file in /apps/common/UES/easybuild/sources/p/ParaView. It must be called "nvindex_config.xml" and we provide a default lib path in the same directory.

we updated $LD_LIBRARY_PATH
we defined $NVINDEX_PVPLUGIN_HOME
