### PR TITLE
[dom,daint] Create LAMMPS-7Aug2019-CrayGNU-19.10-PLUMED-2.5.1-cuda-10.1.eb

### DIFF
--- a/easybuild/easyconfigs/l/LAMMPS/LAMMPS-7Aug2019-CrayGNU-19.10-PLUMED-2.5.1-cuda-10.1.eb
+++ b/easybuild/easyconfigs/l/LAMMPS/LAMMPS-7Aug2019-CrayGNU-19.10-PLUMED-2.5.1-cuda-10.1.eb
@@ -3,15 +3,15 @@ easyblock = 'MakeCp'
 
 name = 'LAMMPS'
 version = '7Aug19'
-release = 'stable_7Aug2019'
-cudaversion =  '10.1'
-plumedversion = '2.5.1'
-versionsuffix = '-PLUMED-%s-cuda-%s' % (plumedversion, cudaversion)
-py_maj_ver = '2'
-py_min_ver = '7'
-py_rev_ver = '15.7'
-pyshortver = "%s.%s" % (py_maj_ver, py_min_ver)
-pyver      = "%s.%s.%s" % (py_maj_ver, py_min_ver, py_rev_ver)
+local_release = 'stable_7Aug2019'
+local_cudaversion =  '10.1'
+local_plumedversion = '2.5.1'
+versionsuffix = '-PLUMED-%s-cuda-%s' % (local_plumedversion, local_cudaversion)
+local_py_maj_ver = '2'
+local_py_min_ver = '7'
+local_py_rev_ver = '15.7'
+local_pyshortver = "%s.%s" % (local_py_maj_ver, local_py_min_ver)
+local_pyver      = "%s.%s.%s" % (local_py_maj_ver, local_py_min_ver, local_py_rev_ver)
 
 homepage = 'http://lammps.sandia.gov/'
 description = "LAMMPS (Large-scale Atomic/Molecular Massively Parallel Simulator) is a classical molecular dynamics simulation code designed to run efficiently on parallel computers."
@@ -20,7 +20,7 @@ toolchain = {'name': 'CrayGNU', 'version': '19.10'}
 toolchainopts = { 'usempi': True, 'openmp': True }
 
 source_urls = ['https://github.com/lammps/lammps/archive']
-sources = ['%s.tar.gz' % (release)]
+sources = ['%s.tar.gz' % (local_release)]
 
 prebuildopts = ' cd ./src && '
 prebuildopts += ' make lib-plumed args="-p ${EBROOTPLUMED} -m runtime" && '
@@ -36,12 +36,12 @@ prebuildopts += ' sed -i -e \'s/mpicxx/CC/\' ./MAKE/Makefile.mpi && '
 buildopts = [ ' mpi ', ' omp ' ]
 
 builddependencies = [
-    ('cudatoolkit/%s.105_3.27-7.0.1.1_4.1__ga311ce7' %cudaversion, EXTERNAL_MODULE),
+    ('cudatoolkit/%s.105_3.27-7.0.1.1_4.1__ga311ce7' %local_cudaversion, EXTERNAL_MODULE),
     ('cray-fftw/3.3.8.3', EXTERNAL_MODULE),
-    ('cray-python/%s' %pyver, EXTERNAL_MODULE),
+    ('cray-python/%s' %local_pyver, EXTERNAL_MODULE),
 ]
     
-dependencies = [ ('PLUMED', '%s' %plumedversion) ]
+dependencies = [ ('PLUMED', '%s' %local_plumedversion) ]
 
 files_to_copy = [(['src/lmp*'], "bin")]
 

--- a/easybuild/easyconfigs/l/LAMMPS/LAMMPS-7Aug2019-CrayGNU-19.10-PLUMED-2.5.1-cuda-10.1.eb
+++ b/easybuild/easyconfigs/l/LAMMPS/LAMMPS-7Aug2019-CrayGNU-19.10-PLUMED-2.5.1-cuda-10.1.eb
@@ -1,0 +1,53 @@
+# Contributed by TWR (CSCS)
+easyblock = 'MakeCp'
+
+name = 'LAMMPS'
+version = '7Aug19'
+release = 'stable_7Aug2019'
+cudaversion =  '10.1'
+plumedversion = '2.5.1'
+versionsuffix = '-PLUMED-%s-cuda-%s' % (plumedversion, cudaversion)
+py_maj_ver = '2'
+py_min_ver = '7'
+py_rev_ver = '15.7'
+pyshortver = "%s.%s" % (py_maj_ver, py_min_ver)
+pyver      = "%s.%s.%s" % (py_maj_ver, py_min_ver, py_rev_ver)
+
+homepage = 'http://lammps.sandia.gov/'
+description = "LAMMPS (Large-scale Atomic/Molecular Massively Parallel Simulator) is a classical molecular dynamics simulation code designed to run efficiently on parallel computers."
+
+toolchain = {'name': 'CrayGNU', 'version': '19.10'}
+toolchainopts = { 'usempi': True, 'openmp': True }
+
+source_urls = ['https://github.com/lammps/lammps/archive']
+sources = ['%s.tar.gz' % (release)]
+
+prebuildopts = ' cd ./src && '
+prebuildopts += ' make lib-plumed args="-p ${EBROOTPLUMED} -m runtime" && '
+prebuildopts += ' make yes-standard yes-user-cg-cmm yes-user-omp yes-user-reaxc yes-gpu yes-k-space yes-molecule yes-mpiio yes-rigid yes-misc yes-user-misc yes-user-plumed && '
+prebuildopts += ' make no-latte no-voronoi no-reax no-poems no-meam no-kim no-kokkos no-mscg no-message && '
+prebuildopts += ' make package-update && '
+# go to folder ./lib/gpu, create Makefile.gpu and correct file ./lib/gpu/geryon/nvd_device.h
+prebuildopts += ' pushd ../lib/gpu && sed -e "s/-march=bdver1//g" -e "s/sm_[0-9]*/sm_60/g" Makefile.xk7 > Makefile.gpu && '
+prebuildopts += ' make -f Makefile.gpu && popd && '
+#create Makefile.omp and correct Makefile.mpi
+prebuildopts += ' sed -e \'s/mpicxx/CC -fopenmp/\' ./MAKE/Makefile.mpi > ./MAKE/Makefile.omp && '
+prebuildopts += ' sed -i -e \'s/mpicxx/CC/\' ./MAKE/Makefile.mpi && '
+buildopts = [ ' mpi ', ' omp ' ]
+
+builddependencies = [
+    ('cudatoolkit/%s.105_3.27-7.0.1.1_4.1__ga311ce7' %cudaversion, EXTERNAL_MODULE),
+    ('cray-fftw/3.3.8.3', EXTERNAL_MODULE),
+    ('cray-python/%s' %pyver, EXTERNAL_MODULE),
+]
+    
+dependencies = [ ('PLUMED', '%s' %plumedversion) ]
+
+files_to_copy = [(['src/lmp*'], "bin")]
+
+sanity_check_paths = {
+    'files': ['bin/lmp_mpi','bin/lmp_omp'],
+    'dirs': [],
+}
+
+moduleclass = 'chem'


### PR DESCRIPTION
With PLUMED 2.5 the lammps patch has been removed, see https://www.plumed.org/doc-v2.5/user-doc/html/_c_h_a_n_g_e_s-2-5.html ("LAMMPS patch has been finally removed. Notice that LAMMPS has native support for PLUMED now".). Native support from LAMMPS 2019 onwards, hence the upgrade to 2019 version. Build instructions here: https://lammps.sandia.gov/doc/Build_extras.html#user-plumed