### PR TITLE
[daint] Update xalt path

### DIFF
--- a/login/xalt
+++ b/login/xalt
@@ -1,1 +1,1 @@
-/apps/daint/UES/xalt/git/cscs/xalt/
+/apps/daint/UES/xalt/production/cscs/xalt


### PR DESCRIPTION
Hi,

I have noticed a manual change in the link to the `xalt` folder under `/apps/common/UES/jenkins/production/login`: 
in the mast branch it points to `/apps/daint/UES/xalt/git/cscs/xalt/`, but in the local folder it points to  `/apps/daint/UES/xalt/production/cscs/xalt`.

Could you please confirm that the latter is correct? I have to reset the manul change, otherwise the automatic update of the `production` folder done periodically by `ProductionEBCommon` fails.