### PR TITLE
[dom] Updating intel version in CrayIntel

### DIFF
--- a/easybuild/easyconfigs/c/CrayIntel/CrayIntel-19.03.eb
+++ b/easybuild/easyconfigs/c/CrayIntel/CrayIntel-19.03.eb
@@ -14,7 +14,7 @@ dependencies = [
     # (default) version
     ('PrgEnv-intel', EXTERNAL_MODULE),
     ('atp/2.1.3', EXTERNAL_MODULE),
-    ('intel/18.0.2.199', EXTERNAL_MODULE),
+    ('intel/19.0.1.144', EXTERNAL_MODULE),
     ('modules/3.2.11.1', EXTERNAL_MODULE),
     ('cray-libsci/19.02.1', EXTERNAL_MODULE),
     ('cray-mpich/7.7.6', EXTERNAL_MODULE),


### PR DESCRIPTION
The new default version is reflected in `CrayIntel` and should fix the issues reported here: https://jira.cscs.ch/browse/MAINT-45
Please note that we need to merge this pull request and a force build should be run with Jenkins on `CrayIntel` before #1081 is merged.