### PR TITLE
[daint-gpu] Update 7.0.UP01-19.10-gpu

### DIFF
--- a/jenkins-builds/7.0.UP01-19.10-gpu
+++ b/jenkins-builds/7.0.UP01-19.10-gpu
@@ -39,6 +39,7 @@
  jupyterlab-1.1.1-CrayGNU-19.10-batchspawner.eb
  jupyterhub-1.0.0-CrayGNU-19.10.eb                  --set-default-module
  LAMMPS-22Aug2018-CrayGNU-19.10-cuda-10.1.eb        --set-default-module
+ LAMMPS-03Mar2020-CrayGNU-19.10-cuda-10.1.eb
  Lmod-7.8.2.eb                                      --set-default-module --hidden
  magma-2.4.0-CrayIntel-19.10-cuda-10.1.eb           --set-default-module
  MATLAB-R2019a.eb

--- a/jenkins-builds/7.0.UP01-19.10-mc
+++ b/jenkins-builds/7.0.UP01-19.10-mc
@@ -37,6 +37,7 @@
  jupyterlab-1.1.1-CrayGNU-19.10.eb                  --set-default-module
  jupyterlab-1.1.1-CrayGNU-19.10-batchspawner.eb
  LAMMPS-22Aug2018-CrayGNU-19.10.eb                  --set-default-module
+ LAMMPS-03Mar2020-CrayGNU-19.10.eb
  Lmod-7.8.2.eb                                      --set-default-module --hidden
  MATLAB-R2019a.eb
  NAMD-2.13-CrayIntel-19.10.eb                       --set-default-module


### PR DESCRIPTION
Adds LAMMPS 3 March 2020  to the production lists.