### PR TITLE
[dom] update ospray to 1.8.4  for TC 19.03

### DIFF
--- a/easybuild/easyconfigs/o/ospray/ospray-1.8.4-CrayGNU-19.03.eb
+++ b/easybuild/easyconfigs/o/ospray/ospray-1.8.4-CrayGNU-19.03.eb
@@ -1,0 +1,20 @@
+easyblock = "Tarball"
+
+name = 'ospray'
+version = '1.8.4'
+
+homepage = 'https://github.com/ospray'
+description = """An Open, Scalable, Parallel, Ray Tracing Based Rendering
+Engine for High-Fidelity Visualization"""
+
+toolchain = {'name': 'CrayGNU', 'version': '19.03'}
+
+sources = ['ospray-%(version)s.x86_64.linux.tar.gz']
+source_urls = ['https://github.com/ospray/ospray/releases/download/v%(version)s/']
+
+sanity_check_paths={
+    'files': [],
+    'dirs': ['include', 'lib']
+}
+
+moduleclass = 'devel'


### PR DESCRIPTION
COMPLETED: Installation ended successfully
== Results of the build can be found in the log file(s) /scratch/snx1600tds/jfavre/daint/software/ospray/1.8.4-CrayGNU-19.03/easybuild/easybuild-ospray-1.8.4-20190410.142820.log
== Build succeeded for 1 out of 1

this is used by both ParaView versions