### PR TITLE
[TSAtds] Change buildpath for Tsa

### DIFF
--- a/jenkins/Machines.groovy
+++ b/jenkins/Machines.groovy
@@ -32,7 +32,7 @@ def tsa = [name: 'tsa',
 
 def TSAtds = [name: 'TSAtds',
            archs: [],
-           buildPath: '$XDG_RUNTIME_DIR/easybuild/build',
+           buildPath: '/tmp/$USER/easybuild/build',
            unusePath: '/apps/arolla/UES/modulefiles',
            modulesProduction: '',
            modulesUnuseProduction: '',


### PR DESCRIPTION
The variable `XDG_RUNTIME_DIR` on Tsa RH7.7 is not set anymore by default. (this seems due to an issue in the updated setup of SLURM (https://bugs.schedmd.com/show_bug.cgi?id=5920)
It is suggested to use `/tmp/$USER` as buildpath.