### PR TITLE
[dom] ipyparallel-6.2.4-CrayGNU-19.10-python3.eb

### DIFF
--- a/easybuild/easyconfigs/i/ipyparallel/ipyparallel-6.2.4-CrayGNU-19.10-python3.eb
+++ b/easybuild/easyconfigs/i/ipyparallel/ipyparallel-6.2.4-CrayGNU-19.10-python3.eb
@@ -1,0 +1,36 @@
+easyblock = 'PythonPackage'
+
+name = 'ipyparallel'
+version = '6.2.4'
+
+local_py_maj_ver = '3'
+local_py_min_ver = '6'
+local_py_rev_ver = '5.7'
+
+local_pyver = '%s.%s.%s' % (local_py_maj_ver, local_py_min_ver, local_py_rev_ver)
+versionsuffix = '-python%s' % (local_py_maj_ver)
+
+req_py_majver = local_py_maj_ver
+req_py_minver = local_py_min_ver
+
+homepage = 'https://pypi.org/project/ipyparallel'
+description = """Use multiple instances of IPython in parallel, interactively."""
+
+toolchain = {'name': 'CrayGNU', 'version': '19.10'}
+toolchainopts = {'verbose': False}
+
+source_urls = [PYPI_SOURCE]
+sources = [SOURCE_TAR_GZ]
+use_pip = True
+
+dependencies = [
+    ('cray-python/%s' % local_pyver, EXTERNAL_MODULE),
+    ('jupyterlab', '1.1.1')
+]
+
+sanity_check_paths = {
+    'files': [],
+    'dirs': ['lib/python%s.%s/site-packages' % (local_py_maj_ver, local_py_min_ver)],
+}
+
+moduleclass = 'devel'


### PR DESCRIPTION
ipyparallel 6.2.4 for JupyterLab 1.1.1 (remove dependency on jupyter/1.0.0, which is not used for more recent version of JuptyerLab). This now has no dependencies other than JupyterLab. Fixes issues we had with compatibility between different versions of tornado, zeromqm etc. 