### PR TITLE
[daint] Add easyconfigs for ReFrame 2.17.2, 2.18 and 2.19 for Daint

### DIFF
--- a/easybuild/easyconfigs/r/reframe/reframe-2.17.2.eb
+++ b/easybuild/easyconfigs/r/reframe/reframe-2.17.2.eb
@@ -1,0 +1,31 @@
+# @author: gppezzi, vkarak, manitart
+
+easyblock = 'Tarball'
+
+name = 'reframe'
+version = '2.17.2'
+homepage = 'https://eth-cscs.github.io/reframe'
+description = 'A regression framework for writing portable tests for HPC systems.'
+toolchain = {'name': 'dummy', 'version': ''}
+sources = [
+    {
+        'filename': 'v%(version)s.tar.gz',
+        'source_urls': ['https://github.com/eth-cscs/reframe/archive/']
+    },
+    {
+        'filename': '/apps/common/easybuild/sources/%(nameletterlower)s/'
+                    '%(name)s/reframe-tests-%(version)s.tar.gz'
+    }
+]
+dependencies = [('Python-bare', '3.6.6')]
+keepsymlinks = True
+postinstallcmds = [
+    'cp %(installdir)s/config/cscs.py %(installdir)s/reframe/settings.py',
+    'cp -r %(builddir)s/reframe-tests-%(version)s/checks %(installdir)s/cscs-checks/private',
+    'mv %(installdir)s/cscs-checks %(installdir)s/checks'
+]
+sanity_check_paths = {
+    'files': ['reframe.py', 'bin/reframe', 'config/cscs.py'],
+    'dirs':  ['bin', 'checks', 'checks/private', 'unittests'],
+}
+moduleclass = 'devel'

--- a/jenkins-builds/6.0.UP07-18.08-gpu
+++ b/jenkins-builds/6.0.UP07-18.08-gpu
@@ -63,9 +63,6 @@
  PyExtensions-2.7.15.1-CrayGNU-18.08.eb
  PyExtensions-3.6.5.1-CrayGNU-18.08.eb
  QuantumESPRESSO-6.3-CrayIntel-18.08.eb             --set-default-module
- reframe-2.17.2                                     --set-default-module --installpath=$APPS/UES/jenkins/6.0.UP07/gpu/easybuild/reframe
- reframe-2.18                                                            --installpath=$APPS/UES/jenkins/6.0.UP07/gpu/easybuild/reframe
- reframe-2.19                                                            --installpath=$APPS/UES/jenkins/6.0.UP07/gpu/easybuild/reframe
  Spark-2.3.1-CrayGNU-18.08-Hadoop-2.7.eb
  singularity-3.2.1-daint.eb
  TensorFlow-1.7.0-CrayGNU-18.08-cuda-9.1-python3.eb --set-default-module

--- a/jenkins-builds/6.0.UP07-18.08-gpu
+++ b/jenkins-builds/6.0.UP07-18.08-gpu
@@ -63,6 +63,9 @@
  PyExtensions-2.7.15.1-CrayGNU-18.08.eb
  PyExtensions-3.6.5.1-CrayGNU-18.08.eb
  QuantumESPRESSO-6.3-CrayIntel-18.08.eb             --set-default-module
+ reframe-2.17.2                                     --set-default-module --installpath=$APPS/UES/jenkins/6.0.UP07/gpu/easybuild/reframe
+ reframe-2.18
+ reframe-2.19
  Spark-2.3.1-CrayGNU-18.08-Hadoop-2.7.eb
  singularity-3.2.1-daint.eb
  TensorFlow-1.7.0-CrayGNU-18.08-cuda-9.1-python3.eb --set-default-module

--- a/jenkins-builds/6.0.UP07-18.08-gpu
+++ b/jenkins-builds/6.0.UP07-18.08-gpu
@@ -64,8 +64,8 @@
  PyExtensions-3.6.5.1-CrayGNU-18.08.eb
  QuantumESPRESSO-6.3-CrayIntel-18.08.eb             --set-default-module
  reframe-2.17.2                                     --set-default-module --installpath=$APPS/UES/jenkins/6.0.UP07/gpu/easybuild/reframe
- reframe-2.18
- reframe-2.19
+ reframe-2.18                                                            --installpath=$APPS/UES/jenkins/6.0.UP07/gpu/easybuild/reframe
+ reframe-2.19                                                            --installpath=$APPS/UES/jenkins/6.0.UP07/gpu/easybuild/reframe
  Spark-2.3.1-CrayGNU-18.08-Hadoop-2.7.eb
  singularity-3.2.1-daint.eb
  TensorFlow-1.7.0-CrayGNU-18.08-cuda-9.1-python3.eb --set-default-module


### PR DESCRIPTION
This time I am updating also the `gpu` production list so as to remove ReFrame from `/apps/common` and I am using a separate install path. I am planning to put a symlink to the actual modules inside the `login/` folder as we do for `xalt`, but I am not sure how to make it point it  differently for Daint and Dom now.