### PR TITLE
[dom-gpu] Plumed 2.5.1 with CrayIntel 19.03

### DIFF
--- a/easybuild/easyconfigs/b/Bison/Bison-3.3.2-CrayIntel-19.03.eb
+++ b/easybuild/easyconfigs/b/Bison/Bison-3.3.2-CrayIntel-19.03.eb
@@ -17,8 +17,6 @@ dependencies = [
     ('M4', '1.4.18'),
 ]
 
-prebuildopts = " module switch intel intel/19.0.1.144 && "
-
 sanity_check_paths = {
     'files': ['bin/%(namelower)s', 'bin/yacc', 'lib/liby.a'],
     'dirs': [],

--- a/easybuild/easyconfigs/b/Bison/Bison-3.3.2-CrayIntel-19.03.eb
+++ b/easybuild/easyconfigs/b/Bison/Bison-3.3.2-CrayIntel-19.03.eb
@@ -1,0 +1,26 @@
+# Contributed by jg and Luca Marsella (CSCS)
+easyblock = 'ConfigureMake'
+
+name = 'Bison'
+version = '3.3.2'
+
+homepage = 'http://www.gnu.org/software/bison'
+description = """Bison is a general-purpose parser generator that converts an annotated context-free grammar
+ into a deterministic LR or generalized LR (GLR) parser employing LALR(1) parser tables."""
+
+toolchain = {'name': 'CrayIntel', 'version': '19.03'}
+
+source_urls = [GNU_SOURCE]
+sources = [SOURCELOWER_TAR_GZ]
+
+dependencies = [
+    ('M4', '1.4.18'),
+]
+
+
+sanity_check_paths = {
+    'files': ['bin/%(namelower)s', 'bin/yacc', 'lib/liby.a'],
+    'dirs': [],
+}
+
+moduleclass = 'lang'

--- a/easybuild/easyconfigs/b/Bison/Bison-3.3.2-CrayIntel-19.03.eb
+++ b/easybuild/easyconfigs/b/Bison/Bison-3.3.2-CrayIntel-19.03.eb
@@ -17,6 +17,7 @@ dependencies = [
     ('M4', '1.4.18'),
 ]
 
+prebuildopts = " module switch intel intel/19.0.1.144 && "
 
 sanity_check_paths = {
     'files': ['bin/%(namelower)s', 'bin/yacc', 'lib/liby.a'],

--- a/easybuild/easyconfigs/b/binutils/binutils-2.32-CrayIntel-19.03.eb
+++ b/easybuild/easyconfigs/b/binutils/binutils-2.32-CrayIntel-19.03.eb
@@ -1,0 +1,22 @@
+# contributed by Luca Marsella (CSCS)
+name = 'binutils'
+version = '2.32'
+
+homepage = 'http://directory.fsf.org/project/binutils/'
+
+description = "binutils: GNU binary utilities"
+
+toolchain = {'name': 'CrayIntel', 'version': '19.03'}
+
+source_urls = [GNU_SOURCE]
+sources = [SOURCE_TAR_GZ]
+
+builddependencies = [
+    ('Bison', '3.3.2'),
+    ('flex', '2.6.4'),
+    ('zlib', '1.2.11'),
+]
+
+configopts = " --enable-gold=yes " 
+
+moduleclass = 'tools'

--- a/easybuild/easyconfigs/b/byacc/byacc-20170709-CrayIntel-19.03.eb
+++ b/easybuild/easyconfigs/b/byacc/byacc-20170709-CrayIntel-19.03.eb
@@ -1,0 +1,22 @@
+# contributed by Luca Marsella (CSCS)
+easyblock = 'ConfigureMake'
+
+name = 'byacc'
+version = '20170709'
+
+homepage = 'http://invisible-island.net/byacc/byacc.html'
+description = """Berkeley Yacc (byacc) is generally conceded to be the best yacc variant available.
+In contrast to bison, it is written to avoid dependencies upon a particular compiler."""
+
+toolchain = {'name': 'CrayIntel', 'version': '19.03'}
+
+source_urls = ['http://download.openpkg.org/components/cache/%(name)s/']
+sources = [SOURCELOWER_TGZ]
+
+
+sanity_check_paths = {
+    'files': ['bin/yacc'],
+    'dirs': [],
+}
+
+moduleclass = 'lang'

--- a/easybuild/easyconfigs/c/CrayIntel/CrayIntel-19.03.eb
+++ b/easybuild/easyconfigs/c/CrayIntel/CrayIntel-19.03.eb
@@ -14,7 +14,7 @@ dependencies = [
     # (default) version
     ('PrgEnv-intel', EXTERNAL_MODULE),
     ('atp/2.1.3', EXTERNAL_MODULE),
-    ('intel/18.0.2.199', EXTERNAL_MODULE),
+    ('intel/19.0.1.144', EXTERNAL_MODULE),
     ('modules/3.2.11.1', EXTERNAL_MODULE),
     ('cray-libsci/19.02.1', EXTERNAL_MODULE),
     ('cray-mpich/7.7.6', EXTERNAL_MODULE),

--- a/easybuild/easyconfigs/f/flex/flex-2.6.4-CrayIntel-19.03.eb
+++ b/easybuild/easyconfigs/f/flex/flex-2.6.4-CrayIntel-19.03.eb
@@ -1,0 +1,21 @@
+# contributed by Jean-Guillaume Piccinali and Luca Marsella (CSCS)
+easyblock = 'ConfigureMake'
+
+name = 'flex'
+version = '2.6.4'
+
+homepage = 'http://flex.sourceforge.net/'
+description = """Flex (Fast Lexical Analyzer) is a tool for generating scanners. A scanner,
+ sometimes called a tokenizer, is a program which recognizes lexical patterns in text."""
+
+toolchain = {'name': 'CrayIntel', 'version': '19.03'}
+
+source_urls = ['https://github.com/westes/%(name)s/releases/download/v%(version)s']
+sources = [SOURCELOWER_TAR_GZ]
+
+builddependencies = [
+    ('Bison', '3.3.2'),
+]
+
+
+moduleclass = 'lang'

--- a/easybuild/easyconfigs/g/GMP/GMP-6.1.2-CrayIntel-19.03.eb
+++ b/easybuild/easyconfigs/g/GMP/GMP-6.1.2-CrayIntel-19.03.eb
@@ -1,0 +1,27 @@
+# contributed by Guilherme Peretti Pezzi and Luca Marsella (CSCS)
+easyblock = 'ConfigureMake'
+
+name = 'GMP'
+version = '6.1.2'
+
+homepage = 'http://gmplib.org/'
+description = """GMP is a free library for arbitrary precision arithmetic, 
+operating on signed integers, rational numbers, and floating point numbers. """
+
+toolchain = {'name': 'CrayIntel', 'version': '19.03'}
+toolchainopts = {'lowopt': True}
+
+source_urls = [GNU_SOURCE]
+sources = [SOURCELOWER_TAR_BZ2]
+
+preconfigopts = 'export CFLAGS="$CFLAGS -mcmodel=large" && '
+
+
+# the output of config.guess is used by default and can be changed with --build
+# configopts = ' --build=haswell-pc-linux-gnu'
+sanity_check_paths = {
+    'files': ['lib/libgmp.so', 'include/%(namelower)s.h'],
+    'dirs': [],
+}
+
+moduleclass = 'math'

--- a/easybuild/easyconfigs/g/GMP/GMP-6.1.2-CrayIntel-19.03.eb
+++ b/easybuild/easyconfigs/g/GMP/GMP-6.1.2-CrayIntel-19.03.eb
@@ -9,16 +9,15 @@ description = """GMP is a free library for arbitrary precision arithmetic,
 operating on signed integers, rational numbers, and floating point numbers. """
 
 toolchain = {'name': 'CrayIntel', 'version': '19.03'}
-toolchainopts = {'lowopt': True}
 
 source_urls = [GNU_SOURCE]
 sources = [SOURCELOWER_TAR_BZ2]
 
 preconfigopts = 'export CFLAGS="$CFLAGS -mcmodel=large" && '
 
-
-# the output of config.guess is used by default and can be changed with --build
-# configopts = ' --build=haswell-pc-linux-gnu'
+# the output of config.guess is used by default. 
+# It can be changed with the option --build=...
+# E.g.: configopts = ' --build=haswell-pc-linux-gnu'
 sanity_check_paths = {
     'files': ['lib/libgmp.so', 'include/%(namelower)s.h'],
     'dirs': [],

--- a/easybuild/easyconfigs/g/gc/gc-7.6.0-CrayIntel-19.03.eb
+++ b/easybuild/easyconfigs/g/gc/gc-7.6.0-CrayIntel-19.03.eb
@@ -1,0 +1,25 @@
+# contributed by Luca Marsella (CSCS)
+easyblock = 'ConfigureMake'
+
+name = 'gc'
+version = '7.6.0'
+
+homepage = 'http://hboehm.info/gc/'
+description = """The Boehm-Demers-Weiser conservative garbage collector can be used as a garbage collecting 
+ replacement for C malloc or C++ new."""
+
+toolchain = {'name': 'CrayIntel', 'version': '19.03'}
+
+source_urls = ['https://github.com/ivmai/bdwgc/archive/', 'https://github.com/ivmai/libatomic_ops/archive/']
+sources = ['gc7_6_0.tar.gz', 'libatomic_ops-7_4_4.tar.gz']
+
+preconfigopts = "ln -s %(builddir)s/libatomic_ops*/ libatomic_ops && ./autogen.sh && "
+configopts = '--enable-threads=pthreads'
+
+
+sanity_check_paths = {
+    'files': ['include/gc.h', 'lib/libcord.a', 'lib/libcord.so', 'lib/libgc.a', 'lib/libgc.so'],
+    'dirs': ['include/gc', 'share'],
+}
+
+moduleclass = 'lib'

--- a/easybuild/easyconfigs/g/guile/guile-2.0.14-CrayIntel-19.03.eb
+++ b/easybuild/easyconfigs/g/guile/guile-2.0.14-CrayIntel-19.03.eb
@@ -1,0 +1,35 @@
+# contributed by Luca Marsella (CSCS)
+easyblock = 'ConfigureMake'
+
+name = 'guile'
+version = '2.0.14'
+
+homepage = 'http://www.gnu.org/software/guile'
+description = """Guile is the GNU Ubiquitous Intelligent Language for Extensions,
+the official extension language for the GNU operating system."""
+
+toolchain = {'name': 'CrayIntel', 'version': '19.03'}
+
+source_urls = [GNU_SOURCE]
+sources = [SOURCELOWER_TAR_GZ]
+
+dependencies = [
+    ('GMP', '6.1.2'),
+    ('gc', '7.6.0'),
+    ('libunistring', '0.9.7'),
+    ('libffi', '3.2.1'),
+    ('libreadline', '8.0'),
+    ('libtool', '2.4.6'),
+]
+
+#preconfigopts = " export CC=cc && unset CFLAGS && export CXX=CC && unset CXXFLAGS &&"
+preconfigopts = "unset CFLAGS && unset CXXFLAGS && "
+configopts = " --enable-error-on-warning=no"
+
+
+sanity_check_paths = {
+    'files': ['bin/%(name)s', 'bin/%(name)s-config', 'bin/%(name)s-snarf', 'bin/%(name)s-tools', 'lib/libguile-%(version_major_minor)s.a', 'include/%(name)s/%(version_major_minor)s/libguile.h'],
+    'dirs': [],
+}
+
+moduleclass = 'devel'

--- a/easybuild/easyconfigs/l/libffi/libffi-3.2.1-CrayIntel-19.03.eb
+++ b/easybuild/easyconfigs/l/libffi/libffi-3.2.1-CrayIntel-19.03.eb
@@ -1,0 +1,25 @@
+# Contributed by Luca Marsella (CSCS)
+easyblock = 'ConfigureMake'
+
+name = 'libffi'
+version = '3.2.1'
+
+homepage = 'http://sourceware.org/libffi'
+description = """The libffi library provides a portable, high level programming interface to various calling conventions.
+This allows a programmer to call any function specified by a call interface description at run-time.
+
+FFI stands for Foreign Function Interface. A foreign function interface is the popular name for the interface that
+allows code written in one language to call code written in another language."""
+
+toolchain = {'name': 'CrayIntel', 'version': '19.03'}
+
+source_urls = ['ftp://sourceware.org/pub/%(name)s/']
+sources = [SOURCELOWER_TAR_GZ]
+
+
+sanity_check_paths = {
+    'files': ['lib/%(name)s.a'],
+    'dirs': [],
+}
+
+moduleclass = 'lib'

--- a/easybuild/easyconfigs/l/libmatheval/libmatheval-1.1.11-CrayIntel-19.03.eb
+++ b/easybuild/easyconfigs/l/libmatheval/libmatheval-1.1.11-CrayIntel-19.03.eb
@@ -1,0 +1,35 @@
+# contributed by Luca Marsella (CSCS)
+easyblock = 'ConfigureMake'
+
+name = 'libmatheval'
+version = '1.1.11'
+
+homepage = 'http://www.gnu.org/software/libmatheval/'
+description = """GNU libmatheval is a library (callable from C and Fortran) to parse
+ and evaluate symbolic expressions input as text."""
+
+toolchain = {'name': 'CrayIntel', 'version': '19.03'}
+toolchainopts = {'pic': True}
+
+source_urls = [GNU_SOURCE]
+sources = [SOURCELOWER_TAR_GZ]
+# patch for configure.in with guile2 from https://github.com/pld-linux/libmatheval/blob/master/libmatheval-guile2.patch
+patches = ['%(name)s-guile2.patch']
+
+dependencies = [
+    ('flex', '2.6.4'),
+    ('Bison', '3.0.4'),
+    ('byacc', '20170709'),
+    ('guile', '2.0.14'),
+]
+
+#preconfigopts = " export CC=gcc && unset CFLAGS && export CXX=g++ && unset CXXFLAGS &&"
+configopts = '--with-pic GUILE_CONFIG="$EBROOTGUILE/bin/guile -e main -s $EBROOTGUILE/bin/guile-config"'
+
+
+sanity_check_paths = {
+    'files': ['lib/%(name)s.a', 'include/matheval.h'],
+    'dirs': [],
+}
+
+moduleclass = 'lib'

--- a/easybuild/easyconfigs/l/libmatheval/libmatheval-1.1.11-CrayIntel-19.03.eb
+++ b/easybuild/easyconfigs/l/libmatheval/libmatheval-1.1.11-CrayIntel-19.03.eb
@@ -18,7 +18,7 @@ patches = ['%(name)s-guile2.patch']
 
 dependencies = [
     ('flex', '2.6.4'),
-    ('Bison', '3.0.4'),
+    ('Bison', '3.3.2'),
     ('byacc', '20170709'),
     ('guile', '2.0.14'),
 ]

--- a/easybuild/easyconfigs/l/libreadline/libreadline-8.0-CrayIntel-19.03.eb
+++ b/easybuild/easyconfigs/l/libreadline/libreadline-8.0-CrayIntel-19.03.eb
@@ -1,0 +1,29 @@
+# contributed by Luca Marsella (CSCS) 
+easyblock = 'ConfigureMake'
+
+name = 'libreadline'
+version = '8.0'
+
+homepage = 'http://cnswww.cns.cwru.edu/php/chet/readline/rltop.html'
+description = """The GNU Readline library provides a set of functions for use by applications that
+ allow users to edit command lines as they are typed in. Both Emacs and vi editing modes are available.
+ The Readline library includes additional functions to maintain a list of previously-entered command lines,
+ to recall and perhaps reedit those lines, and perform csh-like history expansion on previous commands."""
+
+toolchain = {'name': 'CrayIntel', 'version': '19.03'}
+toolchainopts = {'pic': True}
+
+source_urls = ['http://ftp.gnu.org/gnu/readline']
+sources = ['readline-%(version)s.tar.gz']
+
+dependencies = [
+    ('ncurses', '6.0'),
+]
+
+
+sanity_check_paths = {
+    'files': ['lib/%(name)s.a', 'lib/libhistory.a', 'include/readline/chardefs.h', 'include/readline/history.h', 'include/readline/keymaps.h', 'include/readline/readline.h', 'include/readline/rlconf.h', 'include/readline/rlstdc.h', 'include/readline/rltypedefs.h', 'include/readline/tilde.h'],
+    'dirs': [],
+}
+
+moduleclass = 'lib'

--- a/easybuild/easyconfigs/l/libtool/libtool-2.4.6-CrayIntel-19.03.eb
+++ b/easybuild/easyconfigs/l/libtool/libtool-2.4.6-CrayIntel-19.03.eb
@@ -1,0 +1,21 @@
+# @author: Guilherme Peretti Pezzi and Luca Marsella (CSCS)
+easyblock = 'ConfigureMake'
+
+name = 'libtool'
+version = '2.4.6'
+
+homepage = 'http://www.gnu.org/software/libtool'
+description = """GNU libtool is a generic library support script. Libtool hides the complexity of using shared libraries
+ behind a consistent, portable interface."""
+
+toolchain = {'name': 'CrayIntel', 'version': '19.03'}
+
+source_urls = [GNU_SOURCE]
+sources = [SOURCELOWER_TAR_GZ]
+
+dependencies = [
+    ('M4', '1.4.18'),
+]
+
+
+moduleclass = 'lib'

--- a/easybuild/easyconfigs/l/libunistring/libunistring-0.9.7-CrayIntel-19.03.eb
+++ b/easybuild/easyconfigs/l/libunistring/libunistring-0.9.7-CrayIntel-19.03.eb
@@ -1,0 +1,22 @@
+# Contributed by Luca Marsella (CSCS)
+easyblock = 'ConfigureMake'
+
+name = 'libunistring'
+version = '0.9.7'
+
+homepage = 'http://www.gnu.org/software/libunistring/'
+description = """This library provides functions for manipulating Unicode strings and for manipulating C strings
+according to the Unicode standard."""
+
+toolchain = {'name': 'CrayIntel', 'version': '19.03'}
+
+source_urls = [GNU_SOURCE]
+sources = [SOURCELOWER_TAR_GZ]
+
+
+sanity_check_paths = {
+    'files': ['lib/%(name)s.a', 'lib/%(name)s.so', 'include/unicase.h', 'include/uniconv.h', 'include/unictype.h', 'include/unigbrk.h', 'include/unilbrk.h', 'include/uniname.h', 'include/uninorm.h', 'include/unistdio.h', 'include/unistr.h', 'include/unitypes.h', 'include/uniwbrk.h', 'include/uniwidth.h'],
+    'dirs': ['include/unistring'],
+}
+
+moduleclass = 'lib'

--- a/easybuild/easyconfigs/m/M4/M4-1.4.18-CrayIntel-19.03.eb
+++ b/easybuild/easyconfigs/m/M4/M4-1.4.18-CrayIntel-19.03.eb
@@ -9,7 +9,7 @@ description = """GNU M4 is an implementation of the traditional Unix macro proce
   although it has some extensions (for example, handling more than 9 positional parameters to macros).
  GNU M4 also has built-in functions for including files, running shell commands, doing arithmetic, etc."""
 
-toolchain = {'name': 'CrayGNU', 'version': '19.03'}
+toolchain = {'name': 'CrayIntel', 'version': '19.03'}
 
 sources = [SOURCELOWER_TAR_GZ]
 source_urls = [GNU_SOURCE]

--- a/easybuild/easyconfigs/m/M4/M4-1.4.18-CrayIntel-19.03.eb
+++ b/easybuild/easyconfigs/m/M4/M4-1.4.18-CrayIntel-19.03.eb
@@ -15,7 +15,6 @@ sources = [SOURCELOWER_TAR_GZ]
 source_urls = [GNU_SOURCE]
 
 configopts = "--enable-c++"
-prebuildopts = " module switch intel intel/19.0.1.144 && "
 
 sanity_check_paths = {
     'files': ["bin/m4"],

--- a/easybuild/easyconfigs/m/M4/M4-1.4.18-CrayIntel-19.03.eb
+++ b/easybuild/easyconfigs/m/M4/M4-1.4.18-CrayIntel-19.03.eb
@@ -15,6 +15,7 @@ sources = [SOURCELOWER_TAR_GZ]
 source_urls = [GNU_SOURCE]
 
 configopts = "--enable-c++"
+prebuildopts = " module switch intel intel/19.0.1.144 && "
 
 sanity_check_paths = {
     'files': ["bin/m4"],

--- a/easybuild/easyconfigs/n/ncurses/ncurses-6.0-CrayIntel-19.03.eb
+++ b/easybuild/easyconfigs/n/ncurses/ncurses-6.0-CrayIntel-19.03.eb
@@ -1,0 +1,23 @@
+# Contributed by Luca Marsella (CSCS)
+name = 'ncurses'
+version = '6.0'
+
+homepage = 'http://www.gnu.org/software/ncurses/'
+description = """The Ncurses (new curses) library is a free software emulation
+of curses in System V Release 4.0, and more. It uses Terminfo format, supports
+pads and color and multiple highlights and forms characters and function-key
+mapping, and has all the other SYSV-curses enhancements over BSD Curses."""
+
+toolchain = {'name': 'CrayIntel', 'version': '19.03'}
+toolchainopts = {'optarch': True, 'pic': True}
+
+source_urls = [GNU_SOURCE]
+sources = [SOURCE_TAR_GZ]
+
+
+sanity_check_paths = {
+    'files': ['bin/captoinfo', 'bin/clear', 'bin/infocmp', 'bin/infotocap', 'bin/ncurses6-config', 'bin/reset', 'bin/tabs', 'bin/tic', 'bin/toe', 'bin/tput', 'bin/tset', 'lib/libform.a', 'lib/libform.a', 'lib/libmenu.a', 'lib/libmenu_g.a', 'lib/libncurses.a', 'lib/libncurses++.a', 'lib/libncurses_g.a', 'lib/libpanel.a', 'lib/libpanel_g.a'],
+    'dirs': ['include'],
+}
+
+moduleclass = 'devel'

--- a/easybuild/easyconfigs/p/PLUMED/PLUMED-2.5.1-CrayIntel-19.03.eb
+++ b/easybuild/easyconfigs/p/PLUMED/PLUMED-2.5.1-CrayIntel-19.03.eb
@@ -16,8 +16,12 @@ description = """PLUMED is an open source library for free energy calculations i
 toolchain = {'name': 'CrayIntel', 'version': '19.03'}
 toolchainopts = {'usempi': 'True'}
 
-source_urls = ['https://github.com/%(namelower)s/plumed2/archive/']
+source_urls = ['https://github.com/plumed/plumed2/archive/']
 sources = ['v%(version)s.tar.gz']
+
+builddependencies = [
+    ('binutils', '2.32')
+]
 
 dependencies = [
     ('zlib', '1.2.11'),
@@ -30,11 +34,11 @@ dependencies = [
 preconfigopts = " CC=cc CXX=CC FC=ftn MPIEXEC=srun "
 configopts = " --enable-modules=all --enable-rpath --exec-prefix=%(installdir)s "
 prebuildopts = " source sourceme.sh && "
-#buildopts = 'LD_RO="ld.gold -r -o"'
+buildopts = 'LD_RO="ld.gold -r -o"'
 
 sanity_check_paths = {
-    'files': ['bin/%(namelower)s', 'lib/libplumedKernel.so', 'lib/libplumed.so'],
-    'dirs': ['lib/%(namelower)s'],
+    'files': ['bin/plumed', 'lib/libplumedKernel.%s' % SHLIB_EXT, 'lib/libplumed.%s' % SHLIB_EXT],
+    'dirs': ['lib/plumed']
 }
 
 modextrapaths = {

--- a/easybuild/easyconfigs/p/PLUMED/PLUMED-2.5.1-CrayIntel-19.03.eb
+++ b/easybuild/easyconfigs/p/PLUMED/PLUMED-2.5.1-CrayIntel-19.03.eb
@@ -24,10 +24,11 @@ dependencies = [
     ('GSL', '2.5'),
 ]
 
-# The following options are enabled by default in configure:
+# The following search options are activated by default in configure:
 # --enable-external-blas --enable-external-lapack --enable-gsl --enable-mpi --enable-python
 # Make sure to set the include and library paths accordingly: Cray wrappers set them here
-configopts = " --exec-prefix=%(installdir)s --enable-modules=all"
+preconfigopts = " CC=cc CXX=CC FC=ftn MPIEXEC=srun "
+configopts = " --enable-modules=all --enable-rpath --exec-prefix=%(installdir)s "
 prebuildopts = " source sourceme.sh && "
 #buildopts = 'LD_RO="ld.gold -r -o"'
 

--- a/easybuild/easyconfigs/p/PLUMED/PLUMED-2.5.1-CrayIntel-19.03.eb
+++ b/easybuild/easyconfigs/p/PLUMED/PLUMED-2.5.1-CrayIntel-19.03.eb
@@ -22,12 +22,13 @@ sources = ['v%(version)s.tar.gz']
 dependencies = [
     ('zlib', '1.2.11'),
     ('GSL', '2.5'),
-    ('libmatheval', '1.1.11'),
 ]
 
-configopts = " --exec-prefix=%(installdir)s --enable-gsl --enable-matheval --enable-modules=all"
-
-prebuildopts = "source sourceme.sh && "
+# The following options are enabled by default in configure:
+# --enable-external-blas --enable-external-lapack --enable-gsl --enable-mpi --enable-python
+# Make sure to set the include and library paths accordingly: Cray wrappers set them here
+configopts = " --exec-prefix=%(installdir)s --enable-modules=all"
+prebuildopts = " source sourceme.sh && "
 #buildopts = 'LD_RO="ld.gold -r -o"'
 
 sanity_check_paths = {

--- a/easybuild/easyconfigs/p/PLUMED/PLUMED-2.5.1-CrayIntel-19.03.eb
+++ b/easybuild/easyconfigs/p/PLUMED/PLUMED-2.5.1-CrayIntel-19.03.eb
@@ -1,0 +1,43 @@
+# by Ward Poelmans <wpoely86@gmail.com>
+# Modified by Luca Marsella (CSCS)
+easyblock = 'ConfigureMake'
+
+name = 'PLUMED'
+version = '2.5.1'
+
+homepage = 'http://www.plumed-code.org'
+description = """PLUMED is an open source library for free energy calculations in molecular systems which
+ works together with some of the most popular molecular dynamics engines. Free energy calculations can be
+ performed as a function of many order parameters with a particular  focus on biological problems, using
+ state of the art methods such as metadynamics, umbrella sampling and Jarzynski-equation based steered MD.
+ The software, written in C++, can be easily interfaced with both fortran and C/C++ codes.
+"""
+
+toolchain = {'name': 'CrayIntel', 'version': '19.03'}
+toolchainopts = {'usempi': 'True'}
+
+source_urls = ['https://github.com/%(namelower)s/plumed2/archive/']
+sources = ['v%(version)s.tar.gz']
+
+dependencies = [
+    ('zlib', '1.2.11'),
+    ('GSL', '2.5'),
+    ('libmatheval', '1.1.11'),
+]
+
+configopts = " --exec-prefix=%(installdir)s --enable-gsl --enable-matheval --enable-modules=all"
+
+prebuildopts = "source sourceme.sh && "
+#buildopts = 'LD_RO="ld.gold -r -o"'
+
+sanity_check_paths = {
+    'files': ['bin/%(namelower)s', 'lib/libplumedKernel.so', 'lib/libplumed.so'],
+    'dirs': ['lib/%(namelower)s'],
+}
+
+modextrapaths = {
+    'PLUMED_KERNEL': 'lib/libplumedKernel.%s' % SHLIB_EXT,
+    'PLUMED_ROOT': 'lib/plumed',
+}
+
+moduleclass = 'chem'


### PR DESCRIPTION
`Plumed` does not use anymore `libmatheval` since release `2.5`, therefore I have removed it from the dependencies: see https://plumed.github.io/doc-v2.5/user-doc/html/_c_h_a_n_g_e_s-2-5.html

I keep anyway the recipe of `libmatheval` and its dependencies as they were already tested on `19.03`.