### PR TITLE
[daint dom] Remove fftw from metadata (unused)

### DIFF
--- a/easybuild/cray_external_modules_metadata-19.10.cfg
+++ b/easybuild/cray_external_modules_metadata-19.10.cfg
@@ -86,11 +86,6 @@ name = CUDA
 version = 10.1.105_3.27-7.0.1.1_4.1__ga311ce7
 prefix = CRAY_CUDATOOLKIT_DIR
 
-[fftw/2.1.5.9]
-name = FFTW
-version = 2.1.5.9
-prefix = FFTW_INC/..
-
 [gcc]
 name = GCC
 version = 8.3.0

--- a/easybuild/cray_external_modules_metadata-19.10.cfg
+++ b/easybuild/cray_external_modules_metadata-19.10.cfg
@@ -86,9 +86,9 @@ name = CUDA
 version = 10.1.105_3.27-7.0.1.1_4.1__ga311ce7
 prefix = CRAY_CUDATOOLKIT_DIR
 
-[fftw]
+[fftw/2.1.5.9]
 name = FFTW
-version = 3.3.4.11
+version = 2.1.5.9
 prefix = FFTW_INC/..
 
 [gcc]


### PR DESCRIPTION
From what I can tell this module is not used in any production recipe, but fftw/2.1.5.9 is available on daint. If the entry is not useful I can remove it completely from the metadata file.