### PR TITLE
[dom-gpu] Tool for generating Easyconfig diffs

### DIFF
--- a/tools/ebdiff.py
+++ b/tools/ebdiff.py
@@ -203,7 +203,11 @@ if __name__ == '__main__':
 
         # Sort matches based on similarity to the requested spec
         print_specs(
-            sort_by_similarity(matches, spec1.easyconfig()), file=sys.stderr
+            difflib.get_close_matches(
+                spec1.easyconfig(),
+                (os.path.basename(m) for m in matches),
+                n=options.num_matches,
+            ), file=sys.stderr
         )
 
     if ec2 is None:

--- a/tools/ebdiff.py
+++ b/tools/ebdiff.py
@@ -17,7 +17,7 @@ if sys.version_info.minor < 5:
     print(f'{sys.argv[0]}: unsupported Python version: '
           f'found {sys.version_info.major}.{sys.version_info.minor}, '
           f'required >= 3.6')
-    sys.exit(1)
+    sys.exit(2)
 
 
 def print_specs(matches, *args, **kwargs):
@@ -53,7 +53,7 @@ if __name__ == '__main__':
 
     if not options.robot_paths:
         print(f'{sys.argv[0]}: ERROR: no robot path defined', file=sys.stderr)
-        sys.exit(1)
+        sys.exit(2)
 
     ec1_base = f'{options.package}-{options.spec1}.eb'
     ec2_base = f'{options.package}-{options.spec2}.eb'
@@ -99,7 +99,7 @@ if __name__ == '__main__':
         print_specs(matches, file=sys.stderr)
 
     if not do_diff:
-        sys.exit(1)
+        sys.exit(2)
 
     diff_cmd = os.getenv('EBDIFF_CMD', '/usr/bin/diff')
     completed = subprocess.run([diff_cmd, *diff_args, ec1, ec2],

--- a/tools/ebdiff.py
+++ b/tools/ebdiff.py
@@ -1,0 +1,113 @@
+#!/usr/bin/env python3
+
+#
+# A tool to produce diffs between easyconfigs
+#
+# @author: vkarak
+
+import argparse
+import glob
+import os
+import subprocess
+import sys
+from pathlib import Path
+
+
+if sys.version_info.minor < 5:
+    print(f'{sys.argv[0]}: unsupported Python version: '
+          f'found {sys.version_info.major}.{sys.version_info.minor}, '
+          f'required >= 3.5')
+    sys.exit(1)
+
+
+def print_specs(matches, *args, **kwargs):
+    if not matches:
+        print('no possible matching specs were found', *args, **kwargs)
+        return
+
+    print('the following matching specs were found:', *args, **kwargs)
+    for m in matches:
+        print(f'    - {m}', *args, **kwargs)
+
+
+if __name__ == '__main__':
+    argparser = argparse.ArgumentParser()
+
+    # This is just for the help message
+    argparser.add_argument('diff_optons', metavar='DIFF_OPTS',
+                           nargs='?', default='-uN')
+    argparser.add_argument('package', metavar='PACKAGE')
+    argparser.add_argument('spec1', metavar='SPEC1')
+    argparser.add_argument('spec2', metavar='SPEC2')
+    argparser.add_argument(
+        '-r', '--robot-path', metavar='PATH',
+        action='append', dest='robot_paths', default=[],
+        help="Override EasyBuild's robot path"
+    )
+    options, diff_args = argparser.parse_known_args()
+    if not diff_args:
+        diff_args = ['-uN']
+
+    if not options.robot_paths:
+        options.robot_paths = os.getenv('EASYBUILD_ROBOT_PATHS').split(':')
+
+    if not options.robot_paths:
+        print(f'{sys.argv[0]}: ERROR: no robot path defined', file=sys.stderr)
+        sys.exit(1)
+
+    ec1_base = f'{options.package}-{options.spec1}.eb'
+    ec2_base = f'{options.package}-{options.spec2}.eb'
+    ec1, ec2 = None, None
+    for path in options.robot_paths:
+        prefix = Path(path)/options.package[0].lower()/options.package
+        if ec1 is None:
+            ec1 = prefix / ec1_base
+            if not ec1.exists():
+                ec1 = None
+            else:
+                print(f'Found matching spec for '
+                      f'{options.package}@{options.spec1}: {ec1}')
+
+        if ec2 is None:
+            ec2 = prefix / ec2_base
+            if not ec2.exists():
+                ec2 = None
+            else:
+                print(f'Found matching spec for '
+                      f'{options.package}@{options.spec2}: {ec2}')
+
+    if ec1 is None or ec2 is None:
+        matches = []
+        for path in options.robot_paths:
+            prefix = Path(path)/options.package[0].lower()/options.package
+            matches += glob.glob(
+                f'{prefix}/{options.package}-*.eb'
+            )
+
+        do_diff = False
+    else:
+        do_diff = True
+
+    if ec1 is None:
+        print(f'ERROR: unknown spec: {options.package}@{options.spec1}',
+              file=sys.stderr)
+        print_specs(matches, file=sys.stderr)
+
+    if ec2 is None:
+        print(f'ERROR: unknown spec: {options.package}@{options.spec2}',
+              file=sys.stderr)
+        print_specs(matches, file=sys.stderr)
+
+    if not do_diff:
+        sys.exit(1)
+
+    diff_cmd = os.getenv('EBDIFF_CMD', '/usr/bin/diff')
+    completed = subprocess.run([diff_cmd, *diff_args, ec1, ec2],
+                               stdout=subprocess.PIPE, stderr=subprocess.PIPE,
+                               universal_newlines=True)
+    print(completed.stdout)
+    if completed.returncode == 2:
+        print('ERROR: diff failed', file=sys.stderr)
+        print(completed.stderr, file=sys.stderr)
+
+    sys.exit(completed.returncode)

--- a/tools/ebdiff.py
+++ b/tools/ebdiff.py
@@ -38,7 +38,7 @@ class Spec:
     The format is the following
     {pkg_name}@{pkg_version}^{tc_name}@{tc_version}^{suffix}
 
-    Example: GROMACS@2019.2^CrayGNU@19.09^cuda-10.1
+    Example: GROMACS@2019.2^CrayGNU@19.09^-cuda-10.1
 
     '''
 

--- a/tools/ebdiff.py
+++ b/tools/ebdiff.py
@@ -25,7 +25,7 @@ def print_specs(matches, *args, **kwargs):
         print('no possible matching specs were found', *args, **kwargs)
         return
 
-    print('the following matching specs were found:', *args, **kwargs)
+    print('the following candidate specs were found:', *args, **kwargs)
     for m in matches:
         print(f'    - {m}', *args, **kwargs)
 

--- a/tools/ebdiff.py
+++ b/tools/ebdiff.py
@@ -228,7 +228,6 @@ if __name__ == '__main__':
     if args:
         diff_args = args + diff_args
 
-    print(diff_args)
     completed = subprocess.run([diff_cmd, *diff_args, ec1, ec2],
                                stdout=subprocess.PIPE, stderr=subprocess.PIPE,
                                universal_newlines=True)

--- a/tools/ebdiff.py
+++ b/tools/ebdiff.py
@@ -16,7 +16,7 @@ from pathlib import Path
 if sys.version_info.minor < 5:
     print(f'{sys.argv[0]}: unsupported Python version: '
           f'found {sys.version_info.major}.{sys.version_info.minor}, '
-          f'required >= 3.5')
+          f'required >= 3.6')
     sys.exit(1)
 
 


### PR DESCRIPTION
This is a small tool I've written that generates diffs between two easyconfig specs. The problem I usually face is that since EasyBuild's mentality is to have an easyconfig for each spec (version, variant etc.) for a package, it is difficult to see what actually changes from, for example, reframe 2.3 to 2.4 or from CrayGNU 19.06 to CrayGNU 19.10. That was the motivation for this tool. It is essentially a wrapper to the system's diff command but with some EasyBuild bindings:

```
usage: ebdiff.py [-h] [-r PATH] [--num-matches NUM_MATCHES]
                 [DIFF_OPTS] PACKAGE SPEC1 SPEC2

positional arguments:
  DIFF_OPTS
  PACKAGE
  SPEC1
  SPEC2

optional arguments:
  -h, --help            show this help message and exit
  -r PATH, --robot-path PATH
                        Override EasyBuild's robot path
  --num-matches NUM_MATCHES
                        Number of relevant easyconfigs to print in case of
                        unknown specs
```

It recognizes EasyBuild's robot paths so you don't have to put full easyconfig names. It figures them out automatically. If it can't find a spec, it will give you a list of candidate easyconfigs that you might want to select sorted in order of relevance. Finally, since it wraps `diff`, you can pass it any argument that `diff` accepts and you can also customize the diff command itself through the `EBDIFF_CMD` environment variable. Finally, the tool uses Spack syntax for specifying the specs. Here are some usage examples:

- Comparing reframe versions (no toolchain info)

```
$ ./tools/ebdiff.py reframe 2.3 3.0-dev4
```
```diff
Found matching spec for reframe@2.3: /users/karakasv/Devel/production/easybuild/easyconfigs/r/reframe/reframe-2.3.eb
Found matching spec for reframe@3.0-dev4: /users/karakasv/Devel/production/easybuild/easyconfigs/r/reframe/reframe-3.0-dev4.eb
--- /users/karakasv/Devel/production/easybuild/easyconfigs/r/reframe/reframe-2.3.eb	2017-06-26 15:40:57.828202000 +0200
+++ /users/karakasv/Devel/production/easybuild/easyconfigs/r/reframe/reframe-3.0-dev4.eb	2020-04-30 16:32:03.089139000 +0200
@@ -1,25 +1,45 @@
-# @author: gppezzi
+# @author: gppezzi, vkarak, manitart

-easyblock = "Tarball"
+easyblock = 'Tarball'

 name = 'reframe'
-version = '2.3'
+version = '3.0-dev4'

-homepage = 'https://madra.cscs.ch/scs/reframe/'
-description = "A regression framework for writing portable tests for HPC systems."
+homepage = 'https://github.com/eth-cscs/reframe'
+description = 'A regression framework for writing portable tests for HPC systems.'

-toolchain = {'name': 'dummy', 'version': 'dummy'}
+toolchain = SYSTEM

-sources = [ ('archive.tar.gz?ref=v%(version)s', "tar xfz %s" )]
-source_urls = ['https://madra.cscs.ch/scs/reframe/repository/']
+sources = [
+    {
+        'filename': 'v%(version)s.tar.gz',
+        'source_urls': ['https://github.com/eth-cscs/reframe/archive/']
+    },
+    {
+        'filename': '/apps/common/easybuild/sources/%(nameletterlower)s/'
+                    '%(name)s/reframe-tests-%(version)s.tar.gz'
+    }
+]

-dependencies = [('Python-bare', '3.5.2')]
+builddependencies = [('pip', '20.0.2', '-py3')]

 keepsymlinks = True
+postinstallcmds = [
+    'cp %(installdir)s/config/cscs.py %(installdir)s/reframe/settings.py',
+    'cp -r %(builddir)s/reframe-tests-%(version)s/checks %(installdir)s/cscs-checks/private',
+    'mv %(installdir)s/cscs-checks %(installdir)s/checks',
+    'PYTHONUSERBASE=%(installdir)s/installed_by_pip pip install --upgrade '
+    '--user -r %(builddir)s/reframe-%(version)s/requirements.txt pygelf',
+]

-sanity_check_paths={
-    'files': ['reframe.py', 'bin/reframe'],
-    'dirs': ['bin', 'checks', 'unittests'],
+modextrapaths = {
+    'PYTHONPATH': 'installed_by_pip/lib/python3.6/site-packages'
 }

+sanity_check_paths = {
+    'files': ['reframe.py', 'bin/reframe', 'config/cscs.py'],
+    'dirs':  ['bin', 'checks', 'checks/private', 'unittests'],
+}
+
+sanity_check_commands = ['reframe -V', 'python3 -m pytest --version']
 moduleclass = 'devel'
```

* Comparing GROMACS (toolchains + suffixes). Note that suffixes in EasyBuild include the dash:

```
$ ./tools/ebdiff.py GROMACS 2019.2^CrayGNU@19.09 2019.2^CrayGNU@19.09^-cuda-10.1
```

```diff
Found matching spec for GROMACS@2019.2^CrayGNU@19.09: /users/karakasv/Devel/production/easybuild/easyconfigs/g/GROMACS/GROMACS-2019.2-CrayGNU-19.09.eb
Found matching spec for GROMACS@2019.2^CrayGNU@19.09^-cuda-10.1: /users/karakasv/Devel/production/easybuild/easyconfigs/g/GROMACS/GROMACS-2019.2-CrayGNU-19.09-cuda-10.1.eb
--- /users/karakasv/Devel/production/easybuild/easyconfigs/g/GROMACS/GROMACS-2019.2-CrayGNU-19.09.eb	2019-09-20 10:57:27.075689000 +0200
+++ /users/karakasv/Devel/production/easybuild/easyconfigs/g/GROMACS/GROMACS-2019.2-CrayGNU-19.09-cuda-10.1.eb	2019-10-02 15:37:23.497550000 +0200
@@ -28,7 +28,7 @@
 source_urls = ['ftp://ftp.gromacs.org/pub/gromacs/']
 sources = [SOURCELOWER_TAR_GZ]

-local_common_options = '-DCMAKE_BUILD_TYPE=Release -DGMX_BUILD_OWN_FFTW=ON -DGMX_OPENMP=ON -DGMX_GPU=OFF -DGMX_PREFER_STATIC_LIBS=ON -DGMX_SIMD=AVX2_256'
+local_common_options = '-DCMAKE_BUILD_TYPE=Release -DGPU_DEPLOYMENT_KIT_ROOT_DIR=$CUDATOOLKIT_HOME -DGMX_BUILD_OWN_FFTW=ON -DGMX_OPENMP=ON -DGMX_GPU=ON -DGMX_PREFER_STATIC_LIBS=ON -DGMX_SIMD=AVX2_256'
 configopts = ['%s -DGMX_MPI=OFF ' % local_common_options,
               '%s -DGMX_MPI=ON ' % local_common_options]

@@ -37,9 +37,11 @@
 # CMake dependency with dummy toolchain
 builddependencies = [
     ('CMake', '3.14.1', '', True),
+    ('cudatoolkit/10.1.105_3.27-7.0.1.0_8.1__ga311ce7', EXTERNAL_MODULE),
 ]

 dependencies = [
+    ('craype-accel-nvidia60', EXTERNAL_MODULE),
     ('cray-libsci/19.06.1', EXTERNAL_MODULE)
 ]

```

* Unknown specs

```
$ ./tools/ebdiff.py GROMACS 2019.2^CrayGNU@19.09 2019.2^CrayGNU@19.09^-cuda-11.1
Found matching spec for GROMACS@2019.2^CrayGNU@19.09: /users/karakasv/Devel/production/easybuild/easyconfigs/g/GROMACS/GROMACS-2019.2-CrayGNU-19.09.eb
ERROR: unknown spec: GROMACS@2019.2^CrayGNU@19.09^-cuda-11.1
The following relevant easyconfigs were found:
    - GROMACS-2019.2-CrayGNU-19.09-cuda-10.1.eb
    - GROMACS-2019.2-CrayGNU-19.10-cuda-10.1.eb
    - GROMACS-2019.2-CrayGNU-19.06-cuda-10.1.eb
    - GROMACS-2019.1-CrayGNU-19.09-cuda-10.1.eb
    - GROMACS-2019.1-CrayGNU-19.10-cuda-10.1.eb
    - GROMACS-2019.1-CrayGNU-19.06-cuda-10.1.eb
    - GROMACS-2018.6-CrayGNU-19.09-cuda-10.1.eb
    - GROMACS-2019.1-CrayGNU-19.03-cuda-10.0.eb
    - GROMACS-2018.6-CrayGNU-19.10-cuda-10.1.eb
    - GROMACS-2018.6-CrayGNU-19.06-cuda-10.1.eb
```