### PR TITLE
[daint, dom] Intel Open Image Denoise Update

### DIFF
--- a/easybuild/easyconfigs/o/oidn/oidn-1.1.0-CrayGNU-19.10.eb
+++ b/easybuild/easyconfigs/o/oidn/oidn-1.1.0-CrayGNU-19.10.eb
@@ -1,0 +1,20 @@
+easyblock = "Tarball"
+
+name = 'oidn'
+version = '1.1.0'
+
+homepage = 'https://openimagedenoise.github.io'
+description = """Intel® Open Image Denoise is an open source library of high-performance,
+high-quality denoising filters for images rendered with ray tracing"""
+
+toolchain = {'name': 'CrayGNU', 'version': '19.10'}
+
+sources = ['oidn-%(version)s.x86_64.linux.tar.gz']
+source_urls = ['https://github.com/OpenImageDenoise/oidn/releases/download/v%(version)s/']
+
+sanity_check_paths={
+    'files': [],
+    'dirs': ['include', 'lib']
+}
+
+moduleclass = 'devel'


### PR DESCRIPTION
ParaView 5.8 new release benefits from the update of the Image Denoising library.

COMPLETED: Installation ended successfully (took 4 sec)
== Results of the build can be found in the log file(s) /scratch/snx3000/jfavre/daint/software/oidn/1.1.0-CrayGNU-19.10/easybuild/easybuild-oidn-1.1.0-20200218.082136.log