### PR TITLE
[daint-gpu] Add support to hide hidden dependencies and exit on first error

### DIFF
--- a/easybuild/easyconfigs/b/Bison/Bison-3.3.2-CrayGNU-18.08.eb
+++ b/easybuild/easyconfigs/b/Bison/Bison-3.3.2-CrayGNU-18.08.eb
@@ -1,0 +1,24 @@
+# Contributed by Jean-Guillaume Piccinali and Luca Marsella (CSCS)
+easyblock = 'ConfigureMake'
+
+name = 'Bison'
+version = '3.3.2'
+
+homepage = 'http://www.gnu.org/software/bison'
+description = """Bison is a general-purpose parser generator that converts an annotated context-free grammar
+ into a deterministic LR or generalized LR (GLR) parser employing LALR(1) parser tables."""
+
+toolchain = {'name': 'CrayGNU', 'version': '18.08'}
+
+sources = [SOURCELOWER_TAR_GZ]
+source_urls = [GNU_SOURCE]
+
+dependencies = [('M4', '1.4.18')]
+
+sanity_check_paths = {
+    'files': ["bin/%s" % x for x in ["bison", "yacc"]] + ["lib/liby.a"],
+    'dirs': [],
+}
+
+moduleclass = 'lang'
+

--- a/easybuild/easyconfigs/g/GROMACS/GROMACS-2016.6-CrayGNU-18.08-cuda-9.1.eb
+++ b/easybuild/easyconfigs/g/GROMACS/GROMACS-2016.6-CrayGNU-18.08-cuda-9.1.eb
@@ -1,0 +1,42 @@
+# contributed by Luca Marsella, Victor Holanda Rusu (CSCS)
+#
+# This file is an EasyBuild reciPY as per https://github.com/hpcugent/easybuild
+#
+# Copyright:: Copyright 2012-2013 University of Luxembourg / LCSB, Cyprus Institute / CaSToRC, Ghent University
+# Authors::   Wiktor Jurkowski <wiktor.jurkowski@uni.lu>, Fotis Georgatos <fotis.georgatos@uni.lu>, \
+#             George Tsouloupas <g.tsouloupas@cyi.ac.cy>, Kenneth Hoste
+# License::   MIT/GPL
+# $Id$
+#
+# This work implements a part of the HPCBIOS project and is a component of the policy:
+# http://hpcbios.readthedocs.org/en/latest/HPCBIOS_2012-93.html
+#
+name = 'GROMACS'
+version = "2016.6"
+cudaversion = '9.1'
+versionsuffix = '-cuda-%s' % cudaversion
+
+homepage = 'http://www.gromacs.org'
+description = """GROMACS is a versatile package to perform molecular dynamics,
+ i.e. simulate the Newtonian equations of motion for systems with hundreds to millions of particles."""
+
+toolchain = {'name': 'CrayGNU', 'version': '18.08'}
+toolchainopts = {'usempi': True, 'openmp': True, 'pic': True, 'verbose': False, 'opt': True}
+
+source_urls = ['ftp://ftp.gromacs.org/pub/gromacs/']
+sources = [SOURCELOWER_TAR_GZ]
+
+skipsteps = ['test']
+
+# CMake dependency with dummy toolchain
+builddependencies = [
+    ('CMake', '3.12.0', '', True),
+    ('cray-fftw/3.3.6.5', EXTERNAL_MODULE),
+    ('cudatoolkit/%s.85_3.18-6.0.7.0_5.1__g2eb7c52' %cudaversion, EXTERNAL_MODULE),
+    ('libxml2', '2.9.7'),
+]
+dependencies = [
+    ('craype-accel-nvidia60', EXTERNAL_MODULE)
+]
+
+moduleclass = 'bio'

--- a/jenkins-builds/production.sh
+++ b/jenkins-builds/production.sh
@@ -165,7 +165,7 @@ if [ -n "${eb_lists}" ] && [ -n "${hidden_deps}" ]; then
   __eb_list=`eb --show-full-config | grep -i hide | awk -F'=' '{print $2}' | head -1`
   IFS=', ' read -r -a hidden_deps <<< ${__eb_list}
 
-# match force_list items with production lists: only matching items will be built using the EasyBuild flag '-f'
+# match  items with hide deps list: matching items will be built using the EasyBuild flag '--hidden'
  echo -e "Items matching hidden list and easybuild recipes to install (\"${eb_lists}\")"
  for item in ${hidden_deps[@]}; do
      hidden_match=$(grep $item ${eb_lists[@]})

--- a/jenkins-builds/production.sh
+++ b/jenkins-builds/production.sh
@@ -17,8 +17,8 @@ usage() {
     -p,--prefix       Absolute path to EasyBuild prefix  (mandatory: installation folder)
     -u,--unuse        Module unuse colon separated PATH  (optional: default is null)
     -x,--xalt         [yes|no] update XALT database      (optional: default is yes)
-    --hide-deps       Hide the hidden dependencies
-    --exit-on-error   Hide the hidden dependencies
+    --hide-deps       Force hide modules listed in 'hide-deps' (TestingEB only)
+    --exit-on-error   Exit when an error occurs (TestingEB only)
     "
     exit 1;
 }

--- a/jenkins-builds/production.sh
+++ b/jenkins-builds/production.sh
@@ -10,19 +10,20 @@ scriptdir=$(dirname $0)
 
 usage() {
     echo -e "\n Usage: $0 [OPTIONS] -l <list> -p <prefix>
-    -a,--arch     Architecture (gpu or mc)           (mandatory: Dom and Piz Daint only)
-    -f,--force    Force build of item(s) in list     (optional: double quotes for multiple items)
-    -h,--help     Help message
-    -l,--list     Absolute path to production file   (mandatory: EasyBuild production list)
-    -p,--prefix   Absolute path to EasyBuild prefix  (mandatory: installation folder)
-    -u,--unuse    Module unuse colon separated PATH  (optional: default is null)
-    -x,--xalt     [yes|no] update XALT database      (optional: default is yes)
-    --hide-deps   Hide the hidden dependencies
+    -a,--arch         Architecture (gpu or mc)           (mandatory: Dom and Piz Daint only)
+    -f,--force        Force build of item(s) in list     (optional: double quotes for multiple items)
+    -h,--help         Help message
+    -l,--list         Absolute path to production file   (mandatory: EasyBuild production list)
+    -p,--prefix       Absolute path to EasyBuild prefix  (mandatory: installation folder)
+    -u,--unuse        Module unuse colon separated PATH  (optional: default is null)
+    -x,--xalt         [yes|no] update XALT database      (optional: default is yes)
+    --hide-deps       Hide the hidden dependencies
+    --exit-on-error   Hide the hidden dependencies
     "
     exit 1;
 }
 
-longopts="arch:,force:,help,list:,prefix:,unuse:,xalt:,hide-deps"
+longopts="arch:,force:,help,list:,prefix:,unuse:,xalt:,hide-deps,exit-on-error"
 shortopts="a:,f:,h,l:,p:,u:,x:"
 eval set -- $(getopt -o ${shortopts} -l ${longopts} -n ${scriptname} -- "$@" 2> /dev/null)
 
@@ -57,6 +58,9 @@ while [ $# -ne 0 ]; do
         -x | --xalt)
             shift
             update_xalt_table={$1,,}
+            ;;
+        --exit-on-error)
+            exit_on_error=true
             ;;
         --hide-deps)
             hidden_deps=true
@@ -236,6 +240,9 @@ for((i=0; i<${#eb_files[@]}; i++)); do
         echo -e "eb ${eb_files[$i]} -r ${eb_args}"
         eb ${eb_files[$i]} -r ${eb_args}
         status=$[status+$?]
+    fi
+    if [ -n "${exit_on_error}" ] && [ "X$status" != "X0" ]; then
+        exit 1
     fi
 done
 

--- a/jenkins-builds/production.sh
+++ b/jenkins-builds/production.sh
@@ -17,11 +17,12 @@ usage() {
     -p,--prefix   Absolute path to EasyBuild prefix  (mandatory: installation folder)
     -u,--unuse    Module unuse colon separated PATH  (optional: default is null)
     -x,--xalt     [yes|no] update XALT database      (optional: default is yes)
+    --hide-deps   Hide the hidden dependencies
     "
     exit 1;
 }
 
-longopts="arch:,force:,help,list:,prefix:,unuse:,xalt:"
+longopts="arch:,force:,help,list:,prefix:,unuse:,xalt:,hide-deps"
 shortopts="a:,f:,h,l:,p:,u:,x:"
 eval set -- $(getopt -o ${shortopts} -l ${longopts} -n ${scriptname} -- "$@" 2> /dev/null)
 
@@ -57,6 +58,9 @@ while [ $# -ne 0 ]; do
             shift
             update_xalt_table={$1,,}
             ;;
+        --hide-deps)
+            hidden_deps=true
+            ;;
         --)
             ;;
         *)
@@ -66,8 +70,9 @@ while [ $# -ne 0 ]; do
     shift
 done
 
+
 # checks force_list
-if [ -n "${force_list}" ]; then
+if [ -n "${force_list}" ] && [ -n "${eb_lists}" ]; then
 # match force_list items with production lists: only matching items will be built using the EasyBuild flag '-f'
  echo -e "Items matching production list and system filtered forcelist (\"${force_list}\")"
  for item in ${force_list}; do
@@ -84,13 +89,14 @@ if [ -n "${force_list}" ]; then
  done
 fi
 
+
 # optional EasyBuild arguments
 eb_args=""
 
 # system name (excluding node number)
 if [[ "$HOSTNAME" =~ "esch" ]]; then
  system=${HOSTNAME%%[cl]n-[0-9]*}
-elif [[ "$HOSTNAME" =~ "arolla" || "$HOSTNAME" =~ "tsa" ]]; then 
+elif [[ "$HOSTNAME" =~ "arolla" || "$HOSTNAME" =~ "tsa" ]]; then
  system=${HOSTNAME%%-[cl]n[0-9]*}
 else
  system=${HOSTNAME%%[0-9]*}
@@ -149,6 +155,27 @@ fi
 # --- BUILD ---
 # load module EasyBuild-custom
 module load EasyBuild-custom/cscs
+
+# add hidden flag
+if [ -n "${eb_lists}" ] && [ -n "${hidden_deps}" ]; then
+  __eb_list=`eb --show-full-config | grep -i hide | awk -F'=' '{print $2}' | head -1`
+  IFS=', ' read -r -a hidden_deps <<< ${__eb_list}
+
+# match force_list items with production lists: only matching items will be built using the EasyBuild flag '-f'
+ echo -e "Items matching hidden list and easybuild recipes to install (\"${eb_lists}\")"
+ for item in ${hidden_deps[@]}; do
+     hidden_match=$(grep $item ${eb_lists[@]})
+     if [ -n "${hidden_match}" ]; then
+# 'grep -n' returns the 1-based line number of the matching pattern within the input file
+         index_list=$(cat ${eb_lists[@]} | grep -n $item | awk -F ':' '{print $(NF-1)-1}')
+# append the --hidden flag to matching items within the selected build list
+         for index in ${index_list}; do
+             eb_files[$index]+=" --hidden"
+             echo "${eb_files[$index]}"
+         done
+     fi
+ done
+fi
 
 # print EasyBuild configuration, module list, production file(s), list of builds
 echo -e "\n EasyBuild version and configuration ('eb --version' and 'eb --show-config'): "
@@ -219,10 +246,11 @@ if [[ $system =~ "daint" && $update_xalt_table =~ "y" ]]; then
     module load PrgEnv-cray
 # removing Easybuild module before the reverseMapD operation
     module unload Easybuild
-    echo "running reverseMapD"
     userid=$(id -u)
+    echo "check if will run reverseMapD"
 # commands run by jenscscs user only
     if [ $userid -eq 23395 ]; then
+        echo "running reverseMapD"
         module load Lmod/.7.8.2
         export PATH=$EBROOTLMOD/lmod/7.1/libexec:$PATH  # !!! for spider !!!
         export XALTJENKINS=/apps/daint/UES/xalt/JENSCSCS

--- a/jenkins/JenkinsfileTestingEB
+++ b/jenkins/JenkinsfileTestingEB
@@ -64,9 +64,9 @@ stage('Build Stage') {
                     def buildPath = "/tmp/jenscscs/${gitCommit}${arch}/"
                     def prefix = "$scratch/$projectName/$machineLabel/$gitCommit-$buildID"
                     def command = machineName in ['daint', 'dom'] ? "srun -u --constraint=$arch -n1 --cpus-per-task=$cpusPerTask --job-name=${projectName} --partition=cscsci --time=06:00:00" : ''
-                    def commandComplete = "$command $workingDir/jenkins-builds/production.sh --force=\"\$buildlist\" --list=$prefix/${projectName}.txt --prefix=$prefix"
+                    def commandComplete = "$command $workingDir/jenkins-builds/production.sh --force=\"\$buildlist\" --list=$prefix/${projectName}.txt --prefix=$prefix --hide-deps"
                     if (arch)
-                        commandComplete = "$command $workingDir/jenkins-builds/production.sh --arch=$arch --force=\"\$buildlist\" --list=$prefix/${projectName}.txt --prefix=$prefix --xalt=no"
+                        commandComplete = "$command $workingDir/jenkins-builds/production.sh --arch=$arch --force=\"\$buildlist\" --list=$prefix/${projectName}.txt --prefix=$prefix --xalt=no --hide-deps"
                     def buildList = sh(returnStdout: true,
                                     script: "echo \$(git diff origin/master...HEAD --name-only --oneline --no-merges --diff-filter=ACMRTUXB |grep ^easybuild.*\\.eb\\\$ |awk '{print \"basename \"\$0}'|sh)").trim()
                     withEnv(["EASYBUILD_BUILDPATH=$buildPath",

--- a/jenkins/JenkinsfileTestingEB
+++ b/jenkins/JenkinsfileTestingEB
@@ -64,9 +64,9 @@ stage('Build Stage') {
                     def buildPath = "/tmp/jenscscs/${gitCommit}${arch}/"
                     def prefix = "$scratch/$projectName/$machineLabel/$gitCommit-$buildID"
                     def command = machineName in ['daint', 'dom'] ? "srun -u --constraint=$arch -n1 --cpus-per-task=$cpusPerTask --job-name=${projectName} --partition=cscsci --time=06:00:00" : ''
-                    def commandComplete = "$command $workingDir/jenkins-builds/production.sh --force=\"\$buildlist\" --list=$prefix/${projectName}.txt --prefix=$prefix --hide-deps"
+                    def commandComplete = "$command $workingDir/jenkins-builds/production.sh --force=\"\$buildlist\" --list=$prefix/${projectName}.txt --prefix=$prefix --hide-deps --exit-on-error"
                     if (arch)
-                        commandComplete = "$command $workingDir/jenkins-builds/production.sh --arch=$arch --force=\"\$buildlist\" --list=$prefix/${projectName}.txt --prefix=$prefix --xalt=no --hide-deps"
+                        commandComplete = "$command $workingDir/jenkins-builds/production.sh --arch=$arch --force=\"\$buildlist\" --list=$prefix/${projectName}.txt --prefix=$prefix --xalt=no --hide-deps --exit-on-error"
                     def buildList = sh(returnStdout: true,
                                     script: "echo \$(git diff origin/master...HEAD --name-only --oneline --no-merges --diff-filter=ACMRTUXB |grep ^easybuild.*\\.eb\\\$ |awk '{print \"basename \"\$0}'|sh)").trim()
                     withEnv(["EASYBUILD_BUILDPATH=$buildPath",


### PR DESCRIPTION
Add option 
* `--hide-deps`, which adds `--hidden` to command line for easybuild in case of a hidden dependency recipe.
* `--exit-on-error` which exists the `production.sh` script on the first `eb` failure

Both options should be used in the TestingEB project. 
In this case, the CI will 
* build hidden dependencies only once
* exit the build procedure in case one of the recipes do not succeed.

Added GROMACS and Bison to the PR just to test the effects.