### PR TITLE
[dom] Change deprecated 'dummy' toolchain to 'SYSTEM'

### DIFF
--- a/easybuild/easyconfigs/c/CrayCCE/CrayCCE-19.09-classic.eb
+++ b/easybuild/easyconfigs/c/CrayCCE/CrayCCE-19.09-classic.eb
@@ -7,7 +7,7 @@ homepage = 'https://pubs.cray.com/discover'
 description = """Toolchain using Cray compiler wrapper, using PrgEnv-cray
 (PE release: September 2019).\n"""
 
-toolchain = {'name': 'dummy', 'version': 'dummy'}
+toolchain = SYSTEM
 
 dependencies = [
     # PrgEnv version is not pinned, as Cray recommends to use the latest

--- a/easybuild/easyconfigs/c/CrayCCE/CrayCCE-19.09.eb
+++ b/easybuild/easyconfigs/c/CrayCCE/CrayCCE-19.09.eb
@@ -7,7 +7,7 @@ homepage = 'https://pubs.cray.com/discover'
 description = """Toolchain using Cray compiler wrapper, using PrgEnv-cray
 (PE release: September 2019).\n"""
 
-toolchain = {'name': 'dummy', 'version': 'dummy'}
+toolchain = SYSTEM
 
 dependencies = [
     # PrgEnv version is not pinned, as Cray recommends to use the latest

--- a/easybuild/easyconfigs/c/CrayGNU/CrayGNU-19.09.eb
+++ b/easybuild/easyconfigs/c/CrayGNU/CrayGNU-19.09.eb
@@ -7,7 +7,7 @@ homepage = 'https://pubs.cray.com/discover'
 description = """Toolchain using Cray compiler wrapper, using PrgEnv-gnu module
 (PE release: September 2019).\n"""
 
-toolchain = {'name': 'dummy', 'version': 'dummy'}
+toolchain = SYSTEM
 
 dependencies = [
     # PrgEnv version is not pinned, as Cray recommends to use the latest

--- a/easybuild/easyconfigs/c/CrayIntel/CrayIntel-19.09.eb
+++ b/easybuild/easyconfigs/c/CrayIntel/CrayIntel-19.09.eb
@@ -7,7 +7,7 @@ homepage = 'https://pubs.cray.com/discover'
 description = """Toolchain using Cray compiler wrapper, using PrgEnv-intel
 (PE release: September 2019).\n"""
 
-toolchain = {'name': 'dummy', 'version': 'dummy'}
+toolchain = SYSTEM
 
 dependencies = [
     # PrgEnv version is not pinned, as Cray recommends to use the latest

--- a/easybuild/easyconfigs/c/CrayPGI/CrayPGI-19.09.eb
+++ b/easybuild/easyconfigs/c/CrayPGI/CrayPGI-19.09.eb
@@ -7,7 +7,7 @@ homepage = 'https://pubs.cray.com/discover'
 description = """Toolchain using Cray compiler wrapper, PrgEnv-pgi compiler
 (PE release: September 2019).\n"""
 
-toolchain = {'name': 'dummy', 'version': 'dummy'}
+toolchain = SYSTEM
 
 dependencies = [
     # PrgEnv version is not pinned, as Cray recommends to use the latest


### PR DESCRIPTION
Change deprecated 'dummy' toolchain to 'SYSTEM', since we are using EasyBuild 4.0.0