### PR TITLE
[dom-gpu] PLUMED 2.5.1 with CrayGNU 19.03

### DIFF
--- a/easybuild/easyconfigs/p/PLUMED/PLUMED-2.5.1-CrayGNU-19.03.eb
+++ b/easybuild/easyconfigs/p/PLUMED/PLUMED-2.5.1-CrayGNU-19.03.eb
@@ -22,11 +22,14 @@ sources = ['v%(version)s.tar.gz']
 dependencies = [
     ('zlib', '1.2.11'),
     ('GSL', '2.5'),
-    ('libmatheval', '1.1.11')
 ]
 
-configopts = ' --exec-prefix=%(installdir)s --enable-gsl --enable-matheval --enable-modules=all'
-prebuildopts = 'source sourceme.sh && '
+# The following search options are activated by default in configure:
+# --enable-external-blas --enable-external-lapack --enable-gsl --enable-mpi --enable-python
+# Make sure to set the include and library paths accordingly: Cray wrappers set them here
+preconfigopts = " CC=cc CXX=CC FC=ftn MPIEXEC=srun "
+configopts = " --enable-modules=all --enable-rpath --exec-prefix=%(installdir)s "
+prebuildopts = " source sourceme.sh && "
 
 sanity_check_paths = {
     'files': ['bin/plumed', 'lib/libplumedKernel.%s' % SHLIB_EXT, 'lib/libplumed.%s' % SHLIB_EXT],


### PR DESCRIPTION
I have removed libmatheval from `PLUMED` dependencies, since it is no more used as of release `2.5` (see as well #1096). 