### PR TITLE
[dom-gpu] ffmpeg for remote video encoding

### DIFF
--- a/easybuild/easyconfigs/f/FFmpeg/FFmpeg-4.2-CrayGNU-19.10.eb
+++ b/easybuild/easyconfigs/f/FFmpeg/FFmpeg-4.2-CrayGNU-19.10.eb
@@ -1,0 +1,27 @@
+easyblock = 'ConfigureMake'
+
+name = 'FFmpeg'
+version = '4.2.2'
+
+homepage = 'https://www.ffmpeg.org/'
+description = """A complete, cross-platform solution to record, convert and stream audio and video."""
+
+toolchain = {'name': 'CrayGNU', 'version': '19.10'}
+
+sources = [SOURCELOWER_TAR_BZ2]
+source_urls = ['http://ffmpeg.org/releases/']
+
+dependencies = [
+    ('NASM', '2.14.02'),
+]
+
+configopts = '--enable-pic --enable-shared --enable-gpl --enable-version3 --enable-nonfree --cc="$CC" --cxx="$CXX" '
+
+sanity_check_paths = {
+    'files': ['bin/ff%s' % x for x in ['mpeg', 'probe']] +
+             ['lib/lib%s.%s' % (x, y) for x in ['avdevice', 'avfilter', 'avformat', 'avcodec', 'postproc',
+                                                'swresample', 'swscale', 'avutil'] for y in [SHLIB_EXT, 'a']],
+    'dirs': ['include']
+}
+
+moduleclass = 'vis'


### PR DESCRIPTION
https://jira.cscs.ch/browse/UES-818

is of great use to limit copying images from daint to remote teleworking locations.

== COMPLETED: Installation ended successfully (took 1 min 39 sec)
== Results of the build can be found in the log file(s) /scratch/snx3000/jfavre/daint/software/FFmpeg/4.2.2-CrayGNU-19.10/easybuild/easybuild-FFmpeg-4.2.2-20200427.093351.log