### PR TITLE
[dom] update of dependencies for Lmod

### DIFF
--- a/easybuild/easyconfigs/l/Lua/Lua-5.1.4.9-xalt.eb
+++ b/easybuild/easyconfigs/l/Lua/Lua-5.1.4.9-xalt.eb
@@ -21,7 +21,7 @@ sources = ['lua-%(version)s.tar.bz2']
 
 builddependencies = [
     #('ncurses', '6.0'),
-    ('libreadline', '7.0-xalt')
+    ('libreadline', '8.0-xalt')
 ]
 
 # Use static linking for ncurses so it's not a runtime dep

--- a/easybuild/easyconfigs/l/libreadline/libreadline-8.0-xalt.eb
+++ b/easybuild/easyconfigs/l/libreadline/libreadline-8.0-xalt.eb
@@ -1,0 +1,32 @@
+# contributed by Luca Marsella (CSCS)
+easyblock = 'ConfigureMake'
+
+name = 'libreadline'
+version = "8.0"
+versionsuffix = '-xalt'
+checksums = []
+homepage = 'http://cnswww.cns.cwru.edu/php/chet/readline/rltop.html'
+description = """The GNU Readline library provides a set of functions for use by applications that
+ allow users to edit command lines as they are typed in. Both Emacs and vi editing modes are available.
+ The Readline library includes additional functions to maintain a list of previously-entered command lines,
+ to recall and perhaps reedit those lines, and perform csh-like history expansion on previous commands."""
+
+toolchain = {'name': 'dummy', 'version': ''}
+toolchainopts = {'pic': True}
+
+source_urls = ['http://ftp.gnu.org/gnu/readline']
+sources = ['readline-%(version)s.tar.gz']
+# unset EBROOTLIBREADLINE
+
+# for the termcap symbols, use EB ncurses
+#dependencies = [('ncurses', '6.0')]
+#preconfigopts = "LDFLAGS='-lncurses'"
+
+sanity_check_paths = {
+    'files' : ['lib/libreadline.a', 'lib/libhistory.a'] +
+              ['include/readline/%s' % x for x in ['chardefs.h', 'history.h', 'keymaps.h', 'readline.h', 'rlconf.h',
+                                                   'rlstdc.h', 'rltypedefs.h', 'tilde.h']],
+    'dirs' : [],
+}
+
+moduleclass = 'lib'


### PR DESCRIPTION
There was an issue with libreadline 7.0 on the system. Version 8.0 removes the issue. Locally, the `Lmod` build now passes.