### PR TITLE
[daint-gpu dom-gpu] magma-2.5.2 with CMake for CrayIntel

### DIFF
--- a/easybuild/easyconfigs/m/magma/magma-2.5.2-CrayIntel-19.10-cuda-10.1.eb
+++ b/easybuild/easyconfigs/m/magma/magma-2.5.2-CrayIntel-19.10-cuda-10.1.eb
@@ -40,8 +40,8 @@ preconfigopts = 'module unload cray-libsci && module unload cray-libsci_acc && m
 configopts = "-DCMAKE_C_FLAGS='' -DCMAKE_CXX_FLAGS='' -DCMAKE_Fortran_FLAGS=''"
 
 sanity_check_paths={
-    'files': ['lib/libmagma.so', 'lib/libmagma.a'],
-    'dirs': ['include', 'control'],
+    'files': ['lib/libmagma.so'],
+    'dirs': ['lib', 'include'],
 }
 
 moduleclass = 'math'

--- a/easybuild/easyconfigs/m/magma/magma-2.5.2-CrayIntel-19.10-cuda-10.1.eb
+++ b/easybuild/easyconfigs/m/magma/magma-2.5.2-CrayIntel-19.10-cuda-10.1.eb
@@ -35,19 +35,13 @@ prebuildopts = 'module unload cray-libsci && module unload cray-libsci_acc && mo
 
 #modextravars = { 'LD_LIBRARY_PATH':'$::env(CRAY_LD_LIBRARY_PATH):$::env(LD_LIBRARY_PATH)'}
 
-#prebuildopts = 'module unload cray-libsci && module unload cray-libsci_acc && mv make.inc-2.5.1 make.inc && CUDADIR=$EBROOTCUDA '
-
 preconfigopts = 'module unload cray-libsci && module unload cray-libsci_acc && module list && gcc --version && '
 
-configopts = ""
+configopts = "-DCMAKE_C_FLAGS='' -DCMAKE_CXX_FLAGS='' -DCMAKE_Fortran_FLAGS=''"
 
-#modextrapaths = {'CPATH': ['include/sirius']}
-
-#sanity_check_paths={
-#    'files': ['lib/libmagma.so', 'lib/libmagma.a'],
-#    'dirs': ['include', 'control'],
-#}
-
-maxparallel = 1
+sanity_check_paths={
+    'files': ['lib/libmagma.so', 'lib/libmagma.a'],
+    'dirs': ['include', 'control'],
+}
 
 moduleclass = 'math'

--- a/easybuild/easyconfigs/m/magma/magma-2.5.2-CrayIntel-19.10-cuda-10.1.eb
+++ b/easybuild/easyconfigs/m/magma/magma-2.5.2-CrayIntel-19.10-cuda-10.1.eb
@@ -1,0 +1,53 @@
+# created by Anton Kozhevnikov (CSCS)
+
+easyblock = 'CMakeMake'
+
+name = 'magma'
+version = '2.5.2'
+versionsuffix = '-cuda-10.1'
+
+homepage = 'http://icl.cs.utk.edu/magma/'
+description = """The MAGMA project aims to develop a dense linear algebra
+library similar to LAPACK but for heterogeneous/hybrid architectures, starting
+with current Multicore+GPU systems."""
+
+toolchain = {'name': 'CrayIntel', 'version': '19.10'}
+toolchainopts = {'pic': True, 'openmp': True}
+
+sources = [SOURCE_TAR_GZ]
+source_urls = ['http://icl.cs.utk.edu/projectsfiles/magma/downloads/']
+
+builddependencies = [
+  ('CMake', '3.14.5', '', True),
+  ('cudatoolkit/10.1.105_3.27-7.0.1.1_4.1__ga311ce7', EXTERNAL_MODULE),
+  ('intel/19.0.1.144', EXTERNAL_MODULE),
+  ('gcc/8.3.0', EXTERNAL_MODULE)]
+
+dependencies = [
+  ('cudatoolkit/10.1.105_3.27-7.0.1.1_4.1__ga311ce7', EXTERNAL_MODULE),
+  ('intel/19.0.1.144', EXTERNAL_MODULE),
+  ('gcc/8.3.0', EXTERNAL_MODULE)
+]
+
+separate_build_dir = True
+
+prebuildopts = 'module unload cray-libsci && module unload cray-libsci_acc && module list && gcc --version && '
+
+#modextravars = { 'LD_LIBRARY_PATH':'$::env(CRAY_LD_LIBRARY_PATH):$::env(LD_LIBRARY_PATH)'}
+
+#prebuildopts = 'module unload cray-libsci && module unload cray-libsci_acc && mv make.inc-2.5.1 make.inc && CUDADIR=$EBROOTCUDA '
+
+preconfigopts = 'module unload cray-libsci && module unload cray-libsci_acc && module list && gcc --version && '
+
+configopts = ""
+
+#modextrapaths = {'CPATH': ['include/sirius']}
+
+#sanity_check_paths={
+#    'files': ['lib/libmagma.so', 'lib/libmagma.a'],
+#    'dirs': ['include', 'control'],
+#}
+
+maxparallel = 1
+
+moduleclass = 'math'


### PR DESCRIPTION
Hi guys!
Can somebody help me with this script? The story is the same: I can build Magma with Intel/MKL in my environment, but the same set of command from EB fails. The error message is of no use to me:

```
/opt/nvidia/cudatoolkit10/10.1.105_3.27-7.0.1.1_4.1__ga311ce7/bin/nvcc /run/user/22449/easybuild/build/magma/2.5.2/CrayIntel-19.10-cuda-10.1/magma-2.5.2/magmablas/cpotf2_kernels_var.cu -dc -o /run/user/22449/easybuild/build/magma/2.5.2/CrayIntel-19.10-cuda-10.1/easybuild_obj/CMakeFiles/magma.dir/magmablas/./magma_generated_cpotf2_kernels_var.cu.o -ccbin /opt/cray/pe/craype/2.6.1/bin/cc -m64 --std c++11 -Dmagma_EXPORTS -DMAGMA_WITH_MKL -Xcompiler ,\"-O2\",\"-ftz\",\"-fp-speculation=safe\",\"-fp-model\",\"source\",\"-fopenmp\",\"-fPIC\",\"-craype-verbose\",\"-qopenmp\",\"-Wall\",\"-Wno-unused-function\",\"-fPIC\",\"-g\" -Xcompiler -fPIC -DHAVE_CUBLAS -gencode arch=compute_30,code=sm_30 -gencode arch=compute_35,code=sm_35 -gencode arch=compute_50,code=sm_50 -gencode arch=compute_60,code=sm_60 -gencode arch=compute_60,code=compute_60 -DNVCC -I/opt/nvidia/cudatoolkit10/10.1.105_3.27-7.0.1.1_4.1__ga311ce7/include -I/opt/intel/compilers_and_libraries_2019.1.144/linux/mkl/include -I/run/user/22449/easybuild/build/magma/2.5.2/CrayIntel-19.10-cuda-10.1/magma-2.5.2/include -I/run/user/22449/easybuild/build/magma/2.5.2/CrayIntel-19.10-cuda-10.1/magma-2.5.2/control -I/run/user/22449/easybuild/build/magma/2.5.2/CrayIntel-19.10-cuda-10.1/magma-2.5.2/magmablas -I/run/user/22449/easybuild/build/magma/2.5.2/CrayIntel-19.10-cuda-10.1/magma-2.5.2/sparse/include -I/run/user/22449/easybuild/build/magma/2.5.2/CrayIntel-19.10-cuda-10.1/magma-2.5.2/sparse/control -I/run/user/22449/easybuild/build/magma/2.5.2/CrayIntel-19.10-cuda-10.1/magma-2.5.2/testing
/run/user/22449/easybuild/build/magma/2.5.2/CrayIntel-19.10-cuda-10.1/magma-2.5.2/magmablas/cpotf2_kernels_var.cu(112): error: this declaration has no storage class or type specifier

/run/user/22449/easybuild/build/magma/2.5.2/CrayIntel-19.10-cuda-10.1/magma-2.5.2/magmablas/cpotf2_kernels_var.cu(112): error: expected a ";"

/run/user/22449/easybuild/build/magma/2.5.2/CrayIntel-19.10-cuda-10.1/magma-2.5.2/magmablas/cpotf2_kernels_var.cu(112): error: extra text after expected end of number

/run/user/22449/easybuild/build/magma/2.5.2/CrayIntel-19.10-cuda-10.1/magma-2.5.2/magmablas/cpotf2_kernels_var.cu(112): error: extra text after expected end of number

/run/user/22449/easybuild/build/magma/2.5.2/CrayIntel-19.10-cuda-10.1/magma-2.5.2/magmablas/cpotf2_kernels_var.cu(112): error: extra text after expected end of number

/run/user/22449/easybuild/build/magma/2.5.2/CrayIntel-19.10-cuda-10.1/magma-2.5.2/magmablas/cpotf2_kernels_var.cu(112): error: extra text after expected end of number

/run/user/22449/easybuild/build/magma/2.5.2/CrayIntel-19.10-cuda-10.1/magma-2.5.2/magmablas/cpotf2_kernels_var.cu(112): error: extra text after expected end of number

/run/user/22449/easybuild/build/magma/2.5.2/CrayIntel-19.10-cuda-10.1/magma-2.5.2/magmablas/cpotf2_kernels_var.cu(112): error: extra text after expected end of number

/run/user/22449/easybuild/build/magma/2.5.2/CrayIntel-19.10-cuda-10.1/magma-2.5.2/magmablas/cpotf2_kernels_var.cu(112): error: extra text after expected end of number

/run/user/22449/easybuild/build/magma/2.5.2/CrayIntel-19.10-cuda-10.1/magma-2.5.2/magmablas/cpotf2_kernels_var.cu(112): error: extra text after expected end of number

/run/user/22449/easybuild/build/magma/2.5.2/CrayIntel-19.10-cuda-10.1/magma-2.5.2/magmablas/cpotf2_kernels_var.cu(112): error: extra text after expected end of number

/run/user/22449/easybuild/build/magma/2.5.2/CrayIntel-19.10-cuda-10.1/magma-2.5.2/magmablas/cpotf2_kernels_var.cu(112): error: extra text after expected end of number

/run/user/22449/easybuild/build/magma/2.5.2/CrayIntel-19.10-cuda-10.1/magma-2.5.2/magmablas/cpotf2_kernels_var.cu(112): error: extra text after expected end of number

/run/user/22449/easybuild/build/magma/2.5.2/CrayIntel-19.10-cuda-10.1/magma-2.5.2/magmablas/cpotf2_kernels_var.cu(112): error: extra text
```

This is what CMake from my environment produces:
```
--     CMAKE_INSTALL_PREFIX:  /usr/local/magma
--     CFLAGS:                 -std=c99 -qopenmp -Wall -Wno-unused-function
--     CXXFLAGS:               -std=c++11 -qopenmp -Wall -Wno-unused-function
--     NVCCFLAGS:             -Xcompiler;-fPIC;-DHAVE_CUBLAS;-gencode;arch=compute_30,code=sm_30;-gencode;arch=compute_35,code=sm_35;-gencode;arch=compute_50,code=sm_50;-gencode;arch=compute_60,code=sm_60;-gencode;arch=compute_60,code=compute_60
--     FFLAGS:                 -Dmagma_devptr_t="integer(kind=8)"
--     LIBS:                   /usr/lib64/libopenblas.so /usr/lib64/libopenblas.so /opt/nvidia/cudatoolkit10/10.1.105_3.27-7.0.1.1_4.1__ga311ce7/lib64/libcudart.so /opt/nvidia/cudatoolkit10/10.1.105_3.27-7.0.1.1_4.1__ga311ce7/lib64/libcublas.so /opt/nvidia/cudatoolkit10/10.1.105_3.27-7.0.1.1_4.1__ga311ce7/lib64/libcusparse.so
--     blas_fix:                (MacOS Accelerate only)
--     LAPACK_LIBRARIES:      /usr/lib64/libopenblas.so;/usr/lib64/libopenblas.so
--     CUDA_CUDART_LIBRARY:   /opt/nvidia/cudatoolkit10/10.1.105_3.27-7.0.1.1_4.1__ga311ce7/lib64/libcudart.so
--     CUDA_CUBLAS_LIBRARIES: /opt/nvidia/cudatoolkit10/10.1.105_3.27-7.0.1.1_4.1__ga311ce7/lib64/libcublas.so
--     CUDA_cusparse_LIBRARY: /opt/nvidia/cudatoolkit10/10.1.105_3.27-7.0.1.1_4.1__ga311ce7/lib64/libcusparse.so
--     Fortran modules:       /users/antonk/src/daint/magma-2.5.2/build/magma_param.mod;/users/antonk/src/daint/magma-2.5.2/build/magma.mod;/users/antonk/src/daint/magma-2.5.2/build/magma_sfortran.mod;/users/antonk/src/daint/magma-2.5.2/build/magma_dfortran.mod;/users/antonk/src/daint/magma-2.5.2/build/magma_cfortran.mod;/users/antonk/src/daint/magma-2.5.2/build/magma_zfortran.mod;/users/antonk/src/daint/magma-2.5.2/build/magmablas_sfortran.mod;/users/antonk/src/daint/magma-2.5.2/build/magmablas_dfortran.mod;/users/antonk/src/daint/magma-2.5.2/build/magmablas_cfortran.mod;/users/antonk/src/daint/magma-2.5.2/build/magmablas_zfortran.mod
```

and this is found in the log file of EB:
```
--     CMAKE_INSTALL_PREFIX:  /users/antonk/easybuild/daint/haswell/software/magma/2.5.2-CrayIntel-19.10-cuda-10.1
--     CFLAGS:                -O2 -ftz -fp-speculation=safe -fp-model source -fopenmp -fPIC -craype-verbose -std=c99 -qopenmp -Wall -Wno-unused-function
--     CXXFLAGS:              -O2 -ftz -fp-speculation=safe -fp-model source -fopenmp -fPIC -craype-verbose -std=c++11 -qopenmp -Wall -Wno-unused-function
--     NVCCFLAGS:             -Xcompiler;-fPIC;-DHAVE_CUBLAS;-gencode;arch=compute_30,code=sm_30;-gencode;arch=compute_35,code=sm_35;-gencode;arch=compute_50,code=sm_50;-gencode;arch=compute_60,code=sm_60;-gencode;arch=compute_60,code=compute_60
--     FFLAGS:                -O2 -ftz -fp-speculation=safe -fp-model source -fopenmp -fPIC -craype-verbose -Dmagma_devptr_t="integer(kind=8)"
--     LIBS:                   /opt/intel/compilers_and_libraries_2019.1.144/linux/mkl/lib/intel64_lin/libmkl_intel_lp64.so /opt/intel/compilers_and_libraries_2019.1.144/linux/mkl/lib/intel64_lin/libmkl_intel_thread.so /opt/intel/compilers_and_libraries_2019.1.144/linux/mkl/lib/intel64_lin/libmkl_core.so /opt/intel/compilers_and_libraries_2019.1.144/linux/compiler/lib/intel64_lin/libiomp5.so -lm -ldl /opt/nvidia/cudatoolkit10/10.1.105_3.27-7.0.1.1_4.1__ga311ce7/lib64/libcudart.so /opt/nvidia/cudatoolkit10/10.1.105_3.27-7.0.1.1_4.1__ga311ce7/lib64/libcublas.so /opt/nvidia/cudatoolkit10/10.1.105_3.27-7.0.1.1_4.1__ga311ce7/lib64/libcusparse.so
--     blas_fix:                (MacOS Accelerate only)
--     LAPACK_LIBRARIES:      /opt/intel/compilers_and_libraries_2019.1.144/linux/mkl/lib/intel64_lin/libmkl_intel_lp64.so;/opt/intel/compilers_and_libraries_2019.1.144/linux/mkl/lib/intel64_lin/libmkl_intel_thread.so;/opt/intel/compilers_and_libraries_2019.1.144/linux/mkl/lib/intel64_lin/libmkl_core.so;/opt/intel/compilers_and_libraries_2019.1.144/linux/compiler/lib/intel64_lin/libiomp5.so;-lm;-ldl
--     CUDA_CUDART_LIBRARY:   /opt/nvidia/cudatoolkit10/10.1.105_3.27-7.0.1.1_4.1__ga311ce7/lib64/libcudart.so
--     CUDA_CUBLAS_LIBRARIES: /opt/nvidia/cudatoolkit10/10.1.105_3.27-7.0.1.1_4.1__ga311ce7/lib64/libcublas.so
--     CUDA_cusparse_LIBRARY: /opt/nvidia/cudatoolkit10/10.1.105_3.27-7.0.1.1_4.1__ga311ce7/lib64/libcusparse.so
--     Fortran modules:       /run/user/22449/easybuild/build/magma/2.5.2/CrayIntel-19.10-cuda-10.1/easybuild_obj/magma_param.mod;/run/user/22449/easybuild/build/magma/2.5.2/CrayIntel-19.10-cuda-10.1/easybuild_obj/magma.mod;/run/user/22449/easybuild/build/magma/2.5.2/CrayIntel-19.10-cuda-10.1/easybuild_obj/magma_sfortran.mod;/run/user/22449/easybuild/build/magma/2.5.2/CrayIntel-19.10-cuda-10.1/easybuild_obj/magma_dfortran.mod;/run/user/22449/easybuild/build/magma/2.5.2/CrayIntel-19.10-cuda-10.1/easybuild_obj/magma_cfortran.mod;/run/user/22449/easybuild/build/magma/2.5.2/CrayIntel-19.10-cuda-10.1/easybuild_obj/magma_zfortran.mod;/run/user/22449/easybuild/build/magma/2.5.2/CrayIntel-19.10-cuda-10.1/easybuild_obj/magmablas_sfortran.mod;/run/user/22449/easybuild/build/magma/2.5.2/CrayIntel-19.10-cuda-10.1/easybuild_obj/magmablas_dfortran.mod;/run/user/22449/easybuild/build/magma/2.5.2/CrayIntel-19.10-cuda-10.1/easybuild_obj/magmablas_cfortran.mod;/run/user/22449/easybuild/build/magma/2.5.2/CrayIntel-19.10-cuda-10.1/easybuild_obj/magmablas_zfortran.mod
```