### PR TITLE
[daint-gpu] Split HPX APEX recipe into separate file

### DIFF
--- a/easybuild/easyconfigs/h/HPX/HPX-1.3.0-CrayGNU-19.10-APEX.eb
+++ b/easybuild/easyconfigs/h/HPX/HPX-1.3.0-CrayGNU-19.10-APEX.eb
@@ -3,6 +3,7 @@ easyblock = 'CMakeMake'
 
 name = 'HPX'
 version = '1.3.0'
+versionsuffix = '-APEX'
 checksums = ['cd34da674064c4cc4a331402edbd65c5a1f8058fb46003314ca18fa08423c5ad']
 
 homepage = 'http://stellar-group.org/libraries/hpx'
@@ -17,10 +18,14 @@ toolchainopts = {'pic': True}
 
 builddependencies = [('CMake', '3.14.5', '', True)]
 
+patches = ['git_external.patch']
+
 dependencies = [
     ('Boost', '1.70.0', '-python3'),
     ('hwloc', '2.0.3', '', True),
     ('jemalloc', '5.1.0'),
+    ('OTF2', '2.2', '', True),
+    # papi provided by perftools-base
 ]
 
 source_urls = ['https://github.com/STEllAR-GROUP/hpx/archive']
@@ -28,8 +33,12 @@ sources = ['%(version)s.tar.gz']
 
 separate_build_dir = True
 
-build_type = 'Release'
+build_type = 'RelWithDebInfo'
 
-configopts = "-DHWLOC_ROOT=$EBROOTHWLOC -DHPX_WITH_MALLOC=JEMALLOC -DJEMALLOC_ROOT=$EBROOTJEMALLOC -DHPX_WITH_MAX_CPU_COUNT=128 -DHPX_WITH_PARCELPORT_MPI=ON -DHPX_WITH_PARCELPORT_MPI_MULTITHREADED=ON"
+commonopts = "-DHWLOC_ROOT=$EBROOTHWLOC -DHPX_WITH_MALLOC=JEMALLOC -DJEMALLOC_ROOT=$EBROOTJEMALLOC -DHPX_WITH_MAX_CPU_COUNT=128 -DHPX_WITH_PARCELPORT_MPI=ON -DHPX_WITH_PARCELPORT_MPI_MULTITHREADED=ON"
+
+apexopts = "-DHPX_WITH_PAPI=ON -DHPX_WITH_APEX=ON -DHPX_WITH_APEX_TAG=v2.1.3 -DAPEX_WITH_PAPI=ON -DAPEX_WITH_OTF2=ON -DOTF2_ROOT=$EBROOTOTF2 -DPAPI_ROOT=$(dirname $PAT_BUILD_PAPI_LIBDIR)"
+
+configopts = commonopts + apexopts
 
 moduleclass = 'tools'

--- a/easybuild/easyconfigs/h/HPX/HPX-1.3.0-CrayGNU-19.10-nonetworking.eb
+++ b/easybuild/easyconfigs/h/HPX/HPX-1.3.0-CrayGNU-19.10-nonetworking.eb
@@ -1,0 +1,36 @@
+# contributed by Mikael Simberg, John Biddiscombe and Victor Holanda Rusu (CSCS)
+easyblock = 'CMakeMake'
+
+name = 'HPX'
+version = '1.3.0'
+versionsuffix = '-nonetworking'
+checksums = ['cd34da674064c4cc4a331402edbd65c5a1f8058fb46003314ca18fa08423c5ad']
+
+homepage = 'http://stellar-group.org/libraries/hpx'
+description = """HPX (High Performance ParalleX) is a general purpose C++
+runtime system for parallel and distributed applications of any scale. It
+strives to provide a unified programming model which transparently utilizes
+the available resources to achieve unprecedented levels of scalability.
+"""
+
+toolchain = {'name': 'CrayGNU', 'version': '19.10'}
+toolchainopts = {'pic': True}
+
+builddependencies = [('CMake', '3.14.5', '', True)]
+
+dependencies = [
+    ('Boost', '1.70.0', '-python3'),
+    ('hwloc', '2.0.3', '', True),
+    ('jemalloc', '5.1.0'),
+]
+
+source_urls = ['https://github.com/STEllAR-GROUP/hpx/archive']
+sources = ['%(version)s.tar.gz']
+
+separate_build_dir = True
+
+build_type = 'Release'
+
+configopts = "-DHWLOC_ROOT=$EBROOTHWLOC -DHPX_WITH_MALLOC=JEMALLOC -DJEMALLOC_ROOT=$EBROOTJEMALLOC -DHPX_WITH_MAX_CPU_COUNT=128 -DHPX_WITH_NETWORKING=OFF"
+
+moduleclass = 'tools'


### PR DESCRIPTION
While having the APEX build in the same recipe as the main build reduced duplication, actually using the APEX build still required manual intervention (because of the APEX build path not being present in `LD_LIBRARY_PATH`). This splits the two builds up again.

I've also added a variant with networking disabled, which is a common use-case for a few users at CSCS.