### PR TITLE
[dom-gpu] CP2K 7.1 in production

### DIFF
--- a/jenkins-builds/7.0.UP01-19.10-gpu
+++ b/jenkins-builds/7.0.UP01-19.10-gpu
@@ -7,6 +7,7 @@
  CDO-1.9.5-CrayIntel-19.10.eb
  CMake-3.14.5.eb                                    --set-default-module
  CP2K-6.1-CrayGNU-19.10-cuda-10.1.eb                --set-default-module
+ CP2K-7.1-CrayIntel-19.10-cuda-10.1.eb
  CPMD-4.1-CrayIntel-19.10.eb                        --set-default-module
  CPMD-4.3-CrayIntel-19.10-cuda-10.1.eb
  dask-2.2.0-CrayGNU-19.10-python3.eb                --set-default-module

--- a/jenkins-builds/7.0.UP01-19.10-gpu
+++ b/jenkins-builds/7.0.UP01-19.10-gpu
@@ -7,7 +7,7 @@
  CDO-1.9.5-CrayIntel-19.10.eb
  CMake-3.14.5.eb                                    --set-default-module
  CP2K-6.1-CrayGNU-19.10-cuda-10.1.eb                --set-default-module
- CP2K-7.1-CrayIntel-19.10-cuda-10.1.eb
+ CP2K-7.1-CrayGNU-19.10-cuda-10.1.eb
  CPMD-4.1-CrayIntel-19.10.eb                        --set-default-module
  CPMD-4.3-CrayIntel-19.10-cuda-10.1.eb
  dask-2.2.0-CrayGNU-19.10-python3.eb                --set-default-module

--- a/jenkins-builds/7.0.UP01-19.10-gpu-dom
+++ b/jenkins-builds/7.0.UP01-19.10-gpu-dom
@@ -8,7 +8,7 @@
  CDO-1.9.5-CrayIntel-19.10.eb
  CMake-3.14.5.eb                                    --set-default-module
  CP2K-6.1-CrayGNU-19.10-cuda-10.1.eb                --set-default-module
- CP2K-7.1-CrayIntel-19.10-cuda-10.1.eb
+ CP2K-7.1-CrayGNU-19.10-cuda-10.1.eb
  CPMD-4.1-CrayIntel-19.10.eb                        --set-default-module
  CPMD-4.3-CrayIntel-19.10-cuda-10.1.eb
  dask-2.2.0-CrayGNU-19.10-python3.eb                --set-default-module

--- a/jenkins-builds/7.0.UP01-19.10-gpu-dom
+++ b/jenkins-builds/7.0.UP01-19.10-gpu-dom
@@ -8,6 +8,7 @@
  CDO-1.9.5-CrayIntel-19.10.eb
  CMake-3.14.5.eb                                    --set-default-module
  CP2K-6.1-CrayGNU-19.10-cuda-10.1.eb                --set-default-module
+ CP2K-7.1-CrayIntel-19.10-cuda-10.1.eb
  CPMD-4.1-CrayIntel-19.10.eb                        --set-default-module
  CPMD-4.3-CrayIntel-19.10-cuda-10.1.eb
  dask-2.2.0-CrayGNU-19.10-python3.eb                --set-default-module

--- a/jenkins-builds/7.0.UP01-19.10-mc
+++ b/jenkins-builds/7.0.UP01-19.10-mc
@@ -7,6 +7,7 @@
  CDO-1.9.5-CrayIntel-19.10.eb
  CMake-3.14.5.eb                                    --set-default-module
  CP2K-6.1-CrayGNU-19.10.eb                          --set-default-module
+ CP2K-7.1-CrayIntel-19.10.eb
  CPMD-4.1-CrayIntel-19.10.eb                        --set-default-module
  CPMD-4.3-CrayIntel-19.10.eb
  dask-2.2.0-CrayGNU-19.10-python3.eb                --set-default-module

--- a/jenkins-builds/7.0.UP01-19.10-mc
+++ b/jenkins-builds/7.0.UP01-19.10-mc
@@ -7,7 +7,7 @@
  CDO-1.9.5-CrayIntel-19.10.eb
  CMake-3.14.5.eb                                    --set-default-module
  CP2K-6.1-CrayGNU-19.10.eb                          --set-default-module
- CP2K-7.1-CrayIntel-19.10.eb
+ CP2K-7.1-CrayGNU-19.10.eb
  CPMD-4.1-CrayIntel-19.10.eb                        --set-default-module
  CPMD-4.3-CrayIntel-19.10.eb
  dask-2.2.0-CrayGNU-19.10-python3.eb                --set-default-module

--- a/jenkins-builds/7.0.UP01-19.10-mc-dom
+++ b/jenkins-builds/7.0.UP01-19.10-mc-dom
@@ -8,6 +8,7 @@
  CDO-1.9.5-CrayIntel-19.10.eb
  CMake-3.14.5.eb                                    --set-default-module
  CP2K-6.1-CrayGNU-19.10.eb                          --set-default-module
+ CP2K-7.1-CrayIntel-19.10.eb
  CPMD-4.1-CrayIntel-19.10.eb                        --set-default-module
  CPMD-4.3-CrayIntel-19.10.eb
  dask-2.2.0-CrayGNU-19.10-python3.eb                --set-default-module

--- a/jenkins-builds/7.0.UP01-19.10-mc-dom
+++ b/jenkins-builds/7.0.UP01-19.10-mc-dom
@@ -8,7 +8,7 @@
  CDO-1.9.5-CrayIntel-19.10.eb
  CMake-3.14.5.eb                                    --set-default-module
  CP2K-6.1-CrayGNU-19.10.eb                          --set-default-module
- CP2K-7.1-CrayIntel-19.10.eb
+ CP2K-7.1-CrayGNU-19.10.eb
  CPMD-4.1-CrayIntel-19.10.eb                        --set-default-module
  CPMD-4.3-CrayIntel-19.10.eb
  dask-2.2.0-CrayGNU-19.10-python3.eb                --set-default-module


### PR DESCRIPTION
I am adding `CP2K` 7.1 `CrayGNU` easyconfig files in the production lists of Dom and Piz Daint, as non default for the time being.