### PR TITLE
[dom-mc] Update 6.0.UP07-18.08-mc

### DIFF
--- a/jenkins-builds/6.0.UP07-18.08-mc
+++ b/jenkins-builds/6.0.UP07-18.08-mc
@@ -34,7 +34,8 @@
  jupyterhub-0.9.4-CrayGNU-18.08.eb                  --set-default-module
  jupyterhub-0.9.6-CrayGNU-18.08.eb
  jupyterlab-0.35.2-CrayGNU-18.08.eb
- jupyterlab-1.0.4-CrayGNU-18.08.eb                  --set-default-module
+ jupyterlab-1.0.4-CrayGNU-18.08.eb                  
+ jupyterlab-1.1.1-CrayGNU-18.08.eb                  --set-default-module
  LAMMPS-22Aug2018-CrayGNU-18.08.eb                  --set-default-module
  LLVM-5.0.0-CrayGNU-18.08.eb
  Lmod-7.8.2.eb                                      --set-default-module --hidden


### PR DESCRIPTION
Installed jlab 1.1.1 and set as default. 1.0.4 can no longer be built thanks to npm dependency beyond our control.