### PR TITLE
WIP [keschTDS] Add gcc/7.4.0-2.32 to experimental stack

### DIFF
--- a/easybuild/cray_external_modules_metadata.cfg
+++ b/easybuild/cray_external_modules_metadata.cfg
@@ -381,6 +381,11 @@ name = GCC
 version = 7.1.0
 prefix = GCC_PATH
 
+[gcc/7.4.0]
+name = GCC
+version = 7.4.0
+prefix = GCC_PATH
+
 [java/jdk1.8.0_51]
 name = Java
 version = 1.8.0_51

--- a/easybuild/easyconfigs/b/Bison/Bison-3.3.2-GCCcore-7.4.0.eb
+++ b/easybuild/easyconfigs/b/Bison/Bison-3.3.2-GCCcore-7.4.0.eb
@@ -1,0 +1,23 @@
+# Contributed by Jean-Guillaume Piccinali and Luca Marsella (CSCS)
+easyblock = 'ConfigureMake'
+
+name = 'Bison'
+version = '3.3.2'
+
+homepage = 'http://www.gnu.org/software/bison'
+description = """Bison is a general-purpose parser generator that converts an annotated context-free grammar
+ into a deterministic LR or generalized LR (GLR) parser employing LALR(1) parser tables."""
+
+toolchain = {'name': 'GCCcore', 'version': '7.4.0'}
+
+sources = [SOURCELOWER_TAR_GZ]
+source_urls = [GNU_SOURCE]
+
+dependencies = [('M4', '1.4.18')]
+
+sanity_check_paths = {
+    'files': ["bin/%s" % x for x in ["bison", "yacc"]] + ["lib/liby.a"],
+    'dirs': [],
+}
+
+moduleclass = 'lang'

--- a/easybuild/easyconfigs/b/binutils/binutils-2.32-GCCcore-7.4.0.eb
+++ b/easybuild/easyconfigs/b/binutils/binutils-2.32-GCCcore-7.4.0.eb
@@ -1,0 +1,22 @@
+# contributed by Luca Marsella (CSCS)
+name = 'binutils'
+version = '2.32'
+
+homepage = 'http://directory.fsf.org/project/binutils/'
+description = "binutils: GNU binary utilities"
+
+toolchain = {'name': 'GCCcore', 'version': '7.4.0'}
+
+sources = [SOURCE_TAR_GZ]
+source_urls = [GNU_SOURCE]
+
+builddependencies = [
+    ('flex', '2.6.4'),
+    ('Bison', '3.3.2'),
+    # zlib required, but being linked in statically, so not a runtime dep
+    ('zlib', '1.2.11'),
+    # use same binutils version that was used when building GCC toolchain, to 'bootstrap' this binutils
+    ('binutils', version, '', True)
+]
+
+moduleclass = 'tools'

--- a/easybuild/easyconfigs/b/binutils/binutils-2.32.eb
+++ b/easybuild/easyconfigs/b/binutils/binutils-2.32.eb
@@ -1,0 +1,21 @@
+# contributed by Luca Marsella (CSCS)
+name = 'binutils'
+version = '2.32'
+
+homepage = 'http://directory.fsf.org/project/binutils/'
+
+description = "binutils: GNU binary utilities"
+
+toolchain = {'name': 'dummy', 'version': ''}
+
+source_urls = [GNU_SOURCE]
+sources = [SOURCE_TAR_GZ]
+
+builddependencies = [
+    ('flex', '2.6.4'),
+    ('Bison', '3.3.2'),
+    # zlib required, but being linked in statically, so not a runtime dep
+    ('zlib', '1.2.11'),
+]
+
+moduleclass = 'tools'

--- a/easybuild/easyconfigs/f/flex/flex-2.6.4-GCCcore-7.4.0.eb
+++ b/easybuild/easyconfigs/f/flex/flex-2.6.4-GCCcore-7.4.0.eb
@@ -1,0 +1,31 @@
+# contributed by Luca Marsella (CSCS)
+name = 'flex'
+version = '2.6.4'
+
+homepage = 'http://flex.sourceforge.net/'
+
+description = """
+ Flex (Fast Lexical Analyzer) is a tool for generating scanners. A scanner,
+ sometimes called a tokenizer, is a program which recognizes lexical patterns
+ in text.
+"""
+
+toolchain = {'name': 'GCCcore', 'version': '7.4.0'}
+toolchainopts = {'pic': True}
+
+source_urls = ['https://github.com/westes/flex/releases/download/v%(version)s/']
+sources = [SOURCELOWER_TAR_GZ]
+checksums = ['e87aae032bf07c26f85ac0ed3250998c37621d95f8bd748b31f15b33c45ee995']
+
+builddependencies = [
+    ('Bison', '3.3.2'),
+    ('help2man', '1.47.10'),
+    # use same binutils version that was used when building GCC toolchain
+    ('binutils', '2.32', '', True),
+]
+
+dependencies = [
+    ('M4', '1.4.18'),
+]
+
+moduleclass = 'lang'

--- a/easybuild/easyconfigs/g/GCC/GCC-7.4.0-2.32.eb
+++ b/easybuild/easyconfigs/g/GCC/GCC-7.4.0-2.32.eb
@@ -1,0 +1,26 @@
+# contributed by Luca Marsella (CSCS)
+easyblock = 'Bundle'
+
+name = 'GCC'
+version = '7.4.0'
+
+binutilsver = '2.32'
+versionsuffix = '-%s' % binutilsver
+
+homepage = 'http://gcc.gnu.org/'
+description = """The GNU Compiler Collection includes front ends for C, C++, Objective-C, Fortran, Java, and Ada,
+ as well as libraries for these languages (libstdc++, libgcj,...)."""
+
+toolchain = {'name': 'dummy', 'version': ''}
+
+dependencies = [
+    ('GCCcore', version),
+    # binutils built on top of GCCcore, which was built on top of (dummy-built) binutils
+    ('binutils', binutilsver, '', ('GCCcore', version)),
+]
+
+altroot = 'GCCcore'
+altversion = 'GCCcore'
+
+# this bundle serves as a compiler-only toolchain, so it should be marked as compiler (important for HMNS)
+moduleclass = 'compiler'

--- a/easybuild/easyconfigs/g/GCCcore/GCCcore-7.4.0.eb
+++ b/easybuild/easyconfigs/g/GCCcore/GCCcore-7.4.0.eb
@@ -1,0 +1,51 @@
+easyblock = 'EB_GCC'
+
+name = 'GCCcore'
+version = '7.4.0'
+
+homepage = 'http://gcc.gnu.org/'
+description = """The GNU Compiler Collection includes front ends for C, C++, Objective-C, Fortran, Java, and Ada,
+ as well as libraries for these languages (libstdc++, libgcj,...)."""
+
+toolchain = {'name': 'dummy', 'version': ''}
+
+mpfr_version = '4.0.1'
+
+source_urls = [
+    'http://ftpmirror.gnu.org/gnu/gcc/gcc-%(version)s',  # GCC auto-resolving HTTP mirror
+    'http://ftpmirror.gnu.org/gnu/gmp',  # idem for GMP
+    'http://ftpmirror.gnu.org/gnu/mpfr',  # idem for MPFR
+    'http://ftpmirror.gnu.org/gnu/mpc',  # idem for MPC
+    'ftp://gcc.gnu.org/pub/gcc/infrastructure/',  # GCC dependencies
+    'http://gcc.cybermirror.org/infrastructure/',  # HTTP mirror for GCC dependencies
+    'http://isl.gforge.inria.fr/',  # original HTTP source for ISL
+]
+sources = [
+    'gcc-%(version)s.tar.gz',
+    'gmp-6.1.2.tar.bz2',
+    'mpfr-%s.tar.bz2' % mpfr_version,
+    'mpc-1.1.0.tar.gz',
+    'isl-0.20.tar.bz2',
+]
+patches = [
+    'GCCcore-6.2.0-fix-find-isl.patch',
+]
+checksums = [
+    'cb8df68237b0bea3307217697ad749a0a0565584da259e8a944ef6cfc4dc4d3d',  # gcc-7.4.0.tar.gz
+    '5275bb04f4863a13516b2f39392ac5e272f5e1bb8057b18aec1c9b79d73d8fb2',  # gmp-6.1.2.tar.bz2
+    'a4d97610ba8579d380b384b225187c250ef88cfe1d5e7226b89519374209b86b',  # mpfr-4.0.1.tar.bz2
+    '6985c538143c1208dcb1ac42cedad6ff52e267b47e5f970183a3e75125b43c2e',  # mpc-1.1.0.tar.gz
+    'b587e083eb65a8b394e833dea1744f21af3f0e413a448c17536b5549ae42a4c2',  # isl-0.20.tar.bz2
+    '5ad909606d17d851c6ad629b4fddb6c1621844218b8d139fed18c502a7696c68',  # GCCcore-6.2.0-fix-find-isl.patch
+]
+
+builddependencies = [
+    ('M4', '1.4.18'),
+    ('binutils', '2.32'),
+]
+
+languages = ['c', 'c++', 'fortran']
+
+withisl = True
+
+moduleclass = 'compiler'

--- a/easybuild/easyconfigs/h/help2man/help2man-1.47.10-GCCcore-7.4.0.eb
+++ b/easybuild/easyconfigs/h/help2man/help2man-1.47.10-GCCcore-7.4.0.eb
@@ -1,0 +1,25 @@
+# contributed by Luca Marsella (CSCS)
+easyblock = 'ConfigureMake'
+
+name = 'help2man'
+version = '1.47.10'
+
+homepage = 'https://www.gnu.org/software/help2man/'
+description = """help2man produces simple manual pages from the '--help' and '--version' output of other commands."""
+
+toolchain = {'name': 'GCCcore', 'version': '7.4.0'}
+
+source_urls = [GNU_SOURCE]
+sources = [SOURCE_TAR_XZ]
+
+builddependencies = [
+    # use same binutils version that was used when building GCC toolchain
+    ('binutils', '2.32', '', True),
+]
+
+sanity_check_paths = {
+    'files': ['bin/help2man'],
+    'dirs': [],
+}
+
+moduleclass = 'tools'

--- a/easybuild/easyconfigs/m/M4/M4-1.4.18-GCCcore-7.4.0.eb
+++ b/easybuild/easyconfigs/m/M4/M4-1.4.18-GCCcore-7.4.0.eb
@@ -1,0 +1,36 @@
+# contributed by Luca Marsella (CSCS)
+easyblock = 'ConfigureMake'
+
+name = 'M4'
+version = '1.4.18'
+
+homepage = 'http://www.gnu.org/software/m4/m4.html'
+
+description = """
+ GNU M4 is an implementation of the traditional Unix macro processor. It is
+ mostly SVR4 compatible although it has some extensions (for example, handling
+ more than 9 positional parameters to macros). GNU M4 also has built-in
+ functions for including files, running shell commands, doing arithmetic, etc.
+"""
+
+toolchain = {'name': 'GCCcore', 'version': '7.4.0'}
+
+source_urls = [GNU_SOURCE]
+sources = [SOURCELOWER_TAR_GZ]
+checksums = ['ab2633921a5cd38e48797bf5521ad259bdc4b979078034a3b790d7fec5493fab']
+
+# use same binutils version that was used when building GCC toolchain
+builddependencies = [
+    ('binutils', '2.32', '', True),
+]
+
+# '-fgnu89-inline' is required to avoid linking errors with older glibc's,
+# see https://github.com/easybuilders/easybuild-easyconfigs/issues/529
+configopts = "--enable-cxx CPPFLAGS=-fgnu89-inline"
+
+sanity_check_paths = {
+    'files': ['bin/m4'],
+    'dirs': [],
+}
+
+moduleclass = 'devel'

--- a/easybuild/easyconfigs/z/zlib/zlib-1.2.11-GCCcore-7.4.0.eb
+++ b/easybuild/easyconfigs/z/zlib/zlib-1.2.11-GCCcore-7.4.0.eb
@@ -1,0 +1,26 @@
+# contributed by Luca Marsella (CSCS)
+easyblock = 'ConfigureMake'
+
+name = 'zlib'
+version = '1.2.11'
+
+homepage = 'http://www.zlib.net/'
+description = """zlib is designed to be a free, general-purpose, legally unencumbered -- that is,
+ not covered by any patents -- lossless data-compression library for use on virtually any
+ computer hardware and operating system."""
+
+toolchain = {'name': 'GCCcore', 'version': '7.4.0'}
+toolchainopts = {'pic': True}
+
+source_urls = ['http://zlib.net/fossils']
+sources = [SOURCELOWER_TAR_GZ]
+
+# use same binutils version that was used when building GCC toolchain
+builddependencies = [('binutils', '2.32', '', True)]
+
+sanity_check_paths = {
+    'files': ['include/zconf.h', 'include/zlib.h', 'lib/libz.a', 'lib/libz.%s' % SHLIB_EXT],
+    'dirs': [],
+}
+
+moduleclass = 'lib'

--- a/jenkins-builds/MCH-RH7.5-17.06
+++ b/jenkins-builds/MCH-RH7.5-17.06
@@ -5,6 +5,7 @@
  CDO-1.8.2-gmvolf-17.02.eb                           --installpath=/apps/escha/UES/jenkins/RH7.5/gnu_PE17.02/easybuild
  CMake-3.13.4.eb                                     
  ddt-18.2.2-Redhat-7.0.eb                            --set-default-module
+ GCC-7.4.0-2.32.eb                                   --installpath=/apps/escha/UES/jenkins/RH7.5_experimental/gnu_PE17.02/easybuild
  GDAL-2.2.1-gmvolf-17.02.eb                          --installpath=/apps/escha/UES/jenkins/RH7.5/gnu_PE17.02/easybuild
  GSL-1.16-gmvolf-17.02.eb                            --installpath=/apps/escha/UES/jenkins/RH7.5/gnu_PE17.02/easybuild
  geeqie-1.3.eb                                       


### PR DESCRIPTION
Adding gcc/7.4.0 for MCH to test with FE.

This way was preferred to providing gcccore only, since no change in the workflow is required regarding the modules loaded before compilation.