### PR TITLE
[keschTDS] EB GCC-7.4.0-2.31.1

### DIFF
--- a/jenkins-builds/MCH-RH7.5-18.12
+++ b/jenkins-builds/MCH-RH7.5-18.12
@@ -5,6 +5,7 @@
  CDO-1.8.2-gmvolf-17.02.eb                           --installpath=/apps/escha/UES/jenkins/RH7.5/gnu_PE17.02/easybuild
  CMake-3.13.4.eb                                     
  ddt-18.2.2-Redhat-7.0.eb                            --set-default-module
+ GCC-7.4.0-2.31.1.eb                                 --installpath=/apps/escha/UES/jenkins/RH7.5_experimental/easybuild
  GDAL-2.2.1-gmvolf-17.02.eb                          --installpath=/apps/escha/UES/jenkins/RH7.5/gnu_PE17.02/easybuild
  GSL-1.16-gmvolf-17.02.eb                            --installpath=/apps/escha/UES/jenkins/RH7.5/gnu_PE17.02/easybuild
  geeqie-1.3.eb                                       

--- a/jenkins-builds/MCH-RH7.5-18.12
+++ b/jenkins-builds/MCH-RH7.5-18.12
@@ -5,7 +5,7 @@
  CDO-1.8.2-gmvolf-17.02.eb                           --installpath=/apps/escha/UES/jenkins/RH7.5/gnu_PE17.02/easybuild
  CMake-3.13.4.eb                                     
  ddt-18.2.2-Redhat-7.0.eb                            --set-default-module
- GCC-7.4.0-2.31.1.eb                                 --installpath=/apps/escha/UES/jenkins/RH7.5_experimental/easybuild
+ GCC-7.4.0-2.31.1.eb                                 --installpath=/apps/escha/UES/jenkins/RH7.5/gnu_PE18.12/easybuild
  GDAL-2.2.1-gmvolf-17.02.eb                          --installpath=/apps/escha/UES/jenkins/RH7.5/gnu_PE17.02/easybuild
  GSL-1.16-gmvolf-17.02.eb                            --installpath=/apps/escha/UES/jenkins/RH7.5/gnu_PE17.02/easybuild
  geeqie-1.3.eb                                       


### PR DESCRIPTION
Add the (default from EB repo) recipe to the `experimental` software stack on Kesch for MCH to test.