### PR TITLE
[daint] new pycuda for PyFR

### DIFF
--- a/easybuild/easyconfigs/p/PyFR/PyFR-1.9.0-CrayGNU-19.10-python3.eb
+++ b/easybuild/easyconfigs/p/PyFR/PyFR-1.9.0-CrayGNU-19.10-python3.eb
@@ -22,7 +22,7 @@ sources = ['v%(version)s.tar.gz']
 dependencies = [
     # PyExtensions/3.6.5.7-CrayGNU-19.10 / cray-python/3.6.5.7
     ('cray-python/%s.%s' % (local_pyver, local_py_rev_ver), EXTERNAL_MODULE),
-    ('pycuda', '2018.1.1', '-python3-cuda-10.1'),
+    ('pycuda', '2019.1.2', '-python3-cuda-10.1'),
     ('h5py', '2.8.0', '-python3-serial'),
     ('Mako', '1.1.2', '-python3'),
 ]

--- a/easybuild/easyconfigs/p/pycuda/pycuda-2019.1.2-CrayGNU-19.10-python3-cuda-10.1.eb
+++ b/easybuild/easyconfigs/p/pycuda/pycuda-2019.1.2-CrayGNU-19.10-python3-cuda-10.1.eb
@@ -1,0 +1,40 @@
+# @author: gppezzi
+easyblock = 'PythonPackage'
+
+name = 'pycuda'
+version = '2019.1.2'
+
+local_cudaversion = '10.1'
+
+local_py_maj_ver = '3'
+local_py_min_ver = '6'
+local_py_rev_ver = '5.7'
+
+local_pyver = '%s.%s.%s' % (local_py_maj_ver, local_py_min_ver, local_py_rev_ver)
+local_pyshortver = '%s.%s' % (local_py_maj_ver, local_py_min_ver)
+
+versionsuffix = '-python%s-cuda-%s' % (local_py_maj_ver, local_cudaversion)
+
+homepage = 'https://pypi.python.org/pypi/pycuda'
+description = """Python wrapper for Nvidia CUDA. PyCUDA lets you access Nvidia
+CUDA parallel computation API from Python."""
+
+toolchain = {'name': 'CrayGNU', 'version': '19.10'}
+toolchainopts = {'usempi': True}
+
+source_urls = [PYPI_SOURCE]
+sources = [SOURCE_TAR_GZ]
+
+dependencies = [
+    ('cray-python/%s' % local_pyver, EXTERNAL_MODULE),
+    ('cudatoolkit/10.1.105_3.27-7.0.1.1_4.1__ga311ce7', EXTERNAL_MODULE),
+]
+
+prebuildopts = "python ./configure.py --cuda-root=$EBROOTCUDA"
+
+sanity_check_paths = {
+    'files': [],
+    'dirs': ['lib/python%(pv)s/site-packages/%%(name)s-%%(version)s-py%(pv)s-linux-x86_64.egg' % {'pv': local_pyshortver}],
+}
+
+moduleclass = 'lang'


### PR DESCRIPTION
The pycuda version for PyFR has been updated.

The openmp backend is not working for some reason, but the cuda backend is.