### PR TITLE
[daint-gpu] building ParaView 5.7-RC3 for daint for the Visualization class

### DIFF
--- a/easybuild/easyconfigs/o/OpenImageDenoise/oidn-0.9.0-CrayGNU-18.08.eb
+++ b/easybuild/easyconfigs/o/OpenImageDenoise/oidn-0.9.0-CrayGNU-18.08.eb
@@ -1,0 +1,20 @@
+easyblock = "Tarball"
+
+name = 'oidn'
+version = '0.9.0'
+
+homepage = 'https://openimagedenoise.github.io'
+description = """Intel® Open Image Denoise is an open source library of high-performance,
+high-quality denoising filters for images rendered with ray tracing"""
+
+toolchain = {'name': 'CrayGNU', 'version': '18.08'}
+
+sources = ['oidn-%(version)s.x86_64.linux.tar.gz']
+source_urls = ['https://github.com/OpenImageDenoise/oidn/releases/download/v%(version)s/']
+
+sanity_check_paths={
+    'files': [],
+    'dirs': ['include', 'lib']
+}
+
+moduleclass = 'devel'

--- a/easybuild/easyconfigs/o/ospray/ospray-1.8.5-CrayGNU-18.08.eb
+++ b/easybuild/easyconfigs/o/ospray/ospray-1.8.5-CrayGNU-18.08.eb
@@ -1,0 +1,20 @@
+easyblock = "Tarball"
+
+name = 'ospray'
+version = '1.8.5'
+
+homepage = 'https://github.com/ospray'
+description = """An Open, Scalable, Parallel, Ray Tracing Based Rendering
+Engine for High-Fidelity Visualization"""
+
+toolchain = {'name': 'CrayGNU', 'version': '18.08'}
+
+sources = ['ospray-%(version)s.x86_64.linux.tar.gz']
+source_urls = ['https://github.com/ospray/ospray/releases/download/v%(version)s/']
+
+sanity_check_paths={
+    'files': [],
+    'dirs': ['include', 'lib']
+}
+
+moduleclass = 'devel'

--- a/easybuild/easyconfigs/p/ParaView/ParaView-5.7.0-EGL-CrayGNU-18.08.eb
+++ b/easybuild/easyconfigs/p/ParaView/ParaView-5.7.0-EGL-CrayGNU-18.08.eb
@@ -1,0 +1,91 @@
+# CrayGNU version by Jean Favre (CSCS)
+
+easyblock = 'CMakeMake'
+
+name = 'ParaView'
+version = '5.7.0-RC3'
+versionsuffix='-EGL'
+
+homepage = "http://www.paraview.org"
+description = "ParaView is a scientific parallel visualizer."
+
+toolchain = {'name': 'CrayGNU', 'version': '18.08'}
+toolchainopts = {'pic': True, 'usempi': True, 'verbose': False}
+
+download_suffix = 'download.php?submit=Download&version=v%(version_major_minor)s&type=source&os=all&downloadFile='
+source_urls = ['http://www.paraview.org/paraview-downloads/%s' % download_suffix]
+sources = ["ParaView-v%(version)s.tar.gz"]
+
+#patches = ['VisRTX_Camera.patch']
+
+py_maj_ver = '3'
+py_min_ver = '6'
+py_rev_ver = '5.1'
+
+pyver = '%s.%s.%s' % (py_maj_ver, py_min_ver, py_rev_ver)
+pyshortver = '%s.%s' % (py_maj_ver, py_min_ver)
+pysuff = '-python%s' % py_maj_ver
+
+dependencies = [
+    ('h5py', '2.8.0', '%s-serial' % pysuff),
+    ('ospray', '1.8.5'),
+    ('oidn', '0.9.0'),
+#    ('VisRTX', '0.1.5'), not available until NVIDIA driver is updated
+    ('cray-python/%s' % pyver, EXTERNAL_MODULE)
+]
+
+builddependencies = [('CMake', '3.14.5','', True)]
+
+separate_build_dir = True
+
+maxparallel = 16
+
+configopts =  '-DPARAVIEW_USE_MPI:BOOL=ON '
+configopts += '-DMPI_C_COMPILER=cc -DMPI_CXX_COMPILER=CC '
+configopts += '-DBUILD_TESTING:BOOL=OFF -DPARAVIEW_ENABLE_CATALYST:BOOL=ON '
+configopts += '-DCMAKE_EXE_LINKER_FLAGS_RELWITHDEBINFO="-Wl,-rpath,/opt/cray/nvidia/default/lib64 -L/opt/cray/nvidia/default/lib64" '
+configopts += '-DPARAVIEW_ENABLE_PYTHON:BOOL=ON -DPYTHON_EXECUTABLE=${EBROOTPYTHON}/bin/python3 '
+configopts += '-DCMAKE_BUILD_TYPE=RelWithDebInfo -DPARAVIEW_BUILD_SHARED_LIBS:BOOL=ON '
+# use TBB for on-the-node parallelism
+configopts += '-DVTK_SMP_IMPLEMENTATION_TYPE=TBB -DTBB_INCLUDE_DIR:PATH=/opt/intel/compilers_and_libraries/linux/tbb/include '
+configopts += '-DTBB_LIBRARY_RELEASE:FILEPATH=${EBROOTOSPRAY}/lib/libtbb.so -DTBB_MALLOC_LIBRARY_RELEASE:FILEPATH=${EBROOTOSPRAY}/lib/libtbbmalloc.so '
+#
+configopts += '-DOPENGL_gl_LIBRARY=/opt/cray/nvidia/default/lib64/libGL.so '
+configopts += '-DOPENGL_INCLUDE_DIR=/opt/cray/nvidia/default/include '
+configopts += '-DPARAVIEW_ENABLE_XDMF3:BO0L=OFF '
+configopts += '-DPARAVIEW_BUILD_QT_GUI:BOOL=OFF -DPARAVIEW_ENABLE_WEB:BOOL=OFF '
+# CSCS specific for EGL
+configopts += '-DVTK_OPENGL_HAS_EGL:BOOL=ON -DOPENGL_egl_LIBRARY=/opt/cray/nvidia/default/lib64/libEGL.so -DOPENGL_opengl_LIBRARY=/opt/cray/nvidia/default/lib64/libOpenGL.so -DVTK_USE_X:BOOL=OFF '
+# CSCS specific for Raytracing (OSPRAY and/or OptiX)
+configopts += '-DPARAVIEW_USE_RAYTRACING:BOOL=ON '
+configopts += '-DVTK_ENABLE_OSPRAY:BOOL=ON '
+#configopts += '-DVTK_ENABLE_VISRTX:BOOL=ON '
+configopts += '-DVTKOSPRAY_ENABLE_DENOISER:BOOL=ON '
+configopts += '-DOSPRAY_INSTALL_DIR="$EBROOTOSPRAY" '
+configopts += '-DOpenImageDenoise_DIR="$EBROOTOIDN/lib/cmake/OpenImageDenoise" '
+#configopts += '-DVisRTX_DIR="$EBROOTVISRTX/lib64/cmake/VisRTX-0.1.5" '
+# Using Cray HDF5
+#configopts += '-DVTK_MODULE_USE_EXTERNAL_VTK_hdf5:BOOL=ON -DHDF5_DIR=$HDF5_DIR '
+#configopts += '-DHDF5_C_INCLUDE_DIR="$HDF5_DIR"/include '
+#configopts += '-DHDF5_hdf5_LIBRARY_RELEASE="$HDF5_DIR"/lib/libhdf5.so -DHDF5_hdf5_hl_LIBRARY_RELEASE="$HDF5_DIR"/lib/libhdf5_hl.so '
+# Using CSCS NVIDIA IndeX lib
+configopts += '-DPARAVIEW_PLUGIN_ENABLE_pvNVIDIAIndeX:BOOL=ON '
+
+# Or consult https://gitlab.kitware.com/vtk/vtk/blob/master/Documentation/dev/git/data.md
+# and download ExternalData to $EASYBUILD_SOURCEPATH and adjust -DExternalData_OBJECT_STORES accordingly
+# Without internet connection, comment the following two lines (configopts and prebuildopts)
+# configopts += '-DExternalData_OBJECT_STORES=%(builddir)s/ExternalData '
+# The ParaView server can be cranky, test downloads are quite often failing, especially in the case
+# of parallel downloads. Using ; insted of && gives a second chance to download the test files, if the
+# first serial attempt would fail.
+#prebuildopts = 'make VTKData ;'
+
+modextravars = { 'LD_LIBRARY_PATH':'/apps/common/UES/easybuild/sources/p/ParaView/nvindex_default/linux-x86-64/lib:/project/g33/messmerp/cosmo/backup/vizlibs:/opt/python/%s/lib:$::env(LD_LIBRARY_PATH)' % pyver, 
+                 'NVINDEX_PVPLUGIN_HOME':'/apps/common/UES/easybuild/sources/p/ParaView'}
+
+sanity_check_paths = {
+    'files': ['bin/pvbatch', 'bin/pvserver'],
+    'dirs': [],
+}
+
+moduleclass = 'vis'


### PR DESCRIPTION
Since the viz tutorial at CSCS is scheduled for september 25 and the official version 5.7 is late, I need to build the Release Candidate 3 right away to make sure I have something to test.

N.B. The VisRTX support is also commented out until daint gets a new OpenGL driver after the move to 19.06.

== COMPLETED: Installation ended successfully
== Results of the build can be found in the log file(s) /scratch/snx3000/jfavre/daint/software/ParaView/5.7.0-RC3-CrayGNU-18.08-EGL/easybuild/easybuild-ParaView-5.7.0-RC3-20190909.141235.log
== Build succeeded for 1 out of 1
