### PR TITLE
[daint] Update EasyBuild-custom/cscs

### DIFF
--- a/easybuild/module/EasyBuild-custom/cscs
+++ b/easybuild/module/EasyBuild-custom/cscs
@@ -61,8 +61,6 @@ if { $status == 0 } {
         prepend-path PATH                       /usr/share/Modules/tcl
     }
 }
-# temporary fix!
-setenv EASYBUILD_MODULE_SYNTAX                  Tcl
 #########################
 # SYSTEM SPECIFIC SETUP #
 #########################

--- a/easybuild/module/EasyBuild-custom/cscs
+++ b/easybuild/module/EasyBuild-custom/cscs
@@ -35,7 +35,7 @@ set eb_config_dir          /apps/common/UES/jenkins/production/easybuild
 # EB_CUSTOM_REPOSITORY
 # the following variables should depend on it
 #
-# XDG_CONFIG_HOME
+# XDG_CONFIG_DIRS
 # EASYBUILD_ROBOT_PATHS
 # EASYBUILD_INCLUDE_EASYBLOCKS
 # EASYBUILD_EXTERNAL_MODULES_METADATA (if on cray)
@@ -43,6 +43,7 @@ set eb_config_dir          /apps/common/UES/jenkins/production/easybuild
 if { ! [ info exists ::env(EB_CUSTOM_REPOSITORY) ] } {
     setenv EB_CUSTOM_REPOSITORY $eb_config_dir
 }
+setenv XDG_CONFIG_DIRS                          $::env(EB_CUSTOM_REPOSITORY)
 setenv EASYBUILD_ROBOT_PATHS                    $::env(EB_CUSTOM_REPOSITORY)/easyconfigs/:
 setenv EASYBUILD_INCLUDE_EASYBLOCKS             $::env(EB_CUSTOM_REPOSITORY)/easyblocks/*.py
 setenv EASYBUILD_EXTERNAL_MODULES_METADATA      $::env(EB_CUSTOM_REPOSITORY)/cray_external_modules_metadata.cfg


### PR DESCRIPTION
Re-enable `XDG_CONFIG_DIRS`, otherwise the non-default configuration file `system_wide.cfg` will be ignored: see https://easybuild.readthedocs.io/en/latest/Configuration.html?highlight=XDG_CONFIG_DIRS