### PR TITLE
PyCUDA: Fix for eb 4 compatibility

### DIFF
--- a/easybuild/easyblocks/pycuda.py
+++ b/easybuild/easyblocks/pycuda.py
@@ -34,8 +34,12 @@ EasyBuild support for Python packages, implemented as an easyblock
 import os
 import tempfile
 from os.path import expanduser
-#from vsc import fancylogger
-from vsc.utils import fancylogger
+try:
+    # EasyBuild 4.0 and newer
+    from easybuild.base import fancylogger
+except ImportError:
+    # EasyBuild 3.x
+    from vsc.utils import fancylogger
 
 import easybuild.tools.environment as env
 from easybuild.easyblocks.python import EXTS_FILTER_PYTHON_PACKAGES


### PR DESCRIPTION
This is to ensure that the pycuda easyblock is compatible with EB4 as well with older EB versions.

However we could potentially delete this custom easyblock (it seems that pycuda now builds with stock version, but I didn't test it).

Thanks @boegel !