### PR TITLE
[dom-gpu] Fix libcusmm build with CP2K

### DIFF
--- a/easybuild/easyconfigs/c/CP2K/CP2K-7.1-CrayGNU-19.10-cuda-10.1.psmp
+++ b/easybuild/easyconfigs/c/CP2K/CP2K-7.1-CrayGNU-19.10-cuda-10.1.psmp
@@ -7,7 +7,7 @@ FC       = ftn
 LD       = ftn
 AR       = ar -r
 DFLAGS   = -D__ACC -D__DBCSR_ACC -D__FFTW3 -D__GFORTRAN -D__ELPA=201911 -D__LIBINT -D__LIBXC -D__LIBXSMM -D__MAX_CONTR=4 -D__parallel -D__SCALAPACK
-CFLAGS   = $(DFLAGS) -I$(CRAY_CUDATOOLKIT_DIR)/include -g -O2 
+CFLAGS   = $(DFLAGS) -I$(CRAY_CUDATOOLKIT_DIR)/include -g -O3 -mavx -fopenmp 
 CXXFLAGS = $(CFLAGS)
 FCFLAGS  = $(DFLAGS) -g -O3 -mavx -fopenmp -funroll-loops -ftree-vectorize -ffree-form -ffree-line-length-512
 FCFLAGS  += -I$(ELPA_INCLUDE_DIR)/elpa -I$(ELPA_INCLUDE_DIR)/modules 


### PR DESCRIPTION
I have added `-fopenmp` to `CFLAGS` to match `FCFLAGS`: without the additional flag, `libcusmm` is built without `OpenMP` support and the consistency check introduced by the pull request https://github.com/cp2k/dbcsr/pull/183 stops the execution of `CP2K` when `dbcsr` is initialized.