### PR TITLE
[WIP] [dom-gpu] PoC CrayGNU 19.09 toolchain with CDT

### DIFF
--- a/easybuild/cray_external_modules_metadata.cfg-cdt
+++ b/easybuild/cray_external_modules_metadata.cfg-cdt
@@ -1,0 +1,13 @@
+# metadata useful to EasyBuild (hpcugent.github.io/easybuild) for modules provided by Cray on Cray systems
+# authors: Guilherme Peretti-Pezzi (CSCS), Petar Forai (IMP/IMBA), Kenneth Hoste (HPC-UGent), Eirini Koutsaniti (CSCS)
+
+[cray-hdf5]
+name = HDF5
+version = 1.10.5.1
+prefix = HDF5_DIR
+
+[cray-netcdf]
+name = netCDF, netCDF-Fortran
+version = 4.6.3.1, 4.6.3.1
+prefix = NETCDF_DIR
+

--- a/easybuild/easyconfigs/c/CDO/CDO-1.9.5-CrayGNU-19.09-cdt.eb
+++ b/easybuild/easyconfigs/c/CDO/CDO-1.9.5-CrayGNU-19.09-cdt.eb
@@ -1,0 +1,39 @@
+# Updated by @gppezzi, @jgphpc, @omlins
+easyblock = 'ConfigureMake'
+
+name = 'CDO'
+version = '1.9.5'
+
+homepage = 'https://code.zmaw.de/projects/cdo'
+description = """
+    CDO is a collection of command line Operators to manipulate and analyse
+    Climate and NWP model Data.
+"""
+
+toolchain = {'name': 'CrayGNU', 'version': '19.09-cdt'}
+toolchainopts = {'opt': True, 'pic': True}
+
+# Files visible at https://code.mpimet.mpg.de/projects/cdo/files,
+# however link is different for each version!
+source_urls = ['https://code.mpimet.mpg.de/attachments/download/18264/'] 
+sources = [SOURCELOWER_TAR_GZ]
+checksums = [ '0c60f2c94dc5c76421ecf363153a5043' ]
+
+dependencies = [
+    ('cray-netcdf', EXTERNAL_MODULE),
+    ('cray-hdf5', EXTERNAL_MODULE),
+    # CDO: OpenMP support for compute intensive operators:
+    # https://code.zmaw.de/projects/cdo/wiki/OpenMP_support
+    # No MPI support
+]
+
+preconfigopts = 'export NC_CONFIG=`which nc-config` && '
+
+configopts = "--with-hdf5=$HDF5_DIR --with-netcdf=$EBROOTNETCDFMINFORTRAN "
+
+sanity_check_paths = {
+    'files': ["bin/cdo"],
+    'dirs': [],
+}
+
+moduleclass = 'data'

--- a/easybuild/easyconfigs/c/CrayGNU/CrayGNU-19.09-cdt.eb
+++ b/easybuild/easyconfigs/c/CrayGNU/CrayGNU-19.09-cdt.eb
@@ -1,0 +1,23 @@
+easyblock = 'CrayToolchain'
+
+name = 'CrayGNU'
+version = '19.09-cdt'
+
+homepage = 'https://pubs.cray.com/discover'
+description = """Toolchain using Cray compiler wrapper, using PrgEnv-gnu module
+(PE release: September 2019).\n"""
+
+toolchain = {'name': 'dummy', 'version': 'dummy'}
+
+dependencies = [
+    # PrgEnv version is not pinned, as Cray recommends to use the latest
+    # (default) version
+    ('PrgEnv-gnu', EXTERNAL_MODULE),
+    ('cdt/19.09', EXTERNAL_MODULE),
+    # -----------------
+    ('gcc/8.3.0', EXTERNAL_MODULE),
+]
+
+# LD_LIBRARY_PATH is now updated by production.git/login/daint.footer
+
+moduleclass = 'toolchain'


### PR DESCRIPTION
PoC using defaults from CDT. 

Goal is to minimise the changes needed in the `EXTERNAL_MODULES` when deploying a software stack with a new toolchain version. 

The idea is that, for a specific cdt, only dependencies requiring non-default versions should be pinned in the easyconfigs. By non-default I mean w.r.t the cdt defaults, not to be confused with the system defaults

Here's how to test:

```
export EASYBUILD_EXTERNAL_MODULES_METADATA=..../production/easybuild/cray_external_modules_metadata.cfg-19.09
```
Caveats so far:
- it would require one metadata file per CDT version
- module load is quite verbose (when it loads `cdt`)