### PR TITLE
[tsa] Account for compatibility mode of modules on RH7.7

### DIFF
--- a/easybuild/module/EasyBuild-custom/cscs
+++ b/easybuild/module/EasyBuild-custom/cscs
@@ -82,7 +82,11 @@ if { [ string match *daint* $system ] } {
 } elseif { [ string match *arolla* $system ] || [ string match *tsa* $system ] } {
     setenv EASYBUILD_EXTERNAL_MODULES_METADATA $::env(EB_CUSTOM_REPOSITORY)/cray_external_modules_metadata.cfg
     setenv EASYBUILD_MODULE_NAMING_SCHEME       LowercaseModuleNamingScheme
-    setenv EASYBUILD_MODULES_TOOL               EnvironmentModules
+    if { [ string match tsa-ln003 $::env(HOSTNAME) ] } {
+        setenv EASYBUILD_MODULES_TOOL               EnvironmentModulesC
+    } else {
+        setenv EASYBUILD_MODULES_TOOL               EnvironmentModules
+    }
     setenv EASYBUILD_RECURSIVE_MODULE_UNLOAD    1
     setenv EASYBUILD_RPATH                      1
 } elseif { [ string match *fulen* $system ] } {


### PR DESCRIPTION
On `tsa-ln003`, the compatibility mode of the modules environment was activated to mitigate an issue when unloading already unloaded modules. This requires a change of the EASYBUILD_MODULES_TOOL variable.

This modification is intended to be temporary, to account for the different settings on Tsa (RH7.6 & RH7.7).