### PR TITLE
[dom-gpu] Adding jupyterlab-1.2.4 to jenkins list

### DIFF
--- a/jenkins-builds/7.0.UP01-19.10-gpu-dom
+++ b/jenkins-builds/7.0.UP01-19.10-gpu-dom
@@ -29,10 +29,12 @@
  IDL-8.7.2-CSCS.eb
  ipykernel-4.8.2-CrayGNU-19.10-python2.eb
  ipyparallel-6.2.4-CrayGNU-19.10-python3.eb
+ IPython-7.7.0-CrayGNU-19.10-python3                --set-default-module
  Julia-1.2.0-CrayGNU-19.10-cuda-10.1.eb             --set-default-module
  JuliaExtensions-1.2.0-CrayGNU-19.10-cuda-10.1.eb   --set-default-module
- jupyterlab-1.1.1-CrayGNU-19.10.eb                  --set-default-module
- jupyterlab-1.1.1-CrayGNU-19.10-batchspawner.eb
+ jupyterlab-1.1.1-CrayGNU-19.10.eb                  
+ jupyterlab-1.1.1-CrayGNU-19.10-batchspawner.eb     --set-default-module
+ jupyterlab-1.2.4-CrayGNU-19.10-cuda-10.1-batchspawner.eb    
  jupyterhub-1.0.0-CrayGNU-19.10.eb                  --set-default-module
  LAMMPS-22Aug2018-CrayGNU-19.10-cuda-10.1.eb        --set-default-module
  Lmod-7.8.2.eb                                      --set-default-module --hidden

--- a/jenkins-builds/7.0.UP01-19.10-gpu-dom
+++ b/jenkins-builds/7.0.UP01-19.10-gpu-dom
@@ -31,8 +31,7 @@
  ipyparallel-6.2.4-CrayGNU-19.10-python3.eb
  IPython-7.7.0-CrayGNU-19.10-python3                --set-default-module
  Julia-1.2.0-CrayGNU-19.10-cuda-10.1.eb             --set-default-module
- JuliaExtensions-1.2.0-CrayGNU-19.10-cuda-10.1.eb   --set-default-module
- jupyterlab-1.1.1-CrayGNU-19.10.eb                  
+ JuliaExtensions-1.2.0-CrayGNU-19.10-cuda-10.1.eb   --set-default-module             
  jupyterlab-1.1.1-CrayGNU-19.10-batchspawner.eb     --set-default-module
  jupyterlab-1.2.4-CrayGNU-19.10-cuda-10.1-batchspawner.eb    
  jupyterhub-1.0.0-CrayGNU-19.10.eb                  --set-default-module


### PR DESCRIPTION
Adds IPython to make it available as a module. Adds jupyterlab-1.2.4 with support for IJulia kernel. Change default version of JupyterLab to one that is supported by new batchspawner.