### PR TITLE
[daint-gpu] Latest ELPA release with CrayGNU

### DIFF
--- a/easybuild/easyconfigs/e/ELPA/ELPA-2019.11.001-CrayGNU-19.10.eb
+++ b/easybuild/easyconfigs/e/ELPA/ELPA-2019.11.001-CrayGNU-19.10.eb
@@ -1,0 +1,29 @@
+# Contributed by Luca Marsella (CSCS)
+easyblock = 'ConfigureMake'
+
+name = 'ELPA'
+version = "2019.11.001"
+
+homepage = 'http://elpa.rzg.mpg.de'
+description = """Eigenvalue SoLvers for Petaflop-Applications ."""
+
+toolchain = {'name': 'CrayGNU', 'version': '19.10'}
+toolchainopts = {'usempi': True, 'openmp': True}
+
+source_urls = ['http://elpa.mpcdf.mpg.de/html/Releases/%(version)s/']
+sources = [SOURCELOWER_TAR_GZ]
+
+configopts = '--disable-avx512 --enable-openmp --enable-static'
+
+prebuildopts = ' make clean && '
+
+sanity_check_paths = {
+    'files': ['lib/libelpa_openmp.a', 'lib/libelpa_openmp.%s' % SHLIB_EXT],
+    'dirs': ['bin', 'include/elpa_openmp-%(version)s/elpa', 'include/elpa_openmp-%(version)s/modules', 'lib/pkgconfig']
+}
+
+modextrapaths = {'CPATH': ['include/elpa_openmp-%(version)s']}
+
+modextravars = {'ELPA_INCLUDE_DIR': '%(installdir)s/include/elpa_openmp-%(version)s'}
+
+moduleclass = 'math'


### PR DESCRIPTION
I provide the recipe `ELPA 2019.11.001` with CrayGNU and `cray-libsci` for linear algebra routines. 
The script might be useful for #1551: as a matter of fact, the previous recipe `ELPA-2019.05.001-CrayGNU-19.10.eb` that is used as a dependency in that pull request makes use of MKL libraries instead of `cray-libsci`, however the CrayIntel recipe `ELPA-2019.11.001-CrayIntel-19.10.eb` already exists.