### PR TITLE
[daint] Add easybuild recipes for PROJ and ecCodes for CrayGNU-19.10

### DIFF
--- a/easybuild/easyconfigs/e/ecCodes/ecCodes-2.12.2-CrayGNU-19.10.eb
+++ b/easybuild/easyconfigs/e/ecCodes/ecCodes-2.12.2-CrayGNU-19.10.eb
@@ -1,0 +1,38 @@
+# @autor: sebkelle1
+easyblock = 'CMakeMake'
+
+name = 'ecCodes'
+version = '2.12.5'
+#versionsuffix='-Python-3.6.5'
+
+homepage = 'https://software.ecmwf.int/wiki/display/GRIB/Home'
+description = """ecCodes is a package developed by ECMWF which provides an
+application programming interface and a set of tools for decoding and encoding
+messages in different formats"""
+
+toolchain = {'name': 'CrayGNU', 'version': '19.10'}
+
+source_urls = ['https://software.ecmwf.int/wiki/download/attachments/45757960/']
+sources = ['%(namelower)s-%(version)s-Source.tar.gz']
+
+builddependencies = [
+    ('CMake', '3.14.5', '', True),
+]
+
+dependencies = [
+    ('JasPer', '2.0.14'),
+    ('cray-netcdf', EXTERNAL_MODULE),
+    #('cray-python/3.6.5.1', EXTERNAL_MODULE),
+]
+
+#modextrapaths = {
+#    'PYTHONPATH' : 'lib/python2.7/site-packages'
+#}
+
+#configopts = '--with-jasper=$EBROOTJASPER'
+separate_build_dir = True
+configopts = '-DENABLE_JPG=ON -DENABLE_NETCDF=ON -DENABLE_PYTHON=OFF'
+
+parallel = 1
+
+moduleclass = 'data'

--- a/easybuild/easyconfigs/p/PROJ/PROJ-4.9.3-CrayGNU-19.10.eb
+++ b/easybuild/easyconfigs/p/PROJ/PROJ-4.9.3-CrayGNU-19.10.eb
@@ -1,0 +1,30 @@
+##
+# This file is an EasyBuild reciPY as per https://github.com/hpcugent/easybuild
+#
+# Copyright:: Copyright 2014-2015 The Cyprus Institute
+# Authors:: Thekla Loizou <t.loizou@cyi.ac.cy>
+# License:: MIT/GPL
+#
+##
+easyblock = 'ConfigureMake'
+
+name = 'PROJ'
+version = '4.9.3'
+
+homepage = 'http://trac.osgeo.org/proj/'
+description = """Program proj is a standard Unix filter function which converts
+geographic longitude and latitude coordinates into cartesian coordinates"""
+
+toolchain = {'name': 'CrayGNU', 'version': '19.10'}
+toolchainopts = {'pic': True, 'usempi': True}
+
+source_urls = ['http://download.osgeo.org/proj/']
+sources = [SOURCELOWER_TAR_GZ]
+
+sanity_check_paths = {
+    'files': ['bin/cs2cs', 'bin/geod', 'bin/invgeod', 'bin/invproj',
+              'bin/nad2bin', 'bin/proj'],
+    'dirs': [],
+}
+
+moduleclass = 'lib'


### PR DESCRIPTION
Adds two easybuild recipes for the CrayGNU-19.10 system:
* PROJ-4.9.3-CrayGNU-19.10.eb
* ecCodes-2.12.2-CrayGNU-19.10.eb

(PS: It's the first time a make a pull request here, so let me know if this is the wrong procedure.)