### PR TITLE
[dom-gpu] Plumed 2.5.1 with CrayGNU 19.03

### DIFF
--- a/easybuild/easyconfigs/b/byacc/byacc-20170709-CrayGNU-19.03.eb
+++ b/easybuild/easyconfigs/b/byacc/byacc-20170709-CrayGNU-19.03.eb
@@ -1,0 +1,22 @@
+# contributed by Luca Marsella (CSCS)
+easyblock = 'ConfigureMake'
+
+name = 'byacc'
+version = '20170709'
+
+homepage = 'http://invisible-island.net/byacc/byacc.html'
+description = """Berkeley Yacc (byacc) is generally conceded to be the best yacc variant available.
+In contrast to bison, it is written to avoid dependencies upon a particular compiler."""
+
+toolchain = {'name': 'CrayGNU', 'version': '19.03'}
+
+source_urls = ['http://download.openpkg.org/components/cache/%(name)s/']
+sources = [SOURCELOWER_TGZ]
+
+
+sanity_check_paths = {
+    'files': ['bin/yacc'],
+    'dirs': [],
+}
+
+moduleclass = 'lang'

--- a/easybuild/easyconfigs/g/GMP/GMP-6.1.2-CrayGNU-19.03.eb
+++ b/easybuild/easyconfigs/g/GMP/GMP-6.1.2-CrayGNU-19.03.eb
@@ -1,0 +1,27 @@
+# contributed by Guilherme Peretti Pezzi and Luca Marsella (CSCS)
+easyblock = 'ConfigureMake'
+
+name = 'GMP'
+version = "6.1.2"
+
+homepage = 'http://gmplib.org/'
+description = """GMP is a free library for arbitrary precision arithmetic,
+operating on signed integers, rational numbers, and floating point numbers. """
+
+toolchain = {'name': 'CrayGNU', 'version': '19.03'}
+
+sources = [SOURCELOWER_TAR_BZ2]
+source_urls = [GNU_SOURCE]
+
+preconfigopts = 'export CFLAGS="$CFLAGS -mcmodel=large" && '
+
+# the output of config.guess is used by default. 
+# It can be changed with the option --build=...
+# E.g.: configopts = ' --build=haswell-pc-linux-gnu'
+
+sanity_check_paths = {
+    'files': ['lib/libgmp.%s' % SHLIB_EXT, 'include/gmp.h'],
+    'dirs': [],
+}
+
+moduleclass = 'math'

--- a/easybuild/easyconfigs/g/gc/gc-7.6.0-CrayGNU-19.03.eb
+++ b/easybuild/easyconfigs/g/gc/gc-7.6.0-CrayGNU-19.03.eb
@@ -1,0 +1,29 @@
+# contributed by Luca Marsella (CSCS)
+easyblock = 'ConfigureMake'
+
+name = 'gc'
+version = '7.6.0'
+
+homepage = 'http://hboehm.info/gc/'
+description = """The Boehm-Demers-Weiser conservative garbage collector can be used as a garbage collecting
+ replacement for C malloc or C++ new."""
+
+toolchain = {'name': 'CrayGNU', 'version': '19.03'}
+
+source_urls = [
+    'https://github.com/ivmai/bdwgc/archive/', # gc7_6_0.tar.gz
+    'https://github.com/ivmai/libatomic_ops/archive/' # libatomic_ops-7_4_4.tar.gz
+]
+sources = [
+    'gc7_6_0.tar.gz',
+    'libatomic_ops-7_4_4.tar.gz'
+]
+
+preconfigopts = "ln -s %(builddir)s/libatomic_ops*/ libatomic_ops && ./autogen.sh && "
+
+sanity_check_paths = {
+    'files': ['include/gc.h', 'lib/libcord.a', 'lib/libcord.%s' % SHLIB_EXT, 'lib/libgc.a', 'lib/libgc.%s' % SHLIB_EXT],
+    'dirs': ['include/gc', 'share'],
+}
+
+moduleclass = 'lib'

--- a/easybuild/easyconfigs/g/guile/guile-2.0.14-CrayGNU-19.03.eb
+++ b/easybuild/easyconfigs/g/guile/guile-2.0.14-CrayGNU-19.03.eb
@@ -1,0 +1,32 @@
+# contributed by Luca Marsella (CSCS)
+easyblock = 'ConfigureMake'
+
+name = 'guile'
+version = "2.0.14"
+
+homepage = 'http://www.gnu.org/software/guile'
+description = """Guile is the GNU Ubiquitous Intelligent Language for Extensions,
+the official extension language for the GNU operating system."""
+toolchain = {'name': 'CrayGNU', 'version': '19.03'}
+
+sources = [SOURCELOWER_TAR_GZ]
+source_urls = [GNU_SOURCE]
+
+dependencies = [
+    ('GMP', '6.1.2'),
+    ('gc', '7.6.0'),
+    ('libunistring', '0.9.10'),
+    ('libffi', '3.2.1'),
+    ('libreadline', '8.0'),
+    ('libtool', '2.4.6'),
+]
+
+preconfigopts = " export CC=gcc && unset CFLAGS && export CXX=g++ && unset CXXFLAGS &&"
+configopts = " --enable-error-on-warning=no"
+
+sanity_check_paths = {
+    'files': ["bin/%s" % x for x in ["guile", 'guile-config', 'guile-snarf', 'guile-tools']] + ["lib/libguile-%(version_major_minor)s.a", "include/guile/%(version_major_minor)s/libguile.h"],
+    'dirs': []
+}
+
+moduleclass = 'devel'

--- a/easybuild/easyconfigs/l/libffi/libffi-3.2.1-CrayGNU-19.03.eb
+++ b/easybuild/easyconfigs/l/libffi/libffi-3.2.1-CrayGNU-19.03.eb
@@ -1,0 +1,29 @@
+# Contributed by Luca Marsella (CSCS)
+easyblock = 'ConfigureMake'
+
+name = 'libffi'
+version = '3.2.1'
+
+homepage = 'http://sourceware.org/libffi'
+description = """The libffi library provides a portable, high level programming interface to various calling conventions.
+This allows a programmer to call any function specified by a call interface description at run-time.
+
+FFI stands for Foreign Function Interface. A foreign function interface is the popular name for the interface that
+allows code written in one language to call code written in another language."""
+
+toolchain = {'name': 'CrayGNU', 'version': '19.03'}
+
+source_urls = [
+    'ftp://sourceware.org/pub/libffi/',
+    'http://www.mirrorservice.org/sites/sourceware.org/pub/libffi/',
+]
+sources = [SOURCELOWER_TAR_GZ]
+
+prebuildopts = "find -name Makefile -exec sed -i '/^gcc/d' '{}' \; && "
+
+sanity_check_paths = {
+    'files': ['lib64/libffi.a'],
+    'dirs': [],
+}
+
+moduleclass = 'lib'

--- a/easybuild/easyconfigs/l/libmatheval/libmatheval-1.1.11-CrayGNU-19.03.eb
+++ b/easybuild/easyconfigs/l/libmatheval/libmatheval-1.1.11-CrayGNU-19.03.eb
@@ -1,0 +1,38 @@
+# contributed by Luca Marsella (CSCS)
+easyblock = 'ConfigureMake'
+
+name = 'libmatheval'
+version = '1.1.11'
+
+homepage = 'http://www.gnu.org/software/libmatheval/'
+description = """GNU libmatheval is a library (callable from C and Fortran) to parse
+ and evaluate symbolic expressions input as text."""
+
+source_urls = [GNU_SOURCE]
+sources = [SOURCELOWER_TAR_GZ]
+# patch for configure.in with guile2 from https://github.com/pld-linux/libmatheval/blob/master/libmatheval-guile2.patch
+patches = ['libmatheval-guile2.patch']
+
+toolchain = {'name': 'CrayGNU', 'version': '19.03'}
+toolchainopts = {'pic': True}
+
+dependencies = [
+    ('flex', '2.6.4'),
+    ('Bison', '3.3.2'),
+    ('byacc', '20170709'),
+    ('guile', '2.0.14'),
+]
+
+preconfigopts = " export CC=gcc && unset CFLAGS && export CXX=g++ && unset CXXFLAGS &&"
+
+configopts = '--with-pic '
+
+# fix for guile-config being broken because shebang line contains full path to bin/guile
+configopts += 'GUILE_CONFIG="$EBROOTGUILE/bin/guile -e main -s $EBROOTGUILE/bin/guile-config"'
+
+sanity_check_paths = {
+    'files': ['lib/libmatheval.a', 'include/matheval.h'],
+    'dirs': [],
+}
+
+moduleclass = 'lib'

--- a/easybuild/easyconfigs/l/libreadline/libreadline-8.0-CrayGNU-19.03.eb
+++ b/easybuild/easyconfigs/l/libreadline/libreadline-8.0-CrayGNU-19.03.eb
@@ -1,0 +1,28 @@
+# contributed by Luca Marsella (CSCS) 
+easyblock = 'ConfigureMake'
+
+name = 'libreadline'
+version = "8.0"
+
+homepage = 'http://cnswww.cns.cwru.edu/php/chet/readline/rltop.html'
+description = """The GNU Readline library provides a set of functions for use by applications that
+ allow users to edit command lines as they are typed in. Both Emacs and vi editing modes are available.
+ The Readline library includes additional functions to maintain a list of previously-entered command lines,
+ to recall and perhaps reedit those lines, and perform csh-like history expansion on previous commands."""
+
+toolchain = {'name': 'CrayGNU', 'version': '19.03'}
+toolchainopts = {'pic': True}
+
+sources = ['readline-%(version)s.tar.gz']
+source_urls = ['http://ftp.gnu.org/gnu/readline']
+
+dependencies = [('ncurses', '6.1')]
+
+sanity_check_paths = {
+    'files' : ['lib/libreadline.a', 'lib/libhistory.a'] +
+              ['include/readline/%s' % x for x in ['chardefs.h', 'history.h', 'keymaps.h', 'readline.h', 'rlconf.h',
+                                                   'rlstdc.h', 'rltypedefs.h', 'tilde.h']],
+    'dirs' : [],
+}
+
+moduleclass = 'lib'

--- a/easybuild/easyconfigs/l/libtool/libtool-2.4.6-CrayGNU-19.03.eb
+++ b/easybuild/easyconfigs/l/libtool/libtool-2.4.6-CrayGNU-19.03.eb
@@ -1,0 +1,18 @@
+# @author: Guilherme Peretti Pezzi and Luca Marsella (CSCS)
+easyblock = 'ConfigureMake'
+
+name = 'libtool'
+version = '2.4.6'
+
+homepage = 'http://www.gnu.org/software/libtool'
+description = """GNU libtool is a generic library support script. Libtool hides the complexity of using shared libraries
+ behind a consistent, portable interface."""
+
+toolchain = {'name': 'CrayGNU', 'version': '19.03'}
+
+sources = [SOURCELOWER_TAR_GZ]
+source_urls = [GNU_SOURCE]
+
+dependencies = [('M4', '1.4.18')]
+
+moduleclass = 'lib'

--- a/easybuild/easyconfigs/l/libunistring/libunistring-0.9.10-CrayGNU-19.03.eb
+++ b/easybuild/easyconfigs/l/libunistring/libunistring-0.9.10-CrayGNU-19.03.eb
@@ -1,0 +1,23 @@
+# Contributed by Luca Marsella (CSCS)
+easyblock = 'ConfigureMake'
+
+name = 'libunistring'
+version = '0.9.10'
+
+homepage = 'http://www.gnu.org/software/libunistring/'
+description = """This library provides functions for manipulating Unicode strings and for manipulating C strings
+according to the Unicode standard."""
+
+toolchain = {'name': 'CrayGNU', 'version': '19.03'}
+
+sources = [SOURCELOWER_TAR_GZ]
+source_urls = [GNU_SOURCE]
+
+sanity_check_paths = {
+    'files' : ['lib/libunistring.a', 'lib/libunistring.so'] +
+              ['include/uni%s.h' % x for x in ['case', 'conv', 'ctype', 'gbrk', 'lbrk', 'name', 'norm',
+                                               'stdio', 'str', 'types', 'wbrk', 'width']],
+    'dirs' : ['include/unistring'],
+}
+
+moduleclass = 'lib'

--- a/easybuild/easyconfigs/n/ncurses/ncurses-6.1-CrayGNU-19.03.eb
+++ b/easybuild/easyconfigs/n/ncurses/ncurses-6.1-CrayGNU-19.03.eb
@@ -1,0 +1,25 @@
+# contributed by Luca Marsella (CSCS)
+name = 'ncurses'
+version = '6.1'
+
+homepage = 'http://www.gnu.org/software/ncurses/'
+description = """The Ncurses (new curses) library is a free software emulation
+of curses in System V Release 4.0, and more. It uses Terminfo format, supports
+pads and color and multiple highlights and forms characters and function-key
+mapping, and has all the other SYSV-curses enhancements over BSD Curses."""
+
+toolchain = {'name': 'CrayGNU', 'version': '19.03'}
+toolchainopts = {'optarch': True, 'pic': True}
+
+source_urls = [GNU_SOURCE]
+sources = [SOURCE_TAR_GZ]
+
+sanity_check_paths = {
+    'files' : ['bin/%s' % x for x in ["captoinfo", "clear", "infocmp",
+                                      "infotocap", "ncurses6-config", "reset", 
+                                      "tabs", "tic", "toe", "tput", "tset"]]
++ ['lib/lib%s.a' % x for x in ["form", "form", "menu", "menu_g", "ncurses",
+"ncurses++", "ncurses_g", "panel", "panel_g"]], 'dirs' : ['include']
+}
+
+moduleclass = 'devel'

--- a/easybuild/easyconfigs/p/PLUMED/PLUMED-2.5.1-CrayGNU-19.03.eb
+++ b/easybuild/easyconfigs/p/PLUMED/PLUMED-2.5.1-CrayGNU-19.03.eb
@@ -1,0 +1,41 @@
+# by Ward Poelmans <wpoely86@gmail.com>
+# Modified by Luca Marsella (CSCS)
+easyblock = 'ConfigureMake'
+
+name = 'PLUMED'
+version = "2.5.1"
+
+homepage = 'http://www.plumed-code.org'
+description = """PLUMED is an open source library for free energy calculations in molecular systems which
+ works together with some of the most popular molecular dynamics engines. Free energy calculations can be
+ performed as a function of many order parameters with a particular  focus on biological problems, using
+ state of the art methods such as metadynamics, umbrella sampling and Jarzynski-equation based steered MD.
+ The software, written in C++, can be easily interfaced with both fortran and C/C++ codes.
+"""
+
+toolchain = {'name': 'CrayGNU', 'version': '19.03'}
+toolchainopts = {'usempi': 'True'}
+
+source_urls = ['https://github.com/plumed/plumed2/archive/']
+sources = ['v%(version)s.tar.gz']
+
+dependencies = [
+    ('zlib', '1.2.11'),
+    ('GSL', '2.5'),
+    ('libmatheval', '1.1.11')
+]
+
+configopts = ' --exec-prefix=%(installdir)s --enable-gsl --enable-matheval --enable-modules=all'
+prebuildopts = 'source sourceme.sh && '
+
+sanity_check_paths = {
+    'files': ['bin/plumed', 'lib/libplumedKernel.%s' % SHLIB_EXT, 'lib/libplumed.%s' % SHLIB_EXT],
+    'dirs': ['lib/plumed']
+}
+
+modextrapaths = {
+    'PLUMED_KERNEL': 'lib/libplumedKernel.%s' % SHLIB_EXT,
+    'PLUMED_ROOT': 'lib/plumed',
+}
+
+moduleclass = 'chem'


### PR DESCRIPTION
`PLUMED 2.5` was already built on Piz Daint following a user's request. 

I have removed the following from `GMP`: `toolchainopts = {'lowopt': True}`. I recall that it was required to build successfully, but with the current toolchain it's not necessary anymore.
Please kindly correct the recipe otherwise.