### PR TITLE
[daint-gpu] Adding MATLAB in production

### DIFF
--- a/jenkins-builds/7.0.UP01-19.10-gpu
+++ b/jenkins-builds/7.0.UP01-19.10-gpu
@@ -32,6 +32,7 @@
  LAMMPS-22Aug2018-CrayGNU-19.10-cuda-10.1.eb        --set-default-module
  Lmod-7.8.2.eb                                      --set-default-module --hidden
  magma-2.4.0-CrayIntel-19.10-cuda-10.1.eb           --set-default-module
+ MATLAB-R2019a.eb
  NAMD-2.13-CrayIntel-19.10-cuda-10.1.eb             --set-default-module
  NCL-6.4.0.eb                                       --set-default-module
  NCO-4.8.1-CrayGNU-19.10.eb                         --set-default-module

--- a/jenkins-builds/7.0.UP01-19.10-mc
+++ b/jenkins-builds/7.0.UP01-19.10-mc
@@ -29,6 +29,7 @@
  jupyterlab-1.1.1-CrayGNU-19.10.eb                  --set-default-module
  LAMMPS-22Aug2018-CrayGNU-19.10.eb                  --set-default-module
  Lmod-7.8.2.eb                                      --set-default-module --hidden
+ MATLAB-R2019a.eb
  NAMD-2.13-CrayIntel-19.10.eb                       --set-default-module
  NCL-6.4.0.eb                                       --set-default-module
  NCO-4.8.1-CrayGNU-19.10.eb                         --set-default-module


### PR DESCRIPTION
The recipe is still the one available before the CLE upgrade, which used to fail in `TestingEB` due to the different build filesystem with respect to `ProductionEB` (compute vs. login node).