### PR TITLE
[daint-gpu] Updated QuantumESPRESSO 6.5 in production

### DIFF
--- a/easybuild/easyconfigs/q/QuantumESPRESSO/QuantumESPRESSO-6.5-CrayIntel-19.10.eb
+++ b/easybuild/easyconfigs/q/QuantumESPRESSO/QuantumESPRESSO-6.5-CrayIntel-19.10.eb
@@ -1,0 +1,45 @@
+# created by Luca Marsella (CSCS)
+easyblock = "ConfigureMake"
+
+name = 'QuantumESPRESSO'
+version = '6.5'
+
+homepage = 'http://www.quantum-espresso.org/'
+description = """Quantum ESPRESSO is an integrated suite of computer codes
+ for electronic-structure calculations and materials modeling at the nanoscale.
+ It is based on density-functional theory, plane waves, and pseudopotentials
+  (both norm-conserving and ultrasoft)."""
+
+toolchain = {'name': 'CrayIntel', 'version': '19.10'}
+toolchainopts = {'usempi': True, 'openmp': True, 'pic': True, 'verbose': False, 'opt': True}
+
+sources = ['https://github.com/QEF/q-e/archive/' + 'qe-%s.tar.gz' % version ]
+
+preconfigopts = ' module unload cray-libsci && module list && '
+configopts = ' CC=cc FC=ftn '
+configopts += ' SCALAPACK_LIBS="-L$MKLROOT/lib/intel64 -lmkl_scalapack_lp64 -lmkl_intel_lp64 -lmkl_intel_thread -lmkl_core -lmkl_blacs_intelmpi_lp64" '
+configopts += ' LAPACK_LIBS="$MKLROOT/lib/intel64/libmkl_lapack95_lp64.a" BLAS_LIBS="$MKLROOT/lib/intel64/libmkl_blas95_lp64.a" '
+configopts += ' FFT_LIBS="-L$MKLROOT/lib/intel64 -lmkl_intel_lp64 -lmkl_intel_thread -lmkl_core" '
+configopts += ' LDFLAGS="-L$MKLROOT/lib/intel64 -lpthread -lstdc++ -ldl -qopenmp" '
+configopts += ' FFLAGS="-O3 -g -assume byterecl -traceback -qopenmp" F90FLAGS="$FFLAGS" CFLAGS="-O3"'
+configopts += ' ARCH=crayxt --enable-openmp --enable-parallel --with-scalapack '
+
+# use MKL FFT instead of FFTW 
+prebuildopts = """
+    sed -i -e 's/FFTW3/DFTI/' \
+    -e 's#^IFLAGS .*#& -I$(MKLROOT)/include -I$(MKLROOT)/include/fftw#' \
+    make.inc &&
+"""
+prebuildopts += ' module unload cray-libsci && '
+prebuildopts += ' cat make.inc && '
+buildopts = 'all epw'
+
+# single make process: parallel builds fail for targets 'gwl' and 'epw'
+maxparallel = 1
+
+sanity_check_paths = {
+      'files': ['bin/pw.x'],
+      'dirs': ['']
+}
+
+moduleclass = 'chem'

--- a/easybuild/easyconfigs/q/QuantumESPRESSO/QuantumESPRESSO-6.5-CrayIntel-19.10.eb
+++ b/easybuild/easyconfigs/q/QuantumESPRESSO/QuantumESPRESSO-6.5-CrayIntel-19.10.eb
@@ -11,7 +11,8 @@ description = """Quantum ESPRESSO is an integrated suite of computer codes
   (both norm-conserving and ultrasoft)."""
 
 toolchain = {'name': 'CrayIntel', 'version': '19.10'}
-toolchainopts = {'usempi': True, 'openmp': True, 'pic': True, 'verbose': False, 'opt': True}
+toolchainopts = {'usempi': True, 'openmp': True,
+                             'pic': True, 'verbose': False, 'opt': True}
 
 sources = ['https://github.com/QEF/q-e/archive/' + 'qe-%s.tar.gz' % version]
 

--- a/easybuild/easyconfigs/q/QuantumESPRESSO/QuantumESPRESSO-6.5-CrayIntel-19.10.eb
+++ b/easybuild/easyconfigs/q/QuantumESPRESSO/QuantumESPRESSO-6.5-CrayIntel-19.10.eb
@@ -24,7 +24,7 @@ configopts += ' LDFLAGS="-L$MKLROOT/lib/intel64 -lpthread -lstdc++ -ldl -qopenmp
 configopts += ' FFLAGS="-O3 -g -assume byterecl -traceback -qopenmp" F90FLAGS="$FFLAGS" CFLAGS="-O3"'
 configopts += ' ARCH=crayxt --enable-openmp --enable-parallel --with-scalapack '
 
-# use MKL FFT instead of FFTW 
+# use MKL FFT instead of FFTW
 prebuildopts = """
     sed -i -e 's/FFTW3/DFTI/' \
     -e 's#^IFLAGS .*#& -I$(MKLROOT)/include -I$(MKLROOT)/include/fftw#' \

--- a/easybuild/easyconfigs/q/QuantumESPRESSO/QuantumESPRESSO-6.5-CrayIntel-19.10.eb
+++ b/easybuild/easyconfigs/q/QuantumESPRESSO/QuantumESPRESSO-6.5-CrayIntel-19.10.eb
@@ -39,8 +39,8 @@ buildopts = 'all epw'
 maxparallel = 1
 
 sanity_check_paths = {
-      'files': ['bin/pw.x'],
-      'dirs': ['']
+    'files': ['bin/pw.x'],
+    'dirs': ['']
 }
 
 moduleclass = 'chem'

--- a/easybuild/easyconfigs/q/QuantumESPRESSO/QuantumESPRESSO-6.5-CrayIntel-19.10.eb
+++ b/easybuild/easyconfigs/q/QuantumESPRESSO/QuantumESPRESSO-6.5-CrayIntel-19.10.eb
@@ -13,7 +13,7 @@ description = """Quantum ESPRESSO is an integrated suite of computer codes
 toolchain = {'name': 'CrayIntel', 'version': '19.10'}
 toolchainopts = {'usempi': True, 'openmp': True, 'pic': True, 'verbose': False, 'opt': True}
 
-sources = ['https://github.com/QEF/q-e/archive/' + 'qe-%s.tar.gz' % version ]
+sources = ['https://github.com/QEF/q-e/archive/' + 'qe-%s.tar.gz' % version]
 
 preconfigopts = ' module unload cray-libsci && module list && '
 configopts = ' CC=cc FC=ftn '

--- a/easybuild/easyconfigs/q/QuantumESPRESSO/QuantumESPRESSO-6.5a1-CrayPGI-19.10-cuda-10.1.eb
+++ b/easybuild/easyconfigs/q/QuantumESPRESSO/QuantumESPRESSO-6.5a1-CrayPGI-19.10-cuda-10.1.eb
@@ -10,7 +10,11 @@ homepage = 'http://www.quantum-espresso.org/'
 description = """Quantum ESPRESSO is an integrated suite of computer codes
  for electronic-structure calculations and materials modeling at the nanoscale.
  It is based on density-functional theory, plane waves, and pseudopotentials
-  (both norm-conserving and ultrasoft)."""
+  (both norm-conserving and ultrasoft).
+ PGI Fortran gives the warning "ieee_inexact FORTRAN STOP" with QE GPU. 
+ Set NO_STOP_MESSAGES=1 in your batch script to avoid the warning. 
+ More details on the PGI User Forum at https://www.pgroup.com/userforum
+"""
 
 toolchain = {'name': 'CrayPGI', 'version': '19.10'}
 toolchainopts = {'usempi': True, 'openmp': True, 'verbose': False}

--- a/easybuild/easyconfigs/q/QuantumESPRESSO/QuantumESPRESSO-6.5a1-CrayPGI-19.10-cuda-10.1.eb
+++ b/easybuild/easyconfigs/q/QuantumESPRESSO/QuantumESPRESSO-6.5a1-CrayPGI-19.10-cuda-10.1.eb
@@ -7,13 +7,14 @@ local_cudaversion = '10.1'
 versionsuffix = '-cuda-%s' % local_cudaversion
 
 homepage = 'http://www.quantum-espresso.org/'
-description = """Quantum ESPRESSO is an integrated suite of computer codes
- for electronic-structure calculations and materials modeling at the nanoscale.
- It is based on density-functional theory, plane waves, and pseudopotentials
-  (both norm-conserving and ultrasoft).
- PGI Fortran gives the warning "ieee_inexact FORTRAN STOP" with QE GPU. 
- Set NO_STOP_MESSAGES=1 in your batch script to avoid the warning. 
- More details on the PGI User Forum at https://www.pgroup.com/userforum
+description = """Quantum ESPRESSO is an integrated suite of computer codes for
+electronic-structure calculations and materials modeling at the nanoscale. It
+is based on density-functional theory, plane waves, and pseudopotentials (both
+norm-conserving and ultrasoft). 
+
+Note: PGI Fortran gives the warning "ieee_inexact FORTRAN STOP" with QE GPU.  
+Set NO_STOP_MESSAGES=1 in your batch script to avoid the warning.
+More details on the PGI User Forum at https://www.pgroup.com/userforum
 """
 
 toolchain = {'name': 'CrayPGI', 'version': '19.10'}

--- a/jenkins-builds/7.0.UP01-19.10-gpu
+++ b/jenkins-builds/7.0.UP01-19.10-gpu
@@ -60,6 +60,7 @@
  PyExtensions-3.6.5.6-CrayGNU-19.10.eb
  Python-bare-3.7.3.eb                               --hidden
  QuantumESPRESSO-6.4.1-CrayIntel-19.10-cuda-10.1.eb --set-default-module
+ QuantumESPRESSO-6.5a1-CrayPGI-19.10-cuda-10.1.eb
  QuantumESPRESSO-SIRIUS-6.5-rc4-CrayIntel-19.10-cuda-10.1.eb --set-default-module
  singularity-3.5.3-daint.eb
  Spark-2.3.1-CrayGNU-19.10-Hadoop-2.7.eb            --set-default-module

--- a/jenkins-builds/7.0.UP01-19.10-gpu-dom
+++ b/jenkins-builds/7.0.UP01-19.10-gpu-dom
@@ -59,6 +59,7 @@
  PyExtensions-3.6.5.6-CrayGNU-19.10.eb
  Python-bare-3.7.3.eb                               --hidden
  QuantumESPRESSO-6.4.1-CrayIntel-19.10-cuda-10.1.eb --set-default-module
+ QuantumESPRESSO-6.5a1-CrayPGI-19.10-cuda-10.1.eb
  singularity-3.5.3-daint.eb
  Spark-2.3.1-CrayGNU-19.10-Hadoop-2.7.eb            --set-default-module
  TensorFlow-1.14.0-CrayGNU-19.10-cuda-10.1.168-python3.eb --set-default-module

--- a/jenkins-builds/7.0.UP01-19.10-mc
+++ b/jenkins-builds/7.0.UP01-19.10-mc
@@ -56,6 +56,7 @@
  PyExtensions-3.6.5.6-CrayGNU-19.10.eb
  Python-bare-3.7.3.eb                               --hidden
  QuantumESPRESSO-6.4.1-CrayIntel-19.10.eb           --set-default-module
+ QuantumESPRESSO-6.5-CrayIntel-19.10.eb
  singularity-3.5.3-daint.eb
  Spark-2.3.1-CrayGNU-19.10-Hadoop-2.7.eb            --set-default-module
  VASP-5.4.4-CrayIntel-19.10.eb                      --set-default-module

--- a/jenkins-builds/7.0.UP01-19.10-mc-dom
+++ b/jenkins-builds/7.0.UP01-19.10-mc-dom
@@ -56,6 +56,7 @@
  PyExtensions-3.6.5.6-CrayGNU-19.10.eb
  Python-bare-3.7.3.eb                               --hidden
  QuantumESPRESSO-6.4.1-CrayIntel-19.10.eb           --set-default-module
+ QuantumESPRESSO-6.5-CrayIntel-19.10.eb
  singularity-3.5.3-daint.eb
  Spark-2.3.1-CrayGNU-19.10-Hadoop-2.7.eb            --set-default-module
  VASP-5.4.4-CrayIntel-19.10.eb                      --set-default-module


### PR DESCRIPTION
Changes:
- info in `module help` on IEEE warning for QuantumESPRESSO GPU (see https://www.pgroup.com/userforum/viewtopic.php?t=4585)
- change to MKL FFT for QuantumESPRESSO multicore (slightly better performance with respect to FFTW in the Deisa benchmark AuSurf used by ReFrame)

I am also adding the new modules to the production lists of Piz Daint and Dom.