### PR TITLE
[daint-gpu, dom-gpu] Fix CUDA installation issue

### DIFF
--- a/easybuild/easyconfigs/c/CUDA/CUDA-10.1.168.eb
+++ b/easybuild/easyconfigs/c/CUDA/CUDA-10.1.168.eb
@@ -16,6 +16,6 @@ source_urls = ['https://developer.nvidia.com/compute/%(namelower)s/%(version_maj
 sources = ['%%(namelower)s_%%(version)s_%s_linux.run' % local_nv_version]
 checksums = ['9d60e04f88d8618943c928486173cd17']
 
-postinstallcmds = ['rm /tmp/cuda-installer.log']
+postinstallcmds = ['rm -f /tmp/cuda-installer.log']
 
 moduleclass = 'system'


### PR DESCRIPTION
This fixes the error
```
cmd "rm /tmp/cuda-installer.log" exited with exit code 1 and output: 
rm: cannot remove /tmp/cuda-installer.log: No such file or directory
```