### PR TITLE
[dom daint] Remove ipykernel from production list

### DIFF
--- a/jenkins-builds/7.0.UP01-19.10-gpu
+++ b/jenkins-builds/7.0.UP01-19.10-gpu
@@ -31,7 +31,6 @@
  Horovod-0.18.1-CrayGNU-19.10-tf-2.0.0.eb
  IDL-8.5.1.eb                                       --set-default-module
  IDL-8.7.2-CSCS.eb
- ipykernel-4.8.2-CrayGNU-19.10-python2.eb
  ipyparallel-6.2.4-CrayGNU-19.10-python3.eb
  Julia-1.2.0-CrayGNU-19.10-cuda-10.1.eb             --set-default-module
  JuliaExtensions-1.2.0-CrayGNU-19.10-cuda-10.1.eb   --set-default-module

--- a/jenkins-builds/7.0.UP01-19.10-gpu-dom
+++ b/jenkins-builds/7.0.UP01-19.10-gpu-dom
@@ -32,7 +32,6 @@
  Horovod-0.18.1-CrayGNU-19.10-tf-2.0.0.eb
  IDL-8.5.1.eb                                       --set-default-module
  IDL-8.7.2-CSCS.eb
- ipykernel-4.8.2-CrayGNU-19.10-python2.eb
  ipyparallel-6.2.4-CrayGNU-19.10-python3.eb
  Julia-1.2.0-CrayGNU-19.10-cuda-10.1.eb             --set-default-module
  JuliaExtensions-1.2.0-CrayGNU-19.10-cuda-10.1.eb   --set-default-module

--- a/jenkins-builds/7.0.UP01-19.10-mc
+++ b/jenkins-builds/7.0.UP01-19.10-mc
@@ -29,7 +29,6 @@
  h5py-2.8.0-CrayGNU-19.10-python3-serial.eb
  IDL-8.5.1.eb                                       --set-default-module
  IDL-8.7.2-CSCS.eb
- ipykernel-4.8.2-CrayGNU-19.10-python2.eb
  ipyparallel-6.2.4-CrayGNU-19.10-python3.eb
  Julia-1.2.0-CrayGNU-19.10.eb                       --set-default-module
  JuliaExtensions-1.2.0-CrayGNU-19.10.eb             --set-default-module

--- a/jenkins-builds/7.0.UP01-19.10-mc-dom
+++ b/jenkins-builds/7.0.UP01-19.10-mc-dom
@@ -30,7 +30,6 @@
  h5py-2.8.0-CrayGNU-19.10-python3-serial.eb
  IDL-8.5.1.eb                                       --set-default-module
  IDL-8.7.2-CSCS.eb
- ipykernel-4.8.2-CrayGNU-19.10-python2.eb
  ipyparallel-6.2.4-CrayGNU-19.10-python3.eb
  Julia-1.2.0-CrayGNU-19.10.eb                       --set-default-module
  JuliaExtensions-1.2.0-CrayGNU-19.10.eb             --set-default-module


### PR DESCRIPTION
I am not sure why this recipe was introduced in the production list but, as far as I can tell, it is not used in any recipe of a supported application.