### PR TITLE
[daint] Add GREASY version 19.03-cscs

### DIFF
--- a/easybuild/easyconfigs/g/GREASY/GREASY-19.03-cscs-CrayGNU-18.08.eb
+++ b/easybuild/easyconfigs/g/GREASY/GREASY-19.03-cscs-CrayGNU-18.08.eb
@@ -1,7 +1,7 @@
 easyblock = 'ConfigureMake'
 
 name = 'GREASY'
-version = 'CSCS-19.03'
+version = '19.03-cscs'
 
 homepage = 'https://github.com/jonarbo/GREASY'
 description = """Greasy is a tool designed to make easier the deployment of

--- a/easybuild/easyconfigs/g/GREASY/GREASY-CSCS-19.03-CrayGNU-18.08.eb
+++ b/easybuild/easyconfigs/g/GREASY/GREASY-CSCS-19.03-CrayGNU-18.08.eb
@@ -1,0 +1,28 @@
+easyblock = 'ConfigureMake'
+
+name = 'GREASY'
+version = 'CSCS-19.03'
+
+homepage = 'https://github.com/jonarbo/GREASY'
+description = """Greasy is a tool designed to make easier the deployment of
+embarrassingly parallel simulations in any environment. It is able to run in
+parallel a list of different tasks."""
+
+toolchain = {'name': 'CrayGNU', 'version': '18.08'}
+toolchainopts = {'opt': True, 'pic': True}
+
+#
+# GREASY source code modified by us in order to properly use SLURM scheduler
+# The original code was taken from https://github.com/jonarbo/GREASY
+# This version contains the current constraint options to use the GPU on Piz Daint
+#
+sources = ['https://github.com/eth-cscs/GREASY/archive/%(version)s.tar.gz']
+
+#preconfigopts = './autogen.sh && '
+
+sanity_check_paths = {
+    'files': ["bin/greasy"],
+    'dirs': [],
+}
+
+moduleclass = 'data'

--- a/jenkins-builds/6.0.UP07-18.08-gpu
+++ b/jenkins-builds/6.0.UP07-18.08-gpu
@@ -9,7 +9,7 @@
  CP2K-6.1-CrayGNU-18.08-cuda-9.1.eb                 --set-default-module
  CPMD-4.1-CrayIntel-18.08.eb                        --set-default-module
  dask-1.0.0-CrayGNU-18.08-python3.eb                --set-default-module
- GREASY-CSCS-19.03-CrayGNU-18.08.eb                 --set-default-module
+ GREASY-19.03-cscs-CrayGNU-18.08.eb                 --set-default-module
  GROMACS-2018.3-CrayGNU-18.08-cuda-9.1.eb           --set-default-module
  GROMACS-2019-CrayGNU-18.08-cuda-9.1.eb
  GSL-2.5-CrayGNU-18.08.eb                           --set-default-module

--- a/jenkins-builds/6.0.UP07-18.08-gpu
+++ b/jenkins-builds/6.0.UP07-18.08-gpu
@@ -9,7 +9,7 @@
  CP2K-6.1-CrayGNU-18.08-cuda-9.1.eb                 --set-default-module
  CPMD-4.1-CrayIntel-18.08.eb                        --set-default-module
  dask-1.0.0-CrayGNU-18.08-python3.eb                --set-default-module
- GREASY-2.1-cscs-CrayGNU-18.08-gpu.eb               --set-default-module
+ GREASY-CSCS-19.03-CrayGNU-18.08.eb                 --set-default-module
  GROMACS-2018.3-CrayGNU-18.08-cuda-9.1.eb           --set-default-module
  GROMACS-2019-CrayGNU-18.08-cuda-9.1.eb
  GSL-2.5-CrayGNU-18.08.eb                           --set-default-module

--- a/jenkins-builds/6.0.UP07-18.08-mc
+++ b/jenkins-builds/6.0.UP07-18.08-mc
@@ -9,7 +9,7 @@
  CP2K-6.1-CrayGNU-18.08.eb                          --set-default-module
  CPMD-4.1-CrayIntel-18.08.eb                        --set-default-module
  dask-1.0.0-CrayGNU-18.08-python3.eb                --set-default-module
- GREASY-2.1-cscs-CrayGNU-18.08.eb                   --set-default-module
+ GREASY-CSCS-19.03-CrayGNU-18.08.eb                 --set-default-module
  GROMACS-2018.3-CrayGNU-18.08.eb                    --set-default-module
  GSL-2.5-CrayGNU-18.08.eb                           --set-default-module
  GSL-2.5-CrayCCE-18.08.eb

--- a/jenkins-builds/6.0.UP07-18.08-mc
+++ b/jenkins-builds/6.0.UP07-18.08-mc
@@ -9,7 +9,7 @@
  CP2K-6.1-CrayGNU-18.08.eb                          --set-default-module
  CPMD-4.1-CrayIntel-18.08.eb                        --set-default-module
  dask-1.0.0-CrayGNU-18.08-python3.eb                --set-default-module
- GREASY-CSCS-19.03-CrayGNU-18.08.eb                 --set-default-module
+ GREASY-19.03-cscs-CrayGNU-18.08.eb                 --set-default-module
  GROMACS-2018.3-CrayGNU-18.08.eb                    --set-default-module
  GSL-2.5-CrayGNU-18.08.eb                           --set-default-module
  GSL-2.5-CrayCCE-18.08.eb


### PR DESCRIPTION
This is a very disruptive PR for two reasons:

1. GREASY is currently broken, so the module makes no sense to exist
2. The new GREASY has a different usage syntax that is similar to the original GREASY, but on steroids.

So, I am proposing to remove the current (old/broken) GREASY from the production list and update the documentation accordingly.
