### PR TITLE
[daint] Update 6.0.UP07-18.08-gpu and 6.0.UP07-18.08-mc to remove JLab 1.0.4 and dask-labextension

### DIFF
--- a/jenkins-builds/6.0.UP07-18.08-gpu
+++ b/jenkins-builds/6.0.UP07-18.08-gpu
@@ -12,7 +12,6 @@
  dask-1.0.0-CrayGNU-18.08-python3.eb
  dask-1.2.2-CrayGNU-18.08-python3.eb                
  dask-2.2.0-CrayGNU-18.08-python3.eb                --set-default-module
- dask-labextension-1.0.3-CrayGNU-18.08-python3.eb
  GREASY-19.03-cscs.eb                               --set-default-module
  GROMACS-2018.3-CrayGNU-18.08-cuda-9.1.eb           --set-default-module
  GROMACS-2019-CrayGNU-18.08-cuda-9.1.eb

--- a/jenkins-builds/6.0.UP07-18.08-gpu
+++ b/jenkins-builds/6.0.UP07-18.08-gpu
@@ -40,8 +40,7 @@
  jupyterhub-0.9.4-CrayGNU-18.08.eb                  --set-default-module
  jupyterhub-0.9.6-CrayGNU-18.08.eb
  jupyterhub-1.0.0-CrayGNU-18.08.eb
- jupyterlab-0.35.2-CrayGNU-18.08.eb
- jupyterlab-1.0.4-CrayGNU-18.08.eb                  
+ jupyterlab-0.35.2-CrayGNU-18.08.eb             
  jupyterlab-1.1.1-CrayGNU-18.08.eb                  --set-default-module
  LAMMPS-22Aug2018-CrayGNU-18.08-cuda-9.1.eb         --set-default-module
  Lmod-7.8.2.eb                                      --set-default-module --hidden

--- a/jenkins-builds/6.0.UP07-18.08-mc
+++ b/jenkins-builds/6.0.UP07-18.08-mc
@@ -12,7 +12,6 @@
  dask-1.0.0-CrayGNU-18.08-python3.eb
  dask-1.2.2-CrayGNU-18.08-python3.eb                
  dask-2.2.0-CrayGNU-18.08-python3.eb                --set-default-module
- dask-labextension-1.0.3-CrayGNU-18.08-python3.eb
  GREASY-19.03-cscs.eb                               --set-default-module
  GROMACS-2018.3-CrayGNU-18.08.eb                    --set-default-module
  GSL-2.5-CrayGNU-18.08.eb                           --set-default-module

--- a/jenkins-builds/6.0.UP07-18.08-mc
+++ b/jenkins-builds/6.0.UP07-18.08-mc
@@ -34,8 +34,7 @@
  jupyterhub-0.9.4-CrayGNU-18.08.eb                  --set-default-module
  jupyterhub-0.9.6-CrayGNU-18.08.eb
  jupyterhub-1.0.0-CrayGNU-18.08.eb
- jupyterlab-0.35.2-CrayGNU-18.08.eb
- jupyterlab-1.0.4-CrayGNU-18.08.eb                  
+ jupyterlab-0.35.2-CrayGNU-18.08.eb                  
  jupyterlab-1.1.1-CrayGNU-18.08.eb                  --set-default-module
  LAMMPS-22Aug2018-CrayGNU-18.08.eb                  --set-default-module
  LLVM-5.0.0-CrayGNU-18.08.eb


### PR DESCRIPTION
Remove JLab 1.0.4 from this list as it can no longer be built. Remove dask-labextension from this list as it is now included directly in the jupyterlab easybuild recipe. 