### PR TITLE
[daint] added the Mako package, necessary to configure the new Mesa 18

### DIFF
--- a/easybuild/easyconfigs/p/PyExtensions/PyExtensions-2.7.15.1-CrayGNU-18.08.eb
+++ b/easybuild/easyconfigs/p/PyExtensions/PyExtensions-2.7.15.1-CrayGNU-18.08.eb
@@ -40,6 +40,9 @@ exts_list = [
      ('virtualenv', '16.0.0', {
          'source_urls': ['https://pypi.python.org/packages/source/v/virtualenv/'],
      }),
+     ('Mako', '1.0.8', {
+        'source_urls': ['https://pypi.python.org/packages/source/m/mako/'],
+     }),
  ]
 
 # specify that Bundle easyblock should run a full sanity check, rather than just trying to load the module

--- a/easybuild/easyconfigs/p/PyExtensions/PyExtensions-3.6.5.1-CrayGNU-18.08.eb
+++ b/easybuild/easyconfigs/p/PyExtensions/PyExtensions-3.6.5.1-CrayGNU-18.08.eb
@@ -43,6 +43,11 @@ exts_list = [
         'req_py_minver': '6',
         'source_urls': ['https://pypi.python.org/packages/source/p/pandas/'],
     }),
+    ('Mako', '1.0.8', {
+        'req_py_majver': '3',
+        'req_py_minver': '6',
+        'source_urls': ['https://pypi.python.org/packages/source/m/mako/'],
+    }),
 ]
 
 # specify that Bundle easyblock should run a full sanity check, rather than just trying to load the module


### PR DESCRIPTION
build was tested and log file is here:

/scratch/snx3000/jfavre/daint/software/PyExtensions/3.6.5.1-CrayGNU-18.08/easybuild/easybuild-PyExtensions-3.6.5.1-20190408.151848.log

I then successfully built Mesa and then ParaView with it.