### PR TITLE
[daint] working COSMO_pompa 19.08 + deps

### DIFF
--- a/easybuild/easyconfigs/b/Boost/Boost-1.67.0-CrayGNU-19.08.eb
+++ b/easybuild/easyconfigs/b/Boost/Boost-1.67.0-CrayGNU-19.08.eb
@@ -15,7 +15,7 @@ sources = ['%(namelower)s_1_67_0.tar.gz']
 
 dependencies = [
     ('bzip2', '1.0.6'),
-    ('zlib', '1.2.11'),
+    ('zlib', '1.2.11', '', True),
 ]
 
 configopts = " --without-libraries=python"

--- a/easybuild/easyconfigs/c/COSMO_pompa/COSMO_pompa-31d7227-CrayCCE-19.08-cuda-10.0-cordex-double.eb
+++ b/easybuild/easyconfigs/c/COSMO_pompa/COSMO_pompa-31d7227-CrayCCE-19.08-cuda-10.0-cordex-double.eb
@@ -3,7 +3,7 @@ easyblock = 'MakeCp'
 
 name = 'COSMO_pompa'
 version = '31d7227'
-versionsuffix = '-cuda-10.1-cordex-double'
+versionsuffix = '-cuda-10.0-cordex-double'
 
 homepage = "https://github.com/C2SM-RCM/cosmo-pompa/tree/master/dycore (-b crclim)"
 description = """

--- a/easybuild/easyconfigs/c/COSMO_pompa/COSMO_pompa-31d7227-CrayCCE-19.08-cuda-10.0-crclim-double.eb
+++ b/easybuild/easyconfigs/c/COSMO_pompa/COSMO_pompa-31d7227-CrayCCE-19.08-cuda-10.0-crclim-double.eb
@@ -3,7 +3,7 @@ easyblock = 'MakeCp'
 
 name = 'COSMO_pompa'
 version = '31d7227'
-versionsuffix = '-cuda-10.1-crclim-double'
+versionsuffix = '-cuda-10.0-crclim-double'
 
 homepage = "https://github.com/C2SM-RCM/cosmo-pompa/tree/master/dycore (-b crclim)"
 description = """

--- a/easybuild/easyconfigs/c/COSMO_pompa/patch_COSMO_dom_cray_gpu_CrayCCE-19.08.patch
+++ b/easybuild/easyconfigs/c/COSMO_pompa/patch_COSMO_dom_cray_gpu_CrayCCE-19.08.patch
@@ -4,7 +4,7 @@ diff -Nru cosmo_pompa.orig/cosmo/Options cosmo_pompa/cosmo/Options
 @@ -1,17 +1,18 @@
  # compiler
 -F90      = ftn -D__CRAY_FORTRAN__
-+F90      = ftn -D__CRAY_FORTRAN__ -h system_alloc -add-rpath -L/opt/nvidia/cudatoolkit10/10.0.130_3.22-7.0.1.0_5.2__gdfb4ce5/lib64 -lcudart
++F90      = ftn -D__CRAY_FORTRAN__ -h system_alloc -add-rpath -L/opt/nvidia/cudatoolkit10/10.0.130_3.22-7.0.1.0_5.2__gdfb4ce5/lib64 -lcudart -lcublas
  COMPILER = cray
  
  # linker

--- a/easybuild/easyconfigs/d/Dycore/Dycore-551f6b4-CrayGNU-19.08-cuda-10.1-cordex-double.eb
+++ b/easybuild/easyconfigs/d/Dycore/Dycore-551f6b4-CrayGNU-19.08-cuda-10.1-cordex-double.eb
@@ -16,7 +16,7 @@ sources = [{'filename': '/apps/common/UES/easybuild/sources/d/%(name)s/%(name)s_
 
 builddependencies = [
     ('CMake', '3.12.0', '', True),
-    ('cudatoolkit/10.1.105_3.27-7.0.1.0_8.1__ga311ce7', EXTERNAL_MODULE),
+    ('cudatoolkit/10.1.105_3.27-7.0.1.1_4.1__ga311ce7', EXTERNAL_MODULE),
 ]
 dependencies = [
     ('craype-accel-nvidia60', EXTERNAL_MODULE),

--- a/easybuild/easyconfigs/d/Dycore/Dycore-551f6b4-CrayGNU-19.08-cuda-10.1-crclim-double.eb
+++ b/easybuild/easyconfigs/d/Dycore/Dycore-551f6b4-CrayGNU-19.08-cuda-10.1-crclim-double.eb
@@ -16,7 +16,7 @@ sources = [{'filename': '/apps/common/UES/easybuild/sources/d/%(name)s/%(name)s_
 
 builddependencies = [
     ('CMake', '3.12.0', '', True),
-    ('cudatoolkit/10.1.105_3.27-7.0.1.0_8.1__ga311ce7', EXTERNAL_MODULE),
+    ('cudatoolkit/10.1.105_3.27-7.0.1.1_4.1__ga311ce7', EXTERNAL_MODULE),
 ]
 dependencies = [
     ('craype-accel-nvidia60', EXTERNAL_MODULE),

--- a/easybuild/easyconfigs/s/STELLA/STELLA-4a5f9c5-CrayGNU-19.08-cordex-double.eb
+++ b/easybuild/easyconfigs/s/STELLA/STELLA-4a5f9c5-CrayGNU-19.08-cordex-double.eb
@@ -16,7 +16,7 @@ sources = [{'filename': '/apps/common/UES/easybuild/sources/s/%(name)s/%(namelow
 
 builddependencies = [
     ('CMake', '3.12.0', '', True),
-    ('cudatoolkit/10.1.105_3.27-7.0.1.0_8.1__ga311ce7', EXTERNAL_MODULE),
+    ('cudatoolkit/10.1.105_3.27-7.0.1.1_4.1__ga311ce7', EXTERNAL_MODULE),
 ]
 dependencies = [
     ('craype-accel-nvidia60', EXTERNAL_MODULE),

--- a/easybuild/easyconfigs/s/STELLA/STELLA-4a5f9c5-CrayGNU-19.08-crclim-double.eb
+++ b/easybuild/easyconfigs/s/STELLA/STELLA-4a5f9c5-CrayGNU-19.08-crclim-double.eb
@@ -16,7 +16,7 @@ sources = [{'filename': '/apps/common/UES/easybuild/sources/s/%(name)s/%(namelow
 
 builddependencies = [
     ('CMake', '3.12.0', '', True),
-    ('cudatoolkit/10.1.105_3.27-7.0.1.0_8.1__ga311ce7', EXTERNAL_MODULE),
+    ('cudatoolkit/10.1.105_3.27-7.0.1.1_4.1__ga311ce7', EXTERNAL_MODULE),
 ]
 dependencies = [
     ('craype-accel-nvidia60', EXTERNAL_MODULE),


### PR DESCRIPTION
Taking into account the latest cudatoolkit version (that was available on DOM)

**Please note**: The change to the `Boost` recipe was necessary for building in my sandbox. If the original `Boost-1.67.0-CrayGNU-19.08` passes on Daint for other applications, the change of the `zlib` dependency from TC CrayGNU -> dummy might not be necessary.