### PR TITLE
[dom-gpu] Custom cdt modulefile with no verbosity

### DIFF
--- a/login/cdt
+++ b/login/cdt
@@ -1,0 +1,1 @@
+/apps/daint/UES/7.0.UP01/cdt


### PR DESCRIPTION
The output of `diff` with respect to the original Cray `CDT/19.10` modulefile follows below:
```
#      puts stderr "Switching to $mod."			      |	      puts stderr "Switching to $mod."
}							      /	}
```
The line with the `puts` command is commented in the custom module on the left (no verbosity) with respect to the original Cray modulefile on the right: the symbolic link points to `/apps/daint/UES/7.0.UP01/cdt`