### PR TITLE
[daint-gpu] Update libxc-4.3.4-CrayIntel-19.10.eb

### DIFF
--- a/easybuild/easyconfigs/l/libxc/libxc-4.3.4-CrayIntel-19.10.eb
+++ b/easybuild/easyconfigs/l/libxc/libxc-4.3.4-CrayIntel-19.10.eb
@@ -1,6 +1,5 @@
-# contributed by Simon Pintarelli (CSCS)
-
-easyblock = 'CMakeMake'
+# contributed by Luca Marsella (CSCS)
+easyblock = 'ConfigureMake'
 
 name = 'libxc'
 version = "4.3.4"
@@ -13,20 +12,15 @@ toolchain = {'name': 'CrayIntel', 'version': '19.10'}
 toolchainopts = {'opt': True}
 
 sources = [SOURCE_TAR_GZ]
-source_urls = ['https://gitlab.com/libxc/libxc/-/archive/%s/libxc-%s.tar.gz' % (version, version)]
+source_urls = ['http://www.tddft.org/programs/%(name)s/down.php?file=%(version)s']
 
-separate_build_dir = True
-preconfigopts = 'export FC="$F77" && export FCFLAGS="$FFLAGS" &&'
-configopts = '-DBUILD_SHARED_LIBS=On'
-builddependencies = [
-    ('CMake', '3.14.5', '', True),
-]
+configopts = 'FC="$F77" FCFLAGS="$FFLAGS" --enable-shared'
 
 sanity_check_paths = {
-    'files': ['lib64/libxc.so'],
+    'files': ['lib/libxc.a', 'lib/libxc.so'],
     'dirs': ['include'],
 }
 
-parallel = 10
+parallel = 1
 
 moduleclass = 'chem'


### PR DESCRIPTION
I had to revert to the easyblock `ConfigureMake` since some library files requested by `CP2K 7.1` were missing in the CMake build performed with the easyblock `CMakeMake`. 
I have also fixed the download link which was not working any more to download the package (see #1525).