### PR TITLE
Remove XALT dependency on daint-mc and daint-gpu

### DIFF
--- a/jenkins-builds/production.sh
+++ b/jenkins-builds/production.sh
@@ -239,7 +239,7 @@ for((i=0; i<${#eb_files[@]}; i++)); do
     elif [[ "$name" =~ "xalt" ]] && [[ "$system" =~ "daint" || "$system" =~ "dom" ]]; then
         module unload xalt
         echo -e "eb ${eb_files[$i]} -r ${eb_args}"
-        eb ${eb_files[$i]} -r ${eb_args}
+        eb ${eb_files[$i]} -r
         status=$[status+$?]
         module load xalt
     else


### PR DESCRIPTION
The current command to install XALT adds:
```
eb xalt-2.7.24.eb --set-default-module --installpath=.../xalt2 -r  --modules-header=.../daint-gpu.h --modules-footer=.../daint.footer
```

This PR removes the `--modules-header=.../daint-gpu.h --modules-footer=.../daint.footer` which makes the command become
```
eb xalt-2.7.24.eb --set-default-module --installpath=.../xalt2 -r  
```
And by consequence removes the depency on `daint-gpu`.
