### PR TITLE
[daint] Fix proposed by Cray for using non default modules

### DIFF
--- a/easybuild/module/EasyBuild-custom/cscs
+++ b/easybuild/module/EasyBuild-custom/cscs
@@ -155,7 +155,13 @@ if { ! [ info exists ::env(EASYBUILD_SOURCEPATH) ] } {
 # Adding easybuild installed software to the list of modules
 prepend-path MODULEPATH                         $::env(EASYBUILD_INSTALLPATH)/modules/all
 # Loading easybuild module
-module use /apps/common/UES/easybuild/modules/all
+if { [module-info mode] == "load" } {
+        module use /apps/common/UES/easybuild/modules/all
+}
+
 module load EasyBuild
 
+if { [module-info mode] == "remove" || [module-info mode] == "unload" } {
+        module unuse /apps/common/UES/easybuild/modules/all
+}
 # Built with EasyBuild version 3.6.2


### PR DESCRIPTION
Fixes `module use` statement in the EasyBuild module wrapper when using non-default PEs.

Case #251844  

Tested on daint (`eb bzip2-1.0.6-CrayGNU-19.08.eb -r`)