### PR TITLE
[dom] 7.0.UP01-19.10-gpu

### DIFF
--- a/jenkins-builds/7.0.UP01-19.10-gpu
+++ b/jenkins-builds/7.0.UP01-19.10-gpu
@@ -23,7 +23,7 @@
  Horovod-0.16.4-CrayGNU-19.10-tf-1.14.0.eb
  IDL-8.5.1.eb                                       --set-default-module
  ipykernel-4.8.2-CrayGNU-19.10-python2.eb
- ipyparallel-6.2.3-CrayGNU-19.10-python3.eb
+ ipyparallel-6.2.4-CrayGNU-19.10-python3.eb
  Julia-1.0.4.eb
  jupyterlab-1.1.1-CrayGNU-19.10.eb                  --set-default-module
  jupyterhub-1.0.0-CrayGNU-19.10.eb                  --set-default-module

--- a/jenkins-builds/7.0.UP01-19.10-mc
+++ b/jenkins-builds/7.0.UP01-19.10-mc
@@ -22,7 +22,7 @@
  h5py-2.8.0-CrayGNU-19.10-python3-serial.eb
  IDL-8.5.1.eb                                       --set-default-module
  ipykernel-4.8.2-CrayGNU-19.10-python2.eb
- ipyparallel-6.2.3-CrayGNU-19.10-python3.eb
+ ipyparallel-6.2.4-CrayGNU-19.10-python3.eb
  Julia-1.0.4.eb  
  jupyterhub-1.0.0-CrayGNU-19.10.eb                  --set-default-module
  jupyterlab-1.1.1-CrayGNU-19.10.eb                  --set-default-module


### PR DESCRIPTION
ipyparallel 6.2.3 had a dependency on jupyter 1.0.0 which has been retired (replaced by jupyterlab 1.1.1 and deps).