### PR TITLE
[DOM_cle7] Correct unuse patch in machine file

### DIFF
--- a/jenkins/Machines.groovy
+++ b/jenkins/Machines.groovy
@@ -41,7 +41,7 @@ def leone = [name: 'leone',
 def DOM_cle7 = [name: 'DOM_cle7',
            archs: ['gpu', 'mc'],
            buildPath: '$XDG_RUNTIME_DIR/easybuild/build',
-           unusePath: '/apps/dom/UES/jenkins/7.0.UP00/ARCH/easybuild/tools/modules/all:/apps/dom/UES/jenkins/7.0.UP00/ARCH/easybuild/modules/all',
+           unusePath: '/apps/dom/UES/jenkins/6.0.UP07/ARCH/easybuild/tools/modules/all:/apps/dom/UES/jenkins/6.0.UP07/ARCH/easybuild/modules/all',
            modulesProduction: '',
            modulesUnuseProduction: '',
            prefixProduction: '$APPS/UES/jenkins/7.0.UP00/ARCH/easybuild']

--- a/jenkins/Machines.groovy
+++ b/jenkins/Machines.groovy
@@ -41,7 +41,7 @@ def leone = [name: 'leone',
 def DOM_cle7 = [name: 'DOM_cle7',
            archs: ['gpu', 'mc'],
            buildPath: '$XDG_RUNTIME_DIR/easybuild/build',
-           unusePath: '/apps/dom/UES/jenkins/6.0.UP07/ARCH/easybuild/tools/modules/all:/apps/dom/UES/jenkins/6.0.UP07/ARCH/easybuild/modules/all',
+           unusePath: '/apps/dom/UES/jenkins/6.0.UP07/ARCH/easybuild/tools/modules/all:/apps/dom/UES/jenkins/6.0.UP07/ARCH/easybuild/modules/all:/apps/dom/UES/easybuild/modulefiles',
            modulesProduction: '',
            modulesUnuseProduction: '',
            prefixProduction: '$APPS/UES/jenkins/7.0.UP00/ARCH/easybuild']


### PR DESCRIPTION
Correct copy-paste error. Unuse path now points to currently installed modules.