### PR TITLE
[daint-gpu] Fixing W90 bug in QuantumESPRESSO

### DIFF
--- a/easybuild/easyconfigs/q/QuantumESPRESSO/QuantumESPRESSO-6.3-CrayIntel-18.08.eb
+++ b/easybuild/easyconfigs/q/QuantumESPRESSO/QuantumESPRESSO-6.3-CrayIntel-18.08.eb
@@ -24,6 +24,11 @@ configopts = ' ARCH=crayxt --enable-openmp --enable-parallel --with-scalapack '
 
 # correct install rule in Makefile with a phony target (a folder "install" already exists)  
 prebuildopts = ' sed -i -e "s/install :/.PHONY: install\\ninstall:/" Makefile && '
+# correct download url and filename of package W90 (replacing release 2.1.0 with 3.0.0)
+W90 = 'wannier90-3.0.0'
+W90_URL = 'https://github.com/wannier-developers/wannier90/archive/v3.0.0.tar.gz'
+prebuildopts += ' sed -i -e "s/W90=.*/W90=%s/" -e "s#W90_URL=.*#W90_URL=%s#" install/plugins_list && ' % (W90, W90_URL)
+prebuildopts += ' sed -i -e "s/wannier90-2.1.0/%s/" EPW/src/Makefile && ' % W90
 prebuildopts += ' module unload cray-libsci && module list && cat make.inc && '
 buildopts = 'all epw'
 # a single make process is required, since parallel builds fail


### PR DESCRIPTION
The install script of `QuantumESPRESSO` downloads the `Wannier90` package during the build process. 
However the package type has changed from `.tar.gz` to `.tar` and therefore the command used by the script fails with the following error message:
`zip: ../archive/wannier90-2.1.0.tar.gz: not in gzip format`
See https://jenkins.cscs.ch/blue/rest/organizations/jenkins/pipelines/RegressionEB/runs/860/nodes/39/steps/86/log/?start=0

This modified recipe fixes this issue with a more recent version of the package `Wannier90` needed by `QuantumESPRESSO`.