### PR TITLE
[daint-mc] Update 6.0.UP07-18.08-mc

### DIFF
--- a/jenkins-builds/6.0.UP07-18.08-mc
+++ b/jenkins-builds/6.0.UP07-18.08-mc
@@ -33,6 +33,7 @@
  jupyter-1.0.0-CrayGNU-18.08.eb
  jupyterhub-0.9.4-CrayGNU-18.08.eb                  --set-default-module
  jupyterhub-0.9.6-CrayGNU-18.08.eb
+ jupyterhub-1.0.0-CrayGNU-18.08.eb
  jupyterlab-0.35.2-CrayGNU-18.08.eb
  jupyterlab-1.0.4-CrayGNU-18.08.eb                  
  jupyterlab-1.1.1-CrayGNU-18.08.eb                  --set-default-module


### PR DESCRIPTION
JHub 1.0.0 is still needed to support the legacy 0.35.2 since the upgrade to JHub 1.0 on server side.