### PR TITLE
[daint] CP2K with ELPA library

### DIFF
--- a/easybuild/easyconfigs/c/CP2K/CP2K-6.1-CrayGNU-18.08-cuda-9.1.eb
+++ b/easybuild/easyconfigs/c/CP2K/CP2K-6.1-CrayGNU-18.08-cuda-9.1.eb
@@ -23,7 +23,7 @@ toolchainopts = { 'usempi': True, 'openmp': True }
 
 patches = [('%(name)s-%(version)s-%(toolchain_name)s-%(toolchain_version)s%(versionsuffix)s.psmp', '%(builddir)s/%(namelower)s-%(version)s/arch')]
 sources = [SOURCELOWER_TAR_BZ2]
-source_urls = [SOURCEFORGE_SOURCE]
+source_urls = ['https://github.com/%(namelower)s/%(namelower)s/releases/download/v6.1.0']
 
 builddependencies = [
     ('cudatoolkit/%s.85_3.18-6.0.7.0_5.1__g2eb7c52' % cudaversion, EXTERNAL_MODULE),

--- a/easybuild/easyconfigs/c/CP2K/CP2K-6.1-CrayGNU-18.08-cuda-9.1.eb
+++ b/easybuild/easyconfigs/c/CP2K/CP2K-6.1-CrayGNU-18.08-cuda-9.1.eb
@@ -3,6 +3,7 @@ easyblock = 'MakeCp'
 
 name = 'CP2K'
 version = '6.1'
+release = '%s.0' % version
 cudaversion = '9.1'
 versionsuffix = '-cuda-%s' % cudaversion
 
@@ -23,7 +24,7 @@ toolchainopts = { 'usempi': True, 'openmp': True }
 
 patches = [('%(name)s-%(version)s-%(toolchain_name)s-%(toolchain_version)s%(versionsuffix)s.psmp', '%(builddir)s/%(namelower)s-%(version)s/arch')]
 sources = [SOURCELOWER_TAR_BZ2]
-source_urls = ['https://github.com/%(namelower)s/%(namelower)s/releases/download/v6.1.0']
+source_urls = ['https://github.com/%(namelower)s/%(namelower)s/releases/download/v{0}'.format(release)]
 
 builddependencies = [
     ('cudatoolkit/%s.85_3.18-6.0.7.0_5.1__g2eb7c52' % cudaversion, EXTERNAL_MODULE),

--- a/easybuild/easyconfigs/c/CP2K/CP2K-6.1-CrayGNU-18.08-cuda-9.1.eb
+++ b/easybuild/easyconfigs/c/CP2K/CP2K-6.1-CrayGNU-18.08-cuda-9.1.eb
@@ -34,6 +34,7 @@ builddependencies = [
 ]
 
 dependencies = [
+    ('ELPA', '2016.11.001.pre'),
     ('Libint', '1.1.4'),
     ('libxc', '4.2.3'),
 ]

--- a/easybuild/easyconfigs/c/CP2K/CP2K-6.1-CrayGNU-18.08-cuda-9.1.psmp
+++ b/easybuild/easyconfigs/c/CP2K/CP2K-6.1-CrayGNU-18.08-cuda-9.1.psmp
@@ -1,5 +1,5 @@
 # contributed by Luca Marsella (CSCS)
-# modules: CrayGNU cray-fftw cray-python cudatoolkit Libint libxc flex Bison
+# modules: CrayGNU cray-fftw cray-python cudatoolkit ELPA Libint libxc flex Bison
 NVCC     = nvcc
 CC       = cc
 CPP      = 
@@ -7,13 +7,14 @@ FC       = ftn
 LD       = ftn
 AR       = ar -r
 CPPFLAGS =
-DFLAGS   = -D__FFTW3 -D__parallel -D__SCALAPACK -D__HAS_smm_dnn -D__ACC -D__DBCSR_ACC -D__FFTSG -D__LIBINT -D__LIBXC -D__GFORTRAN
+DFLAGS   = -D__FFTW3 -D__parallel -D__SCALAPACK -D__HAS_smm_dnn -D__ACC -D__DBCSR_ACC -D__FFTSG -D__ELPA=201611 -D__LIBINT -D__LIBXC -D__GFORTRAN
 CFLAGS   = $(DFLAGS)
 FCFLAGS  = $(DFLAGS) -O3 -mavx -fopenmp -funroll-loops -ffast-math -ftree-vectorize -ffree-form -ffree-line-length-512
-FCFLAGS  += -I$(EBROOTLIBINT)/include -I$(EBROOTLIBXC)/include
+FCFLAGS  += -I$(ELPA_INCLUDE_DIR)/elpa -I$(ELPA_INCLUDE_DIR)/modules -I$(EBROOTLIBINT)/include -I$(EBROOTLIBXC)/include
 LDFLAGS  = $(FCFLAGS)
 NVFLAGS  = $(DFLAGS) -O3 -arch sm_60
 LIBS   	 = -lfftw3 -lfftw3_threads -lcudart -lcublas -lcufft -lrt 
+LIBS     += -L$(ELPA_LIBRARY_DIR) -lelpa_openmp
 LIBS     += $(EBROOTLIBINT)/lib/libderiv.a $(EBROOTLIBINT)/lib/libint.a $(EBROOTLIBINT)/lib/libr12.a -lstdc++ 
 LIBS     += -L$(EBROOTLIBXC)/lib -lxcf03 -lxc
 LIBS     += /apps/common/UES/easybuild/sources/c/CP2K/libsmm_dnn_cray.gnu.a

--- a/easybuild/easyconfigs/c/CP2K/CP2K-6.1-CrayGNU-18.08.eb
+++ b/easybuild/easyconfigs/c/CP2K/CP2K-6.1-CrayGNU-18.08.eb
@@ -3,6 +3,7 @@ easyblock = 'MakeCp'
 
 name = 'CP2K'
 version = '6.1'
+release = '%s.0' % version
 
 py_maj_ver = '2'
 py_min_ver = '7'
@@ -21,7 +22,7 @@ toolchainopts = { 'usempi': True, 'openmp': True }
 
 patches = [('%(name)s-%(version)s-%(toolchain_name)s-%(toolchain_version)s.psmp', '%(builddir)s/%(namelower)s-%(version)s/arch')]
 sources = [SOURCELOWER_TAR_BZ2]
-source_urls = ['https://github.com/%(namelower)s/%(namelower)s/releases/download/v6.1.0']
+source_urls = ['https://github.com/%(namelower)s/%(namelower)s/releases/download/v{0}'.format(release)]
 
 builddependencies = [
     ('cray-fftw/3.3.6.5', EXTERNAL_MODULE),

--- a/easybuild/easyconfigs/c/CP2K/CP2K-6.1-CrayGNU-18.08.eb
+++ b/easybuild/easyconfigs/c/CP2K/CP2K-6.1-CrayGNU-18.08.eb
@@ -31,6 +31,7 @@ builddependencies = [
 ]
 
 dependencies = [
+    ('ELPA', '2016.11.001.pre'),
     ('Libint', '1.1.4'),
     ('libxc', '4.2.3'),
 ]

--- a/easybuild/easyconfigs/c/CP2K/CP2K-6.1-CrayGNU-18.08.eb
+++ b/easybuild/easyconfigs/c/CP2K/CP2K-6.1-CrayGNU-18.08.eb
@@ -21,7 +21,7 @@ toolchainopts = { 'usempi': True, 'openmp': True }
 
 patches = [('%(name)s-%(version)s-%(toolchain_name)s-%(toolchain_version)s.psmp', '%(builddir)s/%(namelower)s-%(version)s/arch')]
 sources = [SOURCELOWER_TAR_BZ2]
-source_urls = [SOURCEFORGE_SOURCE]
+source_urls = ['https://github.com/%(namelower)s/%(namelower)s/releases/download/v6.1.0']
 
 builddependencies = [
     ('cray-fftw/3.3.6.5', EXTERNAL_MODULE),

--- a/easybuild/easyconfigs/c/CP2K/CP2K-6.1-CrayGNU-18.08.psmp
+++ b/easybuild/easyconfigs/c/CP2K/CP2K-6.1-CrayGNU-18.08.psmp
@@ -1,17 +1,18 @@
 # contributed by Luca Marsella (CSCS)
-# modules: CrayGNU cray-fftw cray-python cudatoolkit Libint libxc flex Bison
+# modules: CrayGNU cray-fftw cray-python cudatoolkit ELPA Libint libxc flex Bison
 CC       = cc
 CPP      = 
 FC       = ftn
 LD       = ftn
 AR       = ar -r
 CPPFLAGS =
-DFLAGS   = -D__FFTW3 -D__parallel -D__SCALAPACK -D__HAS_smm_dnn -D__FFTSG -D__LIBINT -D__LIBXC -D__GFORTRAN
+DFLAGS   = -D__FFTW3 -D__parallel -D__SCALAPACK -D__HAS_smm_dnn -D__FFTSG -D__ELPA=201611 -D__LIBINT -D__LIBXC -D__GFORTRAN
 CFLAGS   = $(DFLAGS)
 FCFLAGS  = $(DFLAGS) -O3 -mavx -fopenmp -funroll-loops -ffast-math -ftree-vectorize -ffree-form -ffree-line-length-512 
-FCFLAGS  += -I$(EBROOTLIBINT)/include -I$(EBROOTLIBXC)/include
+FCFLAGS  += -I$(ELPA_INCLUDE_DIR)/elpa -I$(ELPA_INCLUDE_DIR)/modules -I$(EBROOTLIBINT)/include -I$(EBROOTLIBXC)/include
 LDFLAGS  = $(FCFLAGS)
 LIBS   	 = -lfftw3 -lfftw3_threads 
+LIBS     += -L$(ELPA_LIBRARY_DIR) -lelpa_openmp
 LIBS     += $(EBROOTLIBINT)/lib/libderiv.a $(EBROOTLIBINT)/lib/libint.a $(EBROOTLIBINT)/lib/libr12.a -lstdc++ 
 LIBS     += -L$(EBROOTLIBXC)/lib -lxcf03 -lxc 
 LIBS     += /apps/common/UES/easybuild/sources/c/CP2K/libsmm_dnn_cray.gnu.a

--- a/easybuild/easyconfigs/e/ELPA/ELPA-2016.11.001.pre-CrayGNU-18.08.eb
+++ b/easybuild/easyconfigs/e/ELPA/ELPA-2016.11.001.pre-CrayGNU-18.08.eb
@@ -1,0 +1,29 @@
+# contributed by Luca Marsella (CSCS)
+easyblock = 'ConfigureMake'
+
+name = 'ELPA'
+version = "2016.11.001.pre"
+
+homepage = 'http://elpa.rzg.mpg.de'
+description = """Eigenvalue SoLvers for Petaflop-Applications ."""
+
+toolchain = {'name': 'CrayGNU', 'version': '18.08'}
+toolchainopts = {'usempi': True, 'openmp': True}
+
+source_urls = ['http://elpa.mpcdf.mpg.de/html/Releases/%(version)s/']
+sources = [SOURCELOWER_TAR_GZ]
+
+preconfigopts = ' CC=cc FC=ftn CPP=cpp FCPP=cpp '
+configopts = '--enable-openmp --enable-static'
+
+sanity_check_paths = {
+    'files': ['lib/libelpa_openmp.a', 'lib/libelpa_openmp.%s' % SHLIB_EXT],
+    'dirs': ['bin', 'include/elpa_openmp-%(version)s/elpa', 'include/elpa_openmp-%(version)s/modules', 'lib/pkgconfig']
+}
+
+modextrapaths = {'CPATH': ['include/elpa_openmp-%(version)s/elpa']}
+modextravars = {
+    'ELPA_INCLUDE_DIR': '$root/include/elpa_openmp-%(version)s',
+    'ELPA_LIBRARY_DIR': '$root/lib'
+}
+moduleclass = 'math'

--- a/easybuild/easyconfigs/e/ELPA/ELPA-2017.11.001-CrayGNU-18.08.eb
+++ b/easybuild/easyconfigs/e/ELPA/ELPA-2017.11.001-CrayGNU-18.08.eb
@@ -1,0 +1,29 @@
+# contributed by Luca Marsella (CSCS)
+easyblock = 'ConfigureMake'
+
+name = 'ELPA'
+version = '2017.11.001'
+
+homepage = 'http://elpa.rzg.mpg.de'
+description = """Eigenvalue SoLvers for Petaflop-Applications ."""
+
+toolchain = {'name': 'CrayGNU', 'version': '18.08'}
+toolchainopts = {'usempi': True, 'openmp': True}
+
+source_urls = ['http://elpa.mpcdf.mpg.de/html/Releases/%(version)s/']
+sources = [SOURCELOWER_TAR_GZ]
+
+preconfigopts = ' CC=cc FC=ftn CPP=cpp FCPP=cpp '
+configopts = '--enable-openmp --enable-static'
+
+sanity_check_paths = {
+    'files': ['lib/libelpa_openmp.a', 'lib/libelpa_openmp.%s' % SHLIB_EXT],
+    'dirs': ['bin', 'include/elpa_openmp-%(version)s/elpa', 'include/elpa_openmp-%(version)s/modules', 'lib/pkgconfig']
+}
+
+modextrapaths = {'CPATH': ['include/elpa_openmp-%(version)s/elpa']}
+modextravars = {
+    'ELPA_INCLUDE_DIR': '$root/include/elpa_openmp-%(version)s',
+    'ELPA_LIBRARY_DIR': '$root/lib'
+}
+moduleclass = 'math'

--- a/easybuild/easyconfigs/e/ELPA/ELPA-2018.11.001-CrayGNU-18.08.eb
+++ b/easybuild/easyconfigs/e/ELPA/ELPA-2018.11.001-CrayGNU-18.08.eb
@@ -1,0 +1,29 @@
+# contributed by Luca Marsella (CSCS)
+easyblock = 'ConfigureMake'
+
+name = 'ELPA'
+version = '2018.11.001'
+
+homepage = 'http://elpa.rzg.mpg.de'
+description = """Eigenvalue SoLvers for Petaflop-Applications ."""
+
+toolchain = {'name': 'CrayGNU', 'version': '18.08'}
+toolchainopts = {'usempi': True, 'openmp': True}
+
+source_urls = ['http://elpa.mpcdf.mpg.de/html/Releases/%(version)s/']
+sources = [SOURCELOWER_TAR_GZ]
+
+preconfigopts = ' CC=cc FC=ftn CPP=cpp FCPP=cpp '
+configopts = '--enable-openmp --enable-static'
+
+sanity_check_paths = {
+    'files': ['lib/libelpa_openmp.a', 'lib/libelpa_openmp.%s' % SHLIB_EXT],
+    'dirs': ['bin', 'include/elpa_openmp-%(version)s/elpa', 'include/elpa_openmp-%(version)s/modules', 'lib/pkgconfig']
+}
+
+modextrapaths = {'CPATH': ['include/elpa_openmp-%(version)s/elpa']}
+modextravars = {
+    'ELPA_INCLUDE_DIR': '$root/include/elpa_openmp-%(version)s',
+    'ELPA_LIBRARY_DIR': '$root/lib'
+}
+moduleclass = 'math'


### PR DESCRIPTION
This pull request is addressing CSCS RT #35182. `CP2K` currently supports only `ELPA 2016.11`: I include anyway recipes of two more recent versions of `ELPA` that might be useful for other software packages.