### PR TITLE
[daint-gpu] Change EasyBuild sourcepath in JenkinsfileRegressionEB

### DIFF
--- a/jenkins/JenkinsfileRegressionEB
+++ b/jenkins/JenkinsfileRegressionEB
@@ -71,7 +71,8 @@ stage('Build Stage') {
                     def command = "$workingDir/jenkins-builds/production.sh $listFlag --prefix=$prefix $unuseFlag"
                     if (arch != '')
                         command = "srun -u --constraint=$arch --job-name=$project_name --time=24:00:00 $workingDir/jenkins-builds/production.sh --arch=$arch $listFlag --prefix=$prefix $unuseFlag --xalt=no"
-                    withEnv(["EASYBUILD_TMPDIR=$prefix/sources",
+                    withEnv(["EASYBUILD_SOURCEPATH=$prefix/sources",
+                             "EASYBUILD_TMPDIR=$prefix/tmp",
                              "EASYBUILD_BUILDPATH=$buildPath"]) {
                                  sh("""$loginBash
                                        $moduleDefinition


### PR DESCRIPTION
I have defined the variable `EASYBUILD_SOURCEPATH` to download the packages to be installed by RegressionEB. I have also corrected the variable `EASYBUILD_TMPDIR` to write logs in the subfolder `tmp` of the `EASYBUILD_PREFIX` folder.