### PR TITLE
[daint] Updating production lists with VisIt

### DIFF
--- a/jenkins-builds/6.0.UP07-18.08-gpu
+++ b/jenkins-builds/6.0.UP07-18.08-gpu
@@ -58,6 +58,7 @@
  Theano-1.0.2-CrayGNU-18.08-cuda-9.1-python2.eb
  Theano-1.0.2-CrayGNU-18.08-cuda-9.1-python3.eb     --set-default-module
  VASP-5.4.4-CrayIntel-18.08-cuda-9.1.eb             --set-default-module
+ Visit-3.0.0-CrayGNU-18.08.eb                       --set-default-module
  VMD-1.9.3-egl.eb
  VMD-1.9.3-ogl.eb
  VTK-8.1.1-EGL-CrayGNU-18.08-python3.eb

--- a/jenkins-builds/6.0.UP07-18.08-mc
+++ b/jenkins-builds/6.0.UP07-18.08-mc
@@ -47,6 +47,7 @@
  QuantumESPRESSO-6.3-CrayIntel-18.08.eb             --set-default-module
  Spark-2.3.1-CrayGNU-18.08-Hadoop-2.7.eb
  VASP-5.4.4-CrayIntel-18.08.eb                      --set-default-module
+ Visit-3.0.0-CrayGNU-18.08.eb                       --set-default-module
  advisor_2019_update3.eb                            --set-default-module --installpath=$APPS/UES/jenkins/6.0.UP07/mc/easybuild/tools
  bladeplugin-0.1.eb                                 --set-default-module --installpath=$APPS/UES/jenkins/6.0.UP07/mc/easybuild/tools
  callgraphplugin-0.1.eb                             --set-default-module --installpath=$APPS/UES/jenkins/6.0.UP07/mc/easybuild/tools


### PR DESCRIPTION
The recipe `Visit-3.0.0-CrayGNU-18.08.eb` will be built by EasyBuild on Piz Daint (both `gpu` and `mc` software stacks) and set as default modulefile with `--set-default-module`.