### PR TITLE
[daint-gpu] new version of VTK with EGL

### DIFF
--- a/easybuild/easyconfigs/v/VTK/VTK-8.2.0-EGL-CrayGNU-18.08-python3.eb
+++ b/easybuild/easyconfigs/v/VTK/VTK-8.2.0-EGL-CrayGNU-18.08-python3.eb
@@ -1,0 +1,91 @@
+##
+# This file is an EasyBuild reciPY as per https://github.com/hpcugent/easybuild
+#
+# Copyright:: Copyright 2012-2014 Uni.Lu/LCSB, NTUA
+# Authors::   Fotis Georgatos <fotis@cern.ch>
+# License::   MIT/GPL
+# $Id$
+#
+# This work implements a part of the HPCBIOS project and is a component of the policy:
+# http://hpcbios.readthedocs.org/en/latest/HPCBIOS_2012-97.html
+##
+
+# CrayGNU version by Jean Favre (CSCS) 
+# 
+#
+# VTK_OPENGL_HAS_EGL
+# EGL_INCLUDE_DIR
+# EGL_LIBRARY
+
+easyblock = 'CMakeMake'
+
+name = 'VTK'
+vtk_version = '8.2.0'
+version = '%s-EGL' % vtk_version
+
+homepage = 'http://www.vtk.org'
+description = """The Visualization Toolkit (VTK) is an open-source, freely
+available software system for 3D computer graphics, image processing and
+visualization. VTK consists of a C++ class library and several interpreted
+interface layers including Tcl/Tk, Java, and Python. VTK supports a wide
+variety of visualization algorithms including: scalar, vector, tensor, texture,
+and volumetric methods; and advanced modeling techniques such as: implicit
+modeling, polygon reduction, mesh smoothing, cutting, contouring, and Delaunay
+triangulation."""
+
+toolchain = {'name': 'CrayGNU', 'version': '18.08'}
+toolchainopts = {'verbose': False}
+#toolchainopts = {'pic': True, 'verbose': False}
+
+source_urls = ['http://www.vtk.org/files/release/%(version_major_minor)s']
+sources = [
+    '%s-%s.tar.gz' % (name, vtk_version), 
+    '%sData-%s.tar.gz' % (name, vtk_version),
+]
+
+separate_build_dir = True
+
+maxparallel = 16
+
+py_maj_ver = '3'
+py_min_ver = '6'
+py_rev_ver = '5.1'
+pyver = '%s.%s.%s' % (py_maj_ver, py_min_ver, py_rev_ver)
+pyshortver = '%s.%s' % (py_maj_ver, py_min_ver)
+pysuff = '-python%s' % py_maj_ver
+
+dependencies = [
+    ('cray-python/%s' % pyver, EXTERNAL_MODULE)
+]
+
+builddependencies = [ ('CMake', '3.12.0','', True), ]
+
+configopts = "-DCMAKE_BUILD_TYPE=RelWithDebInfo -DVTK_RENDERING_BACKEND:STRING=OpenGL2 "
+configopts += "-DBUILD_SHARED_LIBS:BOOL=ON -DBUILD_TESTING:BOOL=OFF -DModule_vtkIOXdmf2:BOOL=ON "
+configopts += "-DVTK_WRAP_PYTHON:BOOL=ON -DPYTHON_EXECUTABLE:FILEPATH=${EBROOTPYTHON}/bin/python3 "
+#
+configopts += "-DVTK_Group_MPI:BOOL=ON -DCMAKE_C_COMPILER:PATH=`which cc` "
+configopts += "-DCMAKE_CXX_COMPILER:PATH=`which CC` "
+#configopts += "-DMPI_C_LIBRARIES=${CRAY_MPICH_DIR}/lib/libmpich.so "
+#configopts += "-DMPI_C_INCLUDE_PATH=${CRAY_MPICH_DIR}/include "
+#
+configopts += "-DVTK_USE_X=OFF -DVTK_OPENGL_HAS_EGL:BOOL=ON "
+configopts += "-DEGL_INCLUDE_DIR:PATH=/users/jfavre/Projects/EGL/code-samples/posts/egl_OpenGl_without_Xserver "
+configopts += "-DEGL_LIBRARY:FILEPATH=/opt/cray/nvidia/default/lib64/libEGL.so "
+configopts += "-DEGL_opengl_LIBRARY:FILEPATH=/opt/cray/nvidia/default/lib64/libOpenGL.so "
+
+modextrapaths = {'PYTHONPATH': ['lib/python%s/site-packages' % pyshortver]}
+# a long discussion with Victor, Matthias and Rafael lead to the following hard-wired variable.
+# should the cray-python module be fixed?
+modtclfooter = """
+prepend-path LD_LIBRARY_PATH "/opt/python/3.6.5.1/lib"
+"""
+
+sanity_check_paths = {
+    'files': ['bin/vtkpython'],
+    'dirs': ['lib/python%s/site-packages/' % pyshortver, 'include/vtk-%(version_major_minor)s'],
+}
+
+sanity_check_commands = [('bin/vtkpython', "-c 'import %(namelower)s'")]
+
+moduleclass = 'vis'

--- a/jenkins-builds/6.0.UP07-18.08-gpu
+++ b/jenkins-builds/6.0.UP07-18.08-gpu
@@ -57,7 +57,8 @@
  VASP-5.4.4-CrayIntel-18.08-cuda-9.1.eb             --set-default-module
  VMD-1.9.3-egl.eb
  VMD-1.9.3-ogl.eb
- VTK-8.1.1-EGL-CrayGNU-18.08-python3.eb             --set-default-module
+ VTK-8.1.1-EGL-CrayGNU-18.08-python3.eb
+ VTK-8.2.0-EGL-CrayGNU-18.08-python3.eb             --set-default-module
  advisor_2018.eb                                    --set-default-module --installpath=/apps/daint/UES/jenscscs/6.0.UP07/gpu/easybuild/tools
  advisor_2019.eb                                                         --installpath=/apps/daint/UES/jenscscs/6.0.UP07/gpu/easybuild/tools
  bladeplugin-0.1.eb                                 --set-default-module --installpath=/apps/daint/UES/jenscscs/6.0.UP07/gpu/easybuild/tools


### PR DESCRIPTION
eb -f VTK-8.2.0-EGL-CrayGNU-18.08-python3.eb

== COMPLETED: Installation ended successfully
== Results of the build can be found in the log file(s) /scratch/snx3000/jfavre/daint/software/VTK/8.2.0-EGL-CrayGNU-18.08/easybuild/easybuild-VTK-8.2.0-EGL-20190201.091555.log
== Build succeeded for 1 out of 1
