### PR TITLE
[daint,dom] Create GDAL-2.2.2-CrayGNU-19.10.eb

### DIFF
--- a/easybuild/easyconfigs/e/expat/expat-2.2.4-CrayGNU-19.10.eb
+++ b/easybuild/easyconfigs/e/expat/expat-2.2.4-CrayGNU-19.10.eb
@@ -1,0 +1,16 @@
+easyblock = 'ConfigureMake'
+
+name = 'expat'
+version = '2.2.4'
+
+homepage = 'http://expat.sourceforge.net/'
+description = """Expat is an XML parser library written in C. It is a stream-oriented parser in which an application
+ registers handlers for things the parser might find in the XML document (like start tags)"""
+
+toolchain = {'name': 'CrayGNU', 'version': '19.10'}
+toolchainopts = {'pic': True}
+
+sources = [SOURCELOWER_TAR_BZ2]
+source_urls = [SOURCEFORGE_SOURCE]
+
+moduleclass = 'tools'

--- a/easybuild/easyconfigs/g/GDAL/GDAL-2.2.2-CrayGNU-19.10.eb
+++ b/easybuild/easyconfigs/g/GDAL/GDAL-2.2.2-CrayGNU-19.10.eb
@@ -1,0 +1,32 @@
+easyblock = 'ConfigureMake'
+
+name = 'GDAL'
+version = '2.2.2'
+
+homepage = 'http://www.gdal.org/'
+description = """GDAL is a translator library for raster geospatial data formats that is released under an X/MIT style
+ Open Source license by the Open Source Geospatial Foundation. As a library, it presents a single abstract data model
+ to the calling application for all supported formats. It also comes with a variety of useful commandline utilities for
+ data translation and processing."""
+
+toolchain = {'name': 'CrayGNU', 'version': '19.10'}
+toolchainopts = {'usempi': True}
+
+source_urls = ['http://download.osgeo.org/gdal/%(version)s/']
+sources = [SOURCELOWER_TAR_XZ]
+
+dependencies = [
+    ('cray-netcdf/4.6.3.1', 'EXTERNAL_MODULE'),
+    ('cray-hdf5/1.10.5.1', EXTERNAL_MODULE),
+    ('expat', '2.2.4'),
+    ('libpng', '1.6.34'),
+    ('libxml2', '2.9.7'),
+    ('zlib', '1.2.11'),
+]
+
+sanity_check_paths = {
+    'files': ['lib/libgdal.%s' % SHLIB_EXT, 'lib/libgdal.a'],
+    'dirs': ['bin', 'include']
+}
+
+moduleclass = 'data'

--- a/easybuild/easyconfigs/g/GDAL/GDAL-2.2.2-CrayGNU-19.10.eb
+++ b/easybuild/easyconfigs/g/GDAL/GDAL-2.2.2-CrayGNU-19.10.eb
@@ -16,7 +16,7 @@ source_urls = ['http://download.osgeo.org/gdal/%(version)s/']
 sources = [SOURCELOWER_TAR_XZ]
 
 dependencies = [
-    ('cray-netcdf/4.6.3.1', 'EXTERNAL_MODULE'),
+    ('cray-netcdf/4.6.3.1', EXTERNAL_MODULE),
     ('cray-hdf5/1.10.5.1', EXTERNAL_MODULE),
     ('expat', '2.2.4'),
     ('libpng', '1.6.34'),

--- a/easybuild/easyconfigs/g/GDAL/GDAL-2.2.2-CrayGNU-19.10.eb
+++ b/easybuild/easyconfigs/g/GDAL/GDAL-2.2.2-CrayGNU-19.10.eb
@@ -16,8 +16,8 @@ source_urls = ['http://download.osgeo.org/gdal/%(version)s/']
 sources = [SOURCELOWER_TAR_XZ]
 
 dependencies = [
-    ('cray-netcdf/4.6.3.1', EXTERNAL_MODULE),
-    ('cray-hdf5/1.10.5.1', EXTERNAL_MODULE),
+    ('cray-netcdf', EXTERNAL_MODULE),
+    ('cray-hdf5', EXTERNAL_MODULE),
     ('expat', '2.2.4'),
     ('libpng', '1.6.34'),
     ('libxml2', '2.9.7'),


### PR DESCRIPTION
Add GDAL 2.2.2 with cray-netcdf and cray-hdf5 corresponding to default versions on Daint as at 26 Feb 2020 (PE 19.10).