### PR TITLE
[daint] Create jupyterlab-1.0.4-CrayGNU-18.08.eb

### DIFF
--- a/easybuild/easyconfigs/j/jupyterlab/jupyterlab-1.0.4-CrayGNU-18.08.eb
+++ b/easybuild/easyconfigs/j/jupyterlab/jupyterlab-1.0.4-CrayGNU-18.08.eb
@@ -1,0 +1,458 @@
+# @author: robinson 
+
+easyblock = 'Bundle'
+
+name = 'jupyterlab'
+version = '1.0.4'
+
+py_maj_ver = '3'
+py_min_ver = '6'
+py_rev_ver = '5.1'
+
+pyver = '%s.%s.%s' % (py_maj_ver, py_min_ver, py_rev_ver)
+pyshortver = '%s.%s' % (py_maj_ver, py_min_ver)
+
+homepage = 'https://github.com/jupyterlab/jupyterlab'
+description = "An extensible environment for interactive and reproducible computing, based on the Jupyter Notebook and Architecture."
+
+toolchain = {'name': 'CrayGNU', 'version': '18.08'}
+toolchainopts = {'pic': True, 'verbose': False}
+
+dependencies = [
+    ('libffi', '3.2.1', '', True),
+    ('PyExtensions', '%s' % pyver),
+    ('IPython', '7.7.0', '-python%s' % py_maj_ver),
+    ('configurable-http-proxy', '3.1.1')
+]
+
+# bundle of Python packages
+exts_defaultclass = 'PythonPackage'
+
+exts_list = [
+
+#jupyterlab packages besides ipython and its deps
+    ('pyrsistent', '0.15.4', {
+        'req_py_majver': '3',
+        'req_py_minver': '6',
+        'use_pip': True,
+        'source_urls': ['https://pypi.python.org/packages/source/p/pyrsistent/'],
+        }),
+    ('attrs', '19.1.0', {
+        'req_py_majver': '3',
+        'req_py_minver': '6',
+        'use_pip': True,
+        'modulename': 'attr',
+        'source_urls': ['https://pypi.python.org/packages/source/a/attrs/'],
+        }),
+    ('jsonschema', '3.0.1', {
+        'req_py_majver': '3',
+        'req_py_minver': '6',
+        'use_pip': True,
+        'source_urls': ['https://pypi.python.org/packages/source/j/jsonschema/'],
+        }),
+    ('json5', '0.8.5', {
+        'req_py_majver': '3',
+        'req_py_minver': '6',
+        'use_pip': True,
+        'source_urls': ['https://pypi.python.org/packages/source/j/json5/'],
+        }),
+    ('Send2Trash', '1.5.0', {
+        'req_py_majver': '3',
+        'req_py_minver': '6',
+        'use_pip': True,
+        'source_urls': ['https://pypi.python.org/packages/source/s/Send2Trash/'],
+        }),
+    ('tornado', '6.0.3', {
+        'req_py_majver': '3',
+        'req_py_minver': '6',
+        'use_pip': True,
+        'source_urls': ['https://pypi.python.org/packages/source/t/tornado/'],
+        }),
+    ('pyzmq', '18.0.2', {
+        'req_py_majver': '3',
+        'req_py_minver': '6',
+        'use_pip': True,
+        'modulename': 'zmq',
+        'source_urls': ['https://pypi.python.org/packages/source/p/pyzmq/'],
+        }),
+    ('python-dateutil', '2.8.0', {
+        'req_py_majver': '3',
+        'req_py_minver': '6',
+        'use_pip': True,
+        'modulename':  'dateutil',
+        'source_urls': ['https://pypi.python.org/packages/source/p/python-dateutil/'],
+        }),
+    ('jupyter_core', '4.5.0', {
+        'req_py_majver': '3',
+        'req_py_minver': '6',
+        'use_pip': True,
+        'source_urls': ['https://pypi.python.org/packages/source/j/jupyter_core/'],
+        }),
+    ('jupyter_client', '5.3.1', {
+        'req_py_majver': '3',
+        'req_py_minver': '6',
+        'use_pip': True,
+        'source_urls': ['https://pypi.python.org/packages/source/j/jupyter_client/'],
+        }),
+    ('MarkupSafe', '1.1.1', {
+        'req_py_majver': '3',
+        'req_py_minver': '6',
+        'use_pip': True,
+        'source_urls': ['https://pypi.python.org/packages/source/m/MarkupSafe/'],
+        }),
+    ('Jinja2', '2.10.1', {
+        'req_py_majver': '3',
+        'req_py_minver': '6',
+        'use_pip': True,
+        'source_urls': ['https://pypi.python.org/packages/source/j/Jinja2/'],
+        }),
+    ('webencodings', '0.5.1', {
+        'req_py_majver': '3',
+        'req_py_minver': '6',
+        'use_pip': True,
+        'source_urls': ['https://pypi.python.org/packages/source/w/webencodings/'],
+        }),
+    ('bleach', '3.1.0', {
+        'req_py_majver': '3',
+        'req_py_minver': '6',
+        'use_pip': True,
+        'source_urls': ['https://pypi.python.org/packages/source/b/bleach/'],
+        }),
+    ('defusedxml', '0.6.0', {
+        'req_py_majver': '3',
+        'req_py_minver': '6',
+        'use_pip': True,
+        'source_urls': ['https://pypi.python.org/packages/source/d/defusedxml/'],
+        }),
+    ('entrypoints', '0.3', {
+        'req_py_majver': '3',
+        'req_py_minver': '6',
+        'use_pip': True,
+        'source_urls': ['https://pypi.python.org/packages/source/e/entrypoints/'],
+        }),
+    ('mistune', '0.8.4', {
+        'req_py_majver': '3',
+        'req_py_minver': '6',
+        'use_pip': True,
+        'source_urls': ['https://pypi.python.org/packages/source/m/mistune/'],
+        }),
+    ('nbformat', '4.4.0', {
+        'req_py_majver': '3',
+        'req_py_minver': '6',
+        'use_pip': True,
+        'source_urls': ['https://pypi.python.org/packages/source/n/nbformat/'],
+        }),
+    ('pandocfilters', '1.4.2', {
+        'req_py_majver': '3',
+        'req_py_minver': '6',
+        'use_pip': True,
+        'source_urls': ['https://pypi.python.org/packages/source/p/pandocfilters/'],
+        }),
+    ('testpath', '0.4.2', {
+        'req_py_majver': '3',
+        'req_py_minver': '6',
+        'use_pip': True,
+        'source_urls': ['https://pypi.python.org/packages/source/t/testpath/'],
+        }),
+    ('nbconvert', '5.5.0', {
+        'req_py_majver': '3',
+        'req_py_minver': '6',
+        'use_pip': True,
+        'source_urls': ['https://pypi.python.org/packages/source/n/nbconvert/'],
+        }),
+    ('prometheus_client', '0.7.1', {
+        'req_py_majver': '3',
+        'req_py_minver': '6',
+        'use_pip': True,
+        'source_urls': ['https://pypi.python.org/packages/source/p/prometheus_client/'],
+        }),
+    ('terminado', '0.8.2', {
+        'req_py_majver': '3',
+        'req_py_minver': '6',
+        'use_pip': True,
+        'source_urls': ['https://pypi.python.org/packages/source/t/terminado/'],
+        }),
+    ('jupyterlab_server', '1.0.0', {
+        'req_py_majver': '3',
+        'req_py_minver': '6',
+        'use_pip': True,
+        'source_urls': ['https://pypi.python.org/packages/source/j/jupyterlab_server/'],
+        }),
+    ('ipykernel', '5.1.1', {
+        'req_py_majver': '3',
+        'req_py_minver': '6',
+        'use_pip': True,
+        'source_urls': ['https://pypi.python.org/packages/source/i/ipykernel/'],
+        }),
+    ('notebook', '6.0.0', {
+        'req_py_majver': '3',
+        'req_py_minver': '6',
+        'use_pip': True,
+        'source_urls': ['https://pypi.python.org/packages/source/n/notebook/'],
+        }),
+    (name, version, {
+        'req_py_majver': '3',
+        'req_py_minver': '6',
+        'use_pip': True,
+        'installopts': ' --install-option=--skip-npm ',
+        'source_urls': ['https://pypi.python.org/packages/source/j/jupyterlab/'],
+        }),
+
+# jupyterhub and its deps
+    ('SQLAlchemy', '1.3.6', {
+        'req_py_majver': '3',
+        'req_py_minver': '6',
+        'use_pip': True,
+        'source_urls': ['https://pypi.python.org/packages/source/s/SQLAlchemy/'],
+        }),
+    ('Mako', '1.0.14', {
+        'req_py_majver': '3',
+        'req_py_minver': '6',
+        'use_pip': True,
+        'source_urls': ['https://pypi.python.org/packages/source/m/Mako/'],
+        }),
+    ('alembic', '1.0.11', {
+        'req_py_majver': '3',
+        'req_py_minver': '6',
+        'use_pip': True,
+        'source_urls': ['https://pypi.python.org/packages/source/a/alembic/'],
+        }),
+    ('python-editor', '1.0.4', {
+        'req_py_majver': '3',
+        'req_py_minver': '6',
+        'use_pip': True,
+        'modulename': 'editor',
+        'source_urls': ['https://pypi.python.org/packages/source/p/python-editor/'],
+        }),
+    ('async_generator', '1.10', {
+        'req_py_majver': '3',
+        'req_py_minver': '6',
+        'use_pip': True,
+        'source_urls': ['https://pypi.python.org/packages/source/a/async_generator/'],
+        }),
+    ('pycparser', '2.19', {
+        'req_py_majver': '3',
+        'req_py_minver': '6',
+        'use_pip': True,
+        'source_urls': ['https://pypi.python.org/packages/source/p/pycparser/'],
+        }),
+    ('cffi', '1.12.3', {
+        'req_py_majver': '3',
+        'req_py_minver': '6',
+        'use_pip': False,
+        'source_urls': ['https://pypi.python.org/packages/source/c/cffi/'],
+        }),
+    ('asn1crypto', '0.24.0', {
+        'req_py_majver': '3',
+        'req_py_minver': '6',
+        'use_pip': True,
+        'source_urls': ['https://pypi.python.org/packages/source/a/asn1crypto/'],
+        }),
+    ('cryptography', '2.7', {
+        'req_py_majver': '3',
+        'req_py_minver': '6',
+        'use_pip': True,
+        'source_urls': ['https://pypi.python.org/packages/source/c/cryptography/'],
+        }),
+    ('pyOpenSSL', '19.0.0', {
+        'req_py_majver': '3',
+        'req_py_minver': '6',
+        'use_pip': True,
+        'modulename': "OpenSSL",
+        'source_urls': ['https://pypi.python.org/packages/source/p/pyOpenSSL/'],
+        }),
+    ('certipy', '0.1.3', {
+        'req_py_majver': '3',
+        'req_py_minver': '6',
+        'use_pip': True,
+        'source_urls': ['https://pypi.python.org/packages/source/c/certipy/'],
+        }),
+    ('entrypoints', '0.3', {
+        'req_py_majver': '3',
+        'req_py_minver': '6',
+        'use_pip': True,
+        'source_urls': ['https://pypi.python.org/packages/source/e/entrypoint/'],
+        }),
+    ('oauthlib', '3.0.2', {
+        'req_py_majver': '3',
+        'req_py_minver': '6',
+        'use_pip': True,
+        'source_urls': ['https://pypi.python.org/packages/source/o/oauthlib/'],
+        }),
+    ('pamela', '1.0.0', {
+        'req_py_majver': '3',
+        'req_py_minver': '6',
+        'use_pip': True,
+        'source_urls': ['https://pypi.python.org/packages/source/p/pamela/'],
+        }),
+    ('urllib3', '1.25.3', {
+        'req_py_majver': '3',
+        'req_py_minver': '6',
+        'use_pip': True,
+        'source_urls': ['https://pypi.python.org/packages/source/u/urllib3/'],
+        }),
+    ('idna', '2.8', {
+        'req_py_majver': '3',
+        'req_py_minver': '6',
+        'use_pip': True,
+        'source_urls': ['https://pypi.python.org/packages/source/i/idna/'],
+        }),
+    ('chardet', '3.0.4', {
+        'req_py_majver': '3',
+        'req_py_minver': '6',
+        'use_pip': True,
+        'source_urls': ['https://pypi.python.org/packages/source/c/chardet/'],
+        }),
+    ('certifi', '2019.6.16', {
+        'req_py_majver': '3',
+        'req_py_minver': '6',
+        'use_pip': True,
+        'source_urls': ['https://pypi.python.org/packages/source/c/certifi/'],
+        }),
+    ('requests', '2.22.0', {
+        'req_py_majver': '3',
+        'req_py_minver': '6',
+        'use_pip': True,
+        'source_urls': ['https://pypi.python.org/packages/source/r/requests/'],
+        }),
+    ('jupyterhub', '1.0.0', {
+        'req_py_majver': '3',
+        'req_py_minver': '6',
+        'use_pip': True,
+        'source_urls': ['https://pypi.python.org/packages/source/j/jupyterhub/'],
+        }),
+
+# widgets: note the lab extensions below
+    ('widgetsnbextension', '3.5.1', {
+        'req_py_majver': '3',
+        'req_py_minver': '6',
+        'source_urls': ['https://pypi.python.org/packages/source/w/widgetsnbextension/'],
+        }),
+    ('ipywidgets', '7.5.1', {
+        'req_py_majver': '3',
+        'req_py_minver': '6',
+        'source_urls': ['https://pypi.python.org/packages/source/i/ipywidgets/'],
+        }),
+# ipympl matplotlib widgets, requires lab extension 
+    ('ipympl', '0.3.3', {
+        'req_py_majver': '3',
+        'req_py_minver': '6',
+        'source_urls': ['https://pypi.python.org/packages/source/i/ipympl/'],
+        }),
+
+# plotly, requires the lab extension below
+    ('retrying', '1.3.3', {
+        'req_py_majver': '3',
+        'req_py_minver': '6',
+        'source_urls': ['https://pypi.python.org/packages/source/r/retrying/'],
+        }),
+    ('plotly', '4.0.0', {
+        'req_py_majver': '3',
+        'req_py_minver': '6',
+        'source_urls': ['https://pypi.python.org/packages/source/p/plotly/'],
+        }),
+
+# bokeh, requires the labextension below
+    ('PyYAML', '5.1.2', {
+        'req_py_majver': '3',
+        'req_py_minver': '6',
+        'modulename': 'yaml',
+        'source_urls': ['https://pypi.python.org/packages/source/p/PyYAML/'],
+        }),
+    ('bokeh', '1.3.4', {
+        'req_py_majver': '3',
+        'req_py_minver': '6',
+        'source_urls': ['https://pypi.python.org/packages/source/b/bokeh/'],
+        }),
+    ('packaging', '19.1', {
+        'req_py_majver': '3',
+        'req_py_minver': '6',
+        'source_urls': ['https://pypi.python.org/packages/source/p/packaging/'],
+        }),
+    ('Pillow', '6.1.0', {
+        'req_py_majver': '3',
+        'req_py_minver': '6',
+        'modulename': 'PIL',
+        'source_urls': ['https://pypi.python.org/packages/source/p/Pillow/'],
+        }),
+
+# bqplot: requires the labextension below
+    ('traittypes', '0.2.1', {
+        'req_py_majver': '3',
+        'req_py_minver': '6',
+        'source_urls': ['https://pypi.python.org/packages/source/t/traittypes/'],
+        }),
+    ('bqplot', '0.11.6', {
+        'req_py_majver': '3',
+        'req_py_minver': '6',
+        'source_urls': ['https://pypi.python.org/packages/source/b/bqplot/'],
+        }),
+
+# nbresuse for jupyterlab-system-monitor extension
+    ('psutil', '5.6.3', {
+        'req_py_majver': '3',
+        'req_py_minver': '6',
+        'source_urls': ['https://pypi.python.org/packages/source/p/psutil/'],
+        }),
+    ('nbresuse', '0.3.2', {
+        'req_py_majver': '3',
+        'req_py_minver': '6',
+        'source_urls': ['https://pypi.python.org/packages/source/n/nbresuse/'],
+        }),
+
+# jupyterlab-slrum extension to implement common slurm commands in the notebook, not ready for jlab 1.0, 0.1.3 is ready but not yet in pypi, twr
+#    ('jupyterlab_slurm', '0.1.1', {
+#        'req_py_majver': '3',
+#        'req_py_minver': '6',
+#        'source_urls': ['https://pypi.python.org/packages/source/j/jupyterlab-slurm/'],
+#        }),
+
+# qgrid widgets: note that 1.1.1 is not yet supported with JupyterLab 1.x - commented for now, twr
+#    ('qgrid', '1.1.1', {
+#        'req_py_majver': '3',
+#        'req_py_minver': '6',
+#        'source_urls': ['https://pypi.python.org/packages/source/q/qgrid/'],
+#        }),
+
+]
+
+# specify that Bundle easyblock should run a full sanity check, rather than just trying to load the module
+full_sanity_check = True
+
+modextrapaths = {'PYTHONPATH': ['lib/python%s/site-packages' % pyshortver]}
+
+modextravars = {
+    'JUPYTERLAB_DIR': "%(installdir)s/share/jupyter/lab/",
+}
+
+# install extensions
+# jupyterlab/hub-extension no longer needed as the hub menu is built into jupyterlab core from JLab 1.x, twr
+postinstallcmds = ["export YARN_CACHE_FOLDER=/tmp/$USER/yarn_cache;"
+                   "export JUPYTERLAB_DIR=%(installdir)s/share/jupyter/lab/;"
+                   "export PYTHONPATH=%(installdir)s/lib/python3.6/site-packages:$PYTHONPATH;"
+                   "%(installdir)s/bin/jupyter-labextension install -y @jupyter-widgets/jupyterlab-manager@1.0;"
+                   "%(installdir)s/bin/jupyter labextension install jupyter-matplotlib;"
+                   "%(installdir)s/bin/jupyter labextension install -y plotlywidget@1.0.0;"
+                   "%(installdir)s/bin/jupyter labextension install -y jupyterlab-plotly@1.0.0;"
+                   "%(installdir)s/bin/jupyter labextension install -y jupyterlab-chart-editor@1.2;"
+                   "%(installdir)s/bin/jupyter labextension install -y jupyterlab_bokeh@1.0.0;"
+                   "%(installdir)s/bin/jupyter labextension install -y bqplot@0.4.6;"
+                   "%(installdir)s/bin/jupyter labextension install jupyterlab-topbar-extension jupyterlab-system-monitor;"
+                   "%(installdir)s/bin/jupyter labextension install dask-labextension;"
+                   "%(installdir)s/bin/jupyter serverextension enable jupyter_server_proxy;"
+#                   "%(installdir)s/bin/jupyter labextension install -y jupyterlab-slurm;" #not ready for JLab 1.x, twr
+#                   "%(installdir)s/bin/jupyter labextension install -y qgrid@1.1.1;" #qgrid not yet working in JLab 1.x, twr
+                   "rm -r $YARN_CACHE_FOLDER"]
+sanity_check_paths = {
+    'files': [],
+    'dirs': ['lib/python%s/site-packages' % pyshortver,
+             'share/jupyter/lab/extensions',
+             'share/jupyter/lab/schemas',
+             'share/jupyter/lab/staging',
+             'share/jupyter/lab/static',
+             'share/jupyter/lab/themes',
+             ]
+}
+
+
+moduleclass = 'tools'


### PR DESCRIPTION
JLab 1.x. Major upgrade of JLab easyconfig file with inclusion of JHub dependecies directly and a host of extensions including jupyter-widgets, plotlywidgets, bokeh, topbar, bqplot, dask-labextension, jupyter_server_proxy. hub-extension itself is no longer required as the hub functionality it is built directly in JLab core.