### PR TITLE
[dom] papiwrap for 19.03

### DIFF
--- a/easybuild/easyconfigs/p/papi-wrap/papi-wrap-1.0-CrayCCE-19.03.eb
+++ b/easybuild/easyconfigs/p/papi-wrap/papi-wrap-1.0-CrayCCE-19.03.eb
@@ -1,0 +1,32 @@
+# jgp@cscs
+easyblock = 'MakeCp'
+
+name = "papi-wrap"
+version = "1.0"
+homepage = 'https://github.com/bcumming/papi-wrap'
+description = """wrappers around papi hardware counters."""
+
+toolchain = {'name': 'CrayCCE', 'version': '19.03'}
+source_urls = [ ' https://github.com/jgphpc/papi-wrap/archive/' ]
+sources = [ '%(version)s.tar.gz' ]
+checksums = [ 'e72a6c1d631ffb600e9cea1a0b4da947' ]
+
+# papi provided by perftools-base since 7.0.2, otherwise, use :
+# dependencies = [ ('papi/5.6.0.2', EXTERNAL_MODULE), ]
+
+parallel = 1
+prebuildopts = ' ln -fs cscs/makefile . ;'
+
+files_to_copy = [
+    (['libpapi_wrap.a'], 'lib'),
+    (['*.mod'], 'include'),
+]
+
+sanity_check_paths = {
+    'files': [ 'lib/libpapi_wrap.a', ],
+    'dirs': [],
+}
+
+modextravars = { 'CSCSPERF_EVENTS' : 'PAPI_TOT_CYC|PAPI_TOT_INS', }
+
+moduleclass = 'perf'

--- a/easybuild/easyconfigs/p/papi-wrap/papi-wrap-1.0-CrayGNU-19.03.eb
+++ b/easybuild/easyconfigs/p/papi-wrap/papi-wrap-1.0-CrayGNU-19.03.eb
@@ -1,0 +1,32 @@
+# jgp@cscs
+easyblock = 'MakeCp'
+
+name = "papi-wrap"
+version = "1.0"
+homepage = 'https://github.com/bcumming/papi-wrap'
+description = """wrappers around papi hardware counters."""
+
+toolchain = {'name': 'CrayGNU', 'version': '19.03'}
+source_urls = [ ' https://github.com/jgphpc/papi-wrap/archive/' ]
+sources = [ '%(version)s.tar.gz' ]
+checksums = [ 'e72a6c1d631ffb600e9cea1a0b4da947' ]
+
+# papi provided by perftools-base since 7.0.2, otherwise, use :
+# dependencies = [ ('papi/5.6.0.2', EXTERNAL_MODULE), ]
+
+parallel = 1
+prebuildopts = ' ln -fs cscs/makefile . ;'
+
+files_to_copy = [
+    (['libpapi_wrap.a'], 'lib'),
+    (['*.mod'], 'include'),
+]
+
+sanity_check_paths = {
+    'files': [ 'lib/libpapi_wrap.a', ],
+    'dirs': [],
+}
+
+modextravars = { 'CSCSPERF_EVENTS' : 'PAPI_TOT_CYC|PAPI_TOT_INS', }
+
+moduleclass = 'perf'

--- a/easybuild/easyconfigs/p/papi-wrap/papi-wrap-1.0-CrayIntel-19.03.eb
+++ b/easybuild/easyconfigs/p/papi-wrap/papi-wrap-1.0-CrayIntel-19.03.eb
@@ -1,0 +1,32 @@
+# jgp@cscs
+easyblock = 'MakeCp'
+
+name = "papi-wrap"
+version = "1.0"
+homepage = 'https://github.com/bcumming/papi-wrap'
+description = """wrappers around papi hardware counters."""
+
+toolchain = {'name': 'CrayIntel', 'version': '19.03'}
+source_urls = [ ' https://github.com/jgphpc/papi-wrap/archive/' ]
+sources = [ '%(version)s.tar.gz' ]
+checksums = [ 'e72a6c1d631ffb600e9cea1a0b4da947' ]
+
+# papi provided by perftools-base since 7.0.2, otherwise, use :
+# dependencies = [ ('papi/5.6.0.2', EXTERNAL_MODULE), ]
+
+parallel = 1
+prebuildopts = ' ln -fs cscs/makefile . ;'
+
+files_to_copy = [
+    (['libpapi_wrap.a'], 'lib'),
+    (['*.mod'], 'include'),
+]
+
+sanity_check_paths = {
+    'files': [ 'lib/libpapi_wrap.a', ],
+    'dirs': [],
+}
+
+modextravars = { 'CSCSPERF_EVENTS' : 'PAPI_TOT_CYC|PAPI_TOT_INS', }
+
+moduleclass = 'perf'


### PR DESCRIPTION
```
 papi-wrap-1.0-CrayGNU-19.03.eb                     --set-default-module --installpath=$APPS/UES/jenkins/7.0.UP00/gpu/easybuild/tools
 papi-wrap-1.0-CrayCCE-19.03.eb                                          --installpath=$APPS/UES/jenkins/7.0.UP00/gpu/easybuild/tools
 papi-wrap-1.0-CrayIntel-19.03.eb                                        --installpath=$APPS/UES/jenkins/7.0.UP00/gpu/easybuild/tools
```

```
 papi-wrap-1.0-CrayGNU-19.03.eb                     --set-default-module --installpath=$APPS/UES/jenkins/7.0.UP00/mc/easybuild/tools
 papi-wrap-1.0-CrayCCE-19.03.eb                                          --installpath=$APPS/UES/jenkins/7.0.UP00/mc/easybuild/tools
 papi-wrap-1.0-CrayIntel-19.03.eb                                        --installpath=$APPS/UES/jenkins/7.0.UP00/mc/easybuild/tools
```