### PR TITLE
[dom] Update Machines.groovy

### DIFF
--- a/jenkins/JenkinsfileProductionEB
+++ b/jenkins/JenkinsfileProductionEB
@@ -11,6 +11,7 @@ stage('Initialization') {
         def rootDir = pwd()
         methods = load("${rootDir}/jenkins/util.groovy")
         machinesList = load("${rootDir}/jenkins/Machines.groovy")
+        machinesList.remove('dom')
     }
 }
 

--- a/jenkins/Machines.groovy
+++ b/jenkins/Machines.groovy
@@ -38,4 +38,4 @@ def leone = [name: 'leone',
              modulesUnuseProduction: '',
              prefixProduction: '/apps/leone/UES/jenkins/RHEL6.10/easybuild']
 
-return [daint, dom, kesch, leone, fulen]
+return [daint, kesch, leone, fulen]

--- a/jenkins/Machines.groovy
+++ b/jenkins/Machines.groovy
@@ -38,4 +38,4 @@ def leone = [name: 'leone',
              modulesUnuseProduction: '',
              prefixProduction: '/apps/leone/UES/jenkins/RHEL6.10/easybuild']
 
-return [daint, kesch, leone, fulen]
+return [daint, dom, kesch, leone, fulen]


### PR DESCRIPTION
I propose to remove Dom from production builds until we have a new software list, since the build will keep failing in the meanwhile. 
E.g.: The last failure occurred when building `GREASY` with the error `Unable to locate a modulefile for 'atp/2.1.2'`.
https://jenkins.cscs.ch/blue/rest/organizations/jenkins/pipelines/ProductionEB/runs/580/nodes/37/steps/74/log/?start=0