### PR TITLE
[daint] Provide Instrumented version of Amber18

### DIFF
--- a/easybuild/easyconfigs/a/Amber/Amber-18-14-14-CrayGNU-19.10-cuda-10.1-pat7.1.1.eb
+++ b/easybuild/easyconfigs/a/Amber/Amber-18-14-14-CrayGNU-19.10-cuda-10.1-pat7.1.1.eb
@@ -1,0 +1,63 @@
+# @author: karakasv gppezzi
+# @author: victor holanda rusu
+
+easyblock = 'MakeCp'
+
+name = 'Amber'
+local_patchlevels = (14, 14) # (AmberTools, Amber)
+version = '18-%s-%s' % (local_patchlevels[0], local_patchlevels[1])
+local_cudaversion = '10.1'
+local_patversion = '7.1.1'
+versionsuffix = '-cuda-%s-pat%s' % (local_cudaversion, local_patversion)
+
+homepage = 'http://ambermd.org/'
+description = """Amber (Assisted Model Building with Energy Refinement)
+is software for performing molecular dynamics and structure prediction"""
+whatis = [ "Amber 18 && AmberTools 18",
+           "AmberTools patch level %s" % local_patchlevels[0],
+           "Amber patch level %s" % local_patchlevels[1]]
+
+toolchain = {'name': 'CrayGNU', 'version': '19.10'}
+toolchainopts = { 'verbose': False }
+
+sources = [
+    '/apps/common/UES/easybuild/sources/a/Amber/Amber18.tar.bz2',
+    '/apps/common/UES/easybuild/sources/a/Amber/AmberTools18.tar.bz2'
+]
+
+dependencies = [
+    ('bzip2', '1.0.6'),
+    ('zlib', '1.2.11'),
+    ('craype-accel-nvidia60', EXTERNAL_MODULE),
+]
+
+builddependencies = [
+    ('cudatoolkit/10.1.105_3.27-7.0.1.1_4.1__ga311ce7', EXTERNAL_MODULE),
+    ('cray-hdf5', EXTERNAL_MODULE),
+    ('cray-netcdf', EXTERNAL_MODULE),
+]
+
+buildininstalldir = True
+
+prebuildopts = 'cd .. && mv amber18/* . && '
+prebuildopts += 'export AMBERHOME=%(builddir)s; export CUDA_HOME=$CUDATOOLKIT_HOME;'
+prebuildopts += './update_amber --update-to %s/%s && ' % ("AmberTools", local_patchlevels[0])
+prebuildopts += './update_amber --update-to %s/%s && ' % ("Amber", local_patchlevels[1])
+#
+prebuildopts += './configure -mpi -cuda -noX11 -crayxt5 --skip-python --with-netcdf $EBROOTNETCDF gnu <<< Y;'
+prebuildopts += "echo 'PMEMD_CU_INCLUDES += -I$(MPICH_DIR)/include' >> config.h;"
+
+buildopts = 'install'
+
+files_to_copy = []
+
+sanity_check_paths = {
+    'files' : [ 'bin/pmemd.cuda.MPI' ],
+    'dirs'  : [],
+}
+
+modextravars = {
+    'AMBERHOME' : '%(builddir)s',
+}
+
+moduleclass = 'bio'


### PR DESCRIPTION
Amber was provided as a module on daint
```
------------------------------------------------ /apps/daint/UES/6.0.UP07/craypat/easybuild/modules/all/ -------------------------------------------------
CP2K/6.1-CrayGNU-18.08-cuda-9.1-pat-7.0.2       LAMMPS/22Aug18-CrayGNU-18.08-cuda-9.1-pat-7.0.2 VASP/5.4.4-CrayIntel-18.08-cuda-9.1-pat-7.0.2
CPMD/4.1-CrayIntel-18.08-pat-7.0.2              NAMD/2.12-CrayIntel-18.08-cuda-9.1-pat-7.0.2
```