### PR TITLE
[daint dom] make boostcray easyblock aware of 'parallel' easyconfig parameter

### DIFF
--- a/easybuild/easyblocks/boostcray.py
+++ b/easybuild/easyblocks/boostcray.py
@@ -156,6 +156,9 @@ class boostcray(EasyBlock):
 
         bjamoptions = " --prefix=%s" % self.objdir
 
+        if self.cfg['parallel']:
+            bjamoptions += " -j %s" % self.cfg['parallel']
+
         # specify path for bzip2/zlib if module is loaded
         if not self.cfg['boost_mpi']:
             for lib in ["bzip2", "zlib"]:


### PR DESCRIPTION
This dramatically speeds up the compilation of Boost by making the build being done in parallel.

Example: on `daint105`, building `eb Boost-1.67.0-CrayGNU-18.08.eb --try-software-version 1.70.0` only takes 3 minutes rather than 18 minutes...