### PR TITLE
[kesch] Revert "Setting RPATH"

### DIFF
--- a/easybuild/module/EasyBuild-custom/cscs
+++ b/easybuild/module/EasyBuild-custom/cscs
@@ -77,7 +77,6 @@ if { [ string match *daint* $system ] || [ string match *dom* $system ] } {
 } elseif { [ string match *esch* $system ] } {
     setenv EASYBUILD_MODULE_NAMING_SCHEME       LowercaseModuleNamingScheme
 } elseif { [ string match *arolla* $system ] || [ string match *tsa* $system ] } {
-    setenv EASYBUILD_RPATH                      1    
     setenv EASYBUILD_MODULES_TOOL               EnvironmentModules
     setenv EASYBUILD_MODULE_NAMING_SCHEME       LowercaseModuleNamingScheme
     setenv EASYBUILD_RECURSIVE_MODULE_UNLOAD    1


### PR DESCRIPTION
Reverts eth-cscs/production#1145. Unfortunately setting `rpath` globally affects the deployment of PrgEnv-cce and `dummy` modules too:
```
WARNING One or more required libraries not found for /apps/arolla/UES/jenkins/RH7.5/cce/18.12/easybuild/software/HDF5/1.10.1-Cra
yCCE-18.12-parallel/bin/h5diff:    linux-vdso.so.1 =>  (0x00002aaaaaacd000)
```
The build of rstudio could not be completed too:
```
WARNING No '(RPATH)' found in 'readelf -d' output for /apps/arolla/UES/jenkins/RH7.5/generic/easybuild/software/rstudio/1.2.1335/bin/diagnostics:
```
See full log at https://jenkins.cscs.ch/blue/organizations/jenkins/ProductionEBTsa/detail/ProductionEBTsa/68/pipeline