### PR TITLE
[dom] Update jupyterlab-1.0.4-CrayGNU-19.06.eb

### DIFF
--- a/easybuild/easyconfigs/j/jupyterlab/jupyterlab-1.0.4-CrayGNU-19.06.eb
+++ b/easybuild/easyconfigs/j/jupyterlab/jupyterlab-1.0.4-CrayGNU-19.06.eb
@@ -492,7 +492,10 @@ full_sanity_check = True
 # For Julia packages needed for Jupyter
 julia_depot_path = "%(installdir)s/share/julia/site/"
 
-modextrapaths = {'PYTHONPATH': ['lib/python%s/site-packages' % pyshortver]}
+modextrapaths = {
+    'PYTHONPATH': ['lib/python%s/site-packages' % pyshortver],
+    'JUPYTER_PATH': "%(installdir)s/share/jupyter/",
+}
 
 modextravars = {
     'JUPYTERLAB_DIR': "%(installdir)s/share/jupyter/lab/",

--- a/easybuild/easyconfigs/j/jupyterlab/jupyterlab-1.0.4-CrayGNU-19.06.eb
+++ b/easybuild/easyconfigs/j/jupyterlab/jupyterlab-1.0.4-CrayGNU-19.06.eb
@@ -494,7 +494,7 @@ julia_depot_path = "%(installdir)s/share/julia/site/"
 
 modextrapaths = {
     'PYTHONPATH': ['lib/python%s/site-packages' % pyshortver],
-    'JUPYTER_PATH': "%(installdir)s/share/jupyter/",
+    'JUPYTER_PATH': 'share/jupyter',
 }
 
 modextravars = {


### PR DESCRIPTION
Added JUPYTER_PATH to make centrally-installed kernels available in addition to the ones in the user's ~/.local/share/jupyter directory.