### PR TITLE
[daint] Fixing symbolic link to xalt folder

### DIFF
--- a/login/xalt
+++ b/login/xalt
@@ -1,1 +1,1 @@
-/apps/daint/UES/xalt/production/cscs/xalt
+/apps/daint/UES/xalt/production/cscs/xalt/


### PR DESCRIPTION
I'm submitting a minor change since in my previous request a trailing slash was missing.