### PR TITLE
[daint-gpu] libxc 4.3.4 with CrayGNU

### DIFF
--- a/easybuild/easyconfigs/l/libxc/libxc-4.3.4-CrayGNU-19.10.eb
+++ b/easybuild/easyconfigs/l/libxc/libxc-4.3.4-CrayGNU-19.10.eb
@@ -18,11 +18,9 @@ configopts = 'FC="$F77" FCFLAGS="$FFLAGS" --enable-shared'
 
 sanity_check_paths = {
     'files': ['lib/libxc.a', 'lib/libxc.so', 
-              'lib/libxcf03.a', 'lib/libxcf03.so'
+              'lib/libxcf03.a', 'lib/libxcf03.so',
               'lib/libxcf90.a', 'lib/libxcf90.so'],
     'dirs': ['include'],
 }
-
-parallel = 1
 
 moduleclass = 'chem'

--- a/easybuild/easyconfigs/l/libxc/libxc-4.3.4-CrayGNU-19.10.eb
+++ b/easybuild/easyconfigs/l/libxc/libxc-4.3.4-CrayGNU-19.10.eb
@@ -1,6 +1,5 @@
-# contributed by Simon Pintarelli (CSCS)
-
-easyblock = 'CMakeMake'
+# contributed by Luca Marsella (CSCS)
+easyblock = 'ConfigureMake'
 
 name = 'libxc'
 version = "4.3.4"
@@ -13,20 +12,17 @@ toolchain = {'name': 'CrayGNU', 'version': '19.10'}
 toolchainopts = {'opt': True}
 
 sources = [SOURCE_TAR_GZ]
-source_urls = ['https://gitlab.com/libxc/libxc/-/archive/%s/libxc-%s.tar.gz' % (version, version)]
+source_urls = ['http://www.tddft.org/programs/%(name)s/down.php?file=%(version)s']
 
-separate_build_dir = True
-preconfigopts = 'export FC="$F77" && export FCFLAGS="$FFLAGS" &&'
-configopts = '-DBUILD_SHARED_LIBS=On'
-builddependencies = [
-    ('CMake', '3.14.5', '', True),
-]
+configopts = 'FC="$F77" FCFLAGS="$FFLAGS" --enable-shared'
 
 sanity_check_paths = {
-    'files': ['lib64/libxc.so'],
+    'files': ['lib/libxc.a', 'lib/libxc.so', 
+              'lib/libxcf03.a', 'lib/libxcf03.so'
+              'lib/libxcf90.a', 'lib/libxcf90.so'],
     'dirs': ['include'],
 }
 
-parallel = 10
+parallel = 1
 
 moduleclass = 'chem'


### PR DESCRIPTION
I am submitting a new recipe for `libxc-4.3.4` with `CrayGNU`, since CP2K requires also the Fortran library files `libxcf03` and `libxcf90` in addition to the `libxc` file and the former ones were missing in the build with the easyblock `CMakeMake`. This recipe builds both the static and shared library files, that I have added to the sanity check list: the build will take a bit more time to complete, however I have removed the constraint `parallel = 1` to allow multiple threads with `make`.

The download from GitLab works correctly for manual builds, but recently fails with the Jenkins CI (see #1525): therefore I am reverting to the download from www.tddft.org, although in the past it was occasionally unreliable.