### PR TITLE
[daint] Easyconfig for the bugfix release of ReFrame 2.17.1

### DIFF
--- a/easybuild/easyconfigs/r/reframe/reframe-2.17.1.eb
+++ b/easybuild/easyconfigs/r/reframe/reframe-2.17.1.eb
@@ -1,0 +1,31 @@
+# @author: gppezzi, vkarak, manitart
+
+easyblock = 'Tarball'
+
+name = 'reframe'
+version = '2.17.1'
+homepage = 'https://eth-cscs.github.io/reframe'
+description = 'A regression framework for writing portable tests for HPC systems.'
+toolchain = {'name': 'dummy', 'version': ''}
+sources = [
+    {
+        'filename': 'v%(version)s.tar.gz',
+        'source_urls': ['https://github.com/eth-cscs/reframe/archive/']
+    },
+    {
+        'filename': '/apps/common/easybuild/sources/%(nameletterlower)s/'
+                    '%(name)s/reframe-tests-%(version)s.tar.gz'
+    }
+]
+dependencies = [('Python-bare', '3.6.6')]
+keepsymlinks = True
+postinstallcmds = [
+    'cp %(installdir)s/config/cscs.py %(installdir)s/reframe/settings.py',
+    'cp -r %(builddir)s/reframe-tests-%(version)s/checks %(installdir)s/cscs-checks/private',
+    'mv %(installdir)s/cscs-checks %(installdir)s/checks'
+]
+sanity_check_paths = {
+    'files': ['reframe.py', 'bin/reframe', 'config/cscs.py'],
+    'dirs':  ['bin', 'checks', 'checks/private', 'unittests'],
+}
+moduleclass = 'devel'


### PR DESCRIPTION
The 2.17.1 release of ReFrame is back porting from master some essential fixes to 2.17, the release we currently run on Daint. It back ports the following patches:

- Slurm backend fixes, so that ReFrame does not hang with the later Slurm versions
- Maintenance slurm tests updated.
- Vtune Inspector test

It is essential to merge this PR by today, so that reframe can run without a problem during the weekend.