### PR TITLE
[daint-gpu] NAMD 2.12 with PLUMED 2.5.0

### DIFF
--- a/easybuild/easyconfigs/n/NAMD/NAMD-2.12-CrayIntel-18.08-PLUMED-2.5.0.eb
+++ b/easybuild/easyconfigs/n/NAMD/NAMD-2.12-CrayIntel-18.08-PLUMED-2.5.0.eb
@@ -25,7 +25,7 @@ prebuildopts +=  'plumed-patch -p -e %(namelower)s-%(version)s --runtime --share
 prebuildopts += ' cd CRAY-XC-intel && '
 
 builddependencies = [
-    ('Charm++', '6.8.2'),
+    ('Charm++', '6.8.0'),
     ('Tcl', '8.6.7'),
     ('cray-fftw/3.3.6.5', EXTERNAL_MODULE),
     ('craype-hugepages8M', EXTERNAL_MODULE),

--- a/easybuild/easyconfigs/n/NAMD/NAMD-2.12-CrayIntel-18.08-cuda-9.1-PLUMED-2.5.0.eb
+++ b/easybuild/easyconfigs/n/NAMD/NAMD-2.12-CrayIntel-18.08-cuda-9.1-PLUMED-2.5.0.eb
@@ -28,7 +28,7 @@ prebuildopts +=  'plumed-patch -p -e %(namelower)s-%(version)s --runtime --share
 prebuildopts += ' cd CRAY-XC-intel.cuda && '
 
 builddependencies = [
-    ('Charm++', '6.8.2'),
+    ('Charm++', '6.8.0'),
     ('Tcl', '8.6.7'),
     ('cray-fftw/3.3.6.5', EXTERNAL_MODULE),
     ('craype-hugepages8M', EXTERNAL_MODULE),

--- a/easybuild/easyconfigs/p/PLUMED/PLUMED-2.5.0-CrayIntel-18.08.eb
+++ b/easybuild/easyconfigs/p/PLUMED/PLUMED-2.5.0-CrayIntel-18.08.eb
@@ -22,12 +22,14 @@ sources = ['v%(version)s.tar.gz']
 dependencies = [
     ('zlib', '1.2.11'),
     ('GSL', '2.5'),
-    ('libmatheval', '1.1.11'),
 ]
 
-configopts = " --exec-prefix=%(installdir)s --enable-gsl --enable-matheval --enable-modules=all"
-
-prebuildopts = "source sourceme.sh && "
+# The following search options are activated by default in configure:
+# --enable-external-blas --enable-external-lapack --enable-gsl --enable-mpi --enable-python
+# Make sure to set the include and library paths accordingly: Cray wrappers set them here
+preconfigopts = " CC=cc CXX=CC FC=ftn MPIEXEC=srun "
+configopts = " --enable-modules=all --enable-rpath --exec-prefix=%(installdir)s "
+prebuildopts = " source sourceme.sh && "
 buildopts = 'LD_RO="ld.gold -r -o"'
 
 sanity_check_paths = {


### PR DESCRIPTION
Removing `libmatheval` from `PLUMED` dependencies:
> ... as of `PLUMED 2.5` the `libmatheval` library is not linked anymore, and the `MATHEVAL` function is implemented using the Lepton library
https://www.plumed.org/doc-v2.5/user-doc/html/_m_a_t_h_e_v_a_l.html