### PR TITLE
[dom-gpu] Latest release of NCO

### DIFF
--- a/easybuild/easyconfigs/n/NCO/NCO-4.8.1-CrayGNU-19.09.eb
+++ b/easybuild/easyconfigs/n/NCO/NCO-4.8.1-CrayGNU-19.09.eb
@@ -1,0 +1,28 @@
+# contributed by Luca Marsella (CSCS), updated by Samuel Omlin (CSCS)
+easyblock = 'ConfigureMake'
+
+name = 'NCO'
+version = "4.8.1"
+
+homepage = 'http://nco.sourceforge.net/'
+description = """The NCO toolkit manipulates and analyzes data stored in netCDF-accessible formats, including DAP, HDF4, and HDF5."""
+
+toolchain = {'name': 'CrayGNU', 'version': '19.09'}
+toolchainopts = {'opt': True, 'pic': True}
+
+sources = ['https://github.com/nco/nco/archive/%s.tar.gz' % version]
+
+dependencies = [
+    ('ANTLR', '2.7.7', '-python2'),
+    ('cray-netcdf/4.6.3.1', EXTERNAL_MODULE),
+    ('cray-hdf5/1.10.5.1', EXTERNAL_MODULE),
+    ('JasPer', '2.0.14'),
+    ('UDUNITS', '2.2.26', '', True),
+]
+
+sanity_check_paths = {
+    'files': ["bin/ncbo"],
+    'dirs': [],
+}
+
+moduleclass = 'data'

--- a/jenkins-builds/7.0.UP01-19.09-gpu
+++ b/jenkins-builds/7.0.UP01-19.09-gpu
@@ -32,7 +32,7 @@
  magma-2.4.0-CrayIntel-19.09-cuda-10.1.eb           --set-default-module
  NAMD-2.13-CrayIntel-19.09-cuda-10.1.eb             --set-default-module
  NCL-6.4.0.eb                                       --set-default-module
- NCO-4.7.5-CrayGNU-19.09.eb                         --set-default-module
+ NCO-4.8.1-CrayGNU-19.09.eb                         --set-default-module
  ncview-2.1.7-CrayGNU-19.09.eb                      --set-default-module
  netcdf-python-1.4.1-CrayGNU-19.09-python2.eb
  netcdf-python-1.4.1-CrayGNU-19.09-python3.eb       --set-default-module

--- a/jenkins-builds/7.0.UP01-19.09-mc
+++ b/jenkins-builds/7.0.UP01-19.09-mc
@@ -30,7 +30,7 @@
  Lmod-7.8.2.eb                                      --set-default-module --hidden
  NAMD-2.13-CrayIntel-19.09.eb                       --set-default-module
  NCL-6.4.0.eb                                       --set-default-module
- NCO-4.7.5-CrayGNU-19.09.eb                         --set-default-module
+ NCO-4.8.1-CrayGNU-19.09.eb                         --set-default-module
  ncview-2.1.7-CrayGNU-19.09.eb                      --set-default-module
  netcdf-python-1.4.1-CrayGNU-19.09-python2.eb
  netcdf-python-1.4.1-CrayGNU-19.09-python3.eb       --set-default-module


### PR DESCRIPTION
The build of NCO `4.7.5` fails with the latest configuration on Dom. 
However, the latest release NCO `4.8.1` builds successfully.