### PR TITLE
[daint-gpu] Update 6.0.UP07-18.08-gpu

### DIFF
--- a/jenkins-builds/6.0.UP07-18.08-gpu
+++ b/jenkins-builds/6.0.UP07-18.08-gpu
@@ -38,7 +38,8 @@
  jupyterhub-0.9.4-CrayGNU-18.08.eb                  --set-default-module
  jupyterhub-0.9.6-CrayGNU-18.08.eb
  jupyterlab-0.35.2-CrayGNU-18.08.eb
- jupyterlab-1.0.4-CrayGNU-18.08.eb                  --set-default-module
+ jupyterlab-1.0.4-CrayGNU-18.08.eb                  
+ jupyterlab-1.1.1-CrayGNU-18.08.eb                  --set-default-module
  LAMMPS-22Aug2018-CrayGNU-18.08-cuda-9.1.eb         --set-default-module
  Lmod-7.8.2.eb                                      --set-default-module --hidden
  magma-2.2.0-CrayGNU-18.08-cuda-9.1.eb              --set-default-module


### PR DESCRIPTION
Installed 1.1.1 and upgraded default module - 1.0.4 can no longer be built thanks to a npm dependency update (beyond our control).