### PR TITLE
[dom] Eb templates 19.10

### DIFF
--- a/easybuild/cray_external_modules_metadata-19.10.cfg
+++ b/easybuild/cray_external_modules_metadata-19.10.cfg
@@ -51,10 +51,20 @@ name = PETSc
 version = 3.11.2.0
 prefix = PETSC_DIR
 
+[cray-python/2.7.15.6]
+name = Python
+version = 2.7.15.6
+prefix = /opt/python/2.7.15.6
+
 [cray-python/2.7.15.7]
 name = Python
 version = 2.7.15.7
 prefix = /opt/python/2.7.15.7
+
+[cray-python/3.6.5.6]
+name = Python
+version = 3.6.5.6
+prefix = /opt/python/3.6.5.6
 
 [cray-python/3.6.5.7]
 name = Python

--- a/easybuild/easyconfigs/a/ANTLR/ANTLR-2.7.7-CrayGNU-19.10-python2.eb
+++ b/easybuild/easyconfigs/a/ANTLR/ANTLR-2.7.7-CrayGNU-19.10-python2.eb
@@ -4,12 +4,7 @@ easyblock = 'ConfigureMake'
 name = 'ANTLR'
 version = "2.7.7"
 
-local_py_maj_ver = '2'
-local_py_min_ver = '7'
-local_py_rev_ver = '15.7'
-local_pyver = '%s.%s.%s' % (local_py_maj_ver, local_py_min_ver, local_py_rev_ver)
-
-versionsuffix = '-python%s' % local_py_maj_ver
+versionsuffix = '-python%(pymajver)s'
 
 homepage = 'http://www.antlr.org/'
 description = """
@@ -30,7 +25,7 @@ local_osdependency = ['java']
 dependencies = [
     # On DOM this dependency is provided as local_osdependency
     #('java', EXTERNAL_MODULE),
-    ('cray-python/%s' % local_pyver, EXTERNAL_MODULE),
+    ('cray-python/2.7.15.7', EXTERNAL_MODULE),
 ]
 
 configopts = '--disable-examples --disable-csharp '

--- a/easybuild/easyconfigs/a/Amber/Amber-19-9-17-ff19SB-CrayGNU-19.10-cuda-10.1.eb
+++ b/easybuild/easyconfigs/a/Amber/Amber-19-9-17-ff19SB-CrayGNU-19.10-cuda-10.1.eb
@@ -5,8 +5,7 @@ easyblock = 'MakeCp'
 name = 'Amber'
 local_patchlevels = (9, 17) # (AmberTools, Amber)
 version = '19-%s-%s-ff19SB' % (local_patchlevels[0], local_patchlevels[1])
-local_cudaversion = '10.1'
-versionsuffix = '-cuda-%s' % local_cudaversion
+versionsuffix = '-cuda-%(cudashortver)s'
 
 homepage = 'http://ambermd.org/'
 description = """Amber (Assisted Model Building with Energy Refinement)
@@ -31,10 +30,10 @@ dependencies = [
     ('bzip2', '1.0.6'),
     ('zlib', '1.2.11'),
     ('craype-accel-nvidia60', EXTERNAL_MODULE),
+    ('cudatoolkit/10.1.105_3.27-7.0.1.1_4.1__ga311ce7', EXTERNAL_MODULE),
 ]
 
 builddependencies = [
-    ('cudatoolkit', EXTERNAL_MODULE),
     ('cray-hdf5', EXTERNAL_MODULE),
     ('cray-netcdf', EXTERNAL_MODULE),
 ]

--- a/easybuild/easyconfigs/b/Bazel/Bazel-0.24.1-CrayGNU-19.10.eb
+++ b/easybuild/easyconfigs/b/Bazel/Bazel-0.24.1-CrayGNU-19.10.eb
@@ -3,17 +3,16 @@
 easyblock = "Binary"
 
 name = 'Bazel'
-version = '0.29.1'
-
-local_py_maj_ver = '3'
-local_py_min_ver = '6'
-local_py_rev_ver = '5.7'
-versionsuffix = '-python%s' % (local_py_maj_ver)
+version = '0.24.1'
 
 homepage = 'http://baze.io/'
 description = """Correct, reproducible, fast builds for everyone"""
 
 toolchain = {'name': 'CrayGNU', 'version': '19.10'}
+
+dependencies = [
+#    ('SWIG', '3.0.12', versionsuffix),
+]
 
 osdependencies = ['java']
 

--- a/easybuild/easyconfigs/b/Bazel/Bazel-0.29.1-CrayGNU-19.10.eb
+++ b/easybuild/easyconfigs/b/Bazel/Bazel-0.29.1-CrayGNU-19.10.eb
@@ -3,21 +3,12 @@
 easyblock = "Binary"
 
 name = 'Bazel'
-version = '0.24.1'
-
-local_py_maj_ver = '3'
-local_py_min_ver = '6'
-local_py_rev_ver = '5.7'
-versionsuffix = '-python%s' % (local_py_maj_ver)
+version = '0.29.1'
 
 homepage = 'http://baze.io/'
 description = """Correct, reproducible, fast builds for everyone"""
 
 toolchain = {'name': 'CrayGNU', 'version': '19.10'}
-
-dependencies = [
-#    ('SWIG', '3.0.12', versionsuffix),
-]
 
 osdependencies = ['java']
 

--- a/easybuild/easyconfigs/b/Boost/Boost-1.70.0-CrayGNU-19.10-python2.eb
+++ b/easybuild/easyconfigs/b/Boost/Boost-1.70.0-CrayGNU-19.10-python2.eb
@@ -2,11 +2,8 @@
 name = 'Boost'
 version = '1.70.0'
 
-local_py_maj_ver = '2'
-local_py_min_ver = '7'
-local_py_rev_ver = '15.7'
-
-versionsuffix = '-python%s' % local_py_maj_ver
+_pyminver = '7'
+versionsuffix = '-python%(pymajver)s'
 
 homepage = 'http://www.boost.org/'
 description = """
@@ -21,16 +18,14 @@ source_urls = [SOURCEFORGE_SOURCE]
 
 configopts  = (
     ' --with-python=$(EBROOTPYTHON)/bin/python '
-    ' --with-python-version={0}.{1}'
-    ' --with-python-root=$(EBROOTPYTHON)/lib/python{0}.{1}'
-    .format(local_py_maj_ver, local_py_min_ver)
+    ' --with-python-version=%(pyshortver)s'
+    ' --with-python-root=$(EBROOTPYTHON)/lib/python%(pyshortver)s'
 )
 
 dependencies = [
     ('bzip2', '1.0.6'),
     ('zlib', '1.2.11'),
-    ('cray-python/%s.%s.%s' % (local_py_maj_ver, local_py_min_ver, local_py_rev_ver),
-     EXTERNAL_MODULE),
+    ('cray-python/2.7.15.7', EXTERNAL_MODULE),
 ]
 
 # CURRENTLY DISABLED, SINCE IT LEADS TO COMPATIBILITY ISSUES (e. g. with ParaView, HPX)
@@ -45,7 +40,7 @@ dependencies = [
 # for python3 the corresponding lib is libboost_python36.so
 sanity_check_paths = {
     'files': ['lib/libboost_system.so', 'lib/libboost_mpi.so',
-              'lib/libboost_python%s%s.so' % (local_py_maj_ver, local_py_min_ver)],
+              'lib/libboost_python%%(pymajver)s%s.so' % _pyminver],
     'dirs': ['include/boost']
 }
 

--- a/easybuild/easyconfigs/b/Boost/Boost-1.70.0-CrayGNU-19.10-python3.eb
+++ b/easybuild/easyconfigs/b/Boost/Boost-1.70.0-CrayGNU-19.10-python3.eb
@@ -2,11 +2,8 @@
 name = 'Boost'
 version = '1.70.0'
 
-local_py_maj_ver = '3'
-local_py_min_ver = '6'
-local_py_rev_ver = '5.7'
-
-versionsuffix = '-python%s' % local_py_maj_ver
+_pyminver = '6'
+versionsuffix = '-python%(pymajver)s'
 
 homepage = 'http://www.boost.org/'
 description = """
@@ -21,19 +18,17 @@ source_urls = [SOURCEFORGE_SOURCE]
 
 configopts  = (
     ' --with-python=$(EBROOTPYTHON)/bin/python '
-    ' --with-python-version={0}.{1}'
-    ' --with-python-root=$(EBROOTPYTHON)/lib/python{0}.{1}'
-    .format(local_py_maj_ver, local_py_min_ver)
+    ' --with-python-version=%(pyshortver)s'
+    ' --with-python-root=$(EBROOTPYTHON)/lib/python%(pyshortver)s'
 )
 
 dependencies = [
     ('bzip2', '1.0.6'),
     ('zlib', '1.2.11'),
-    ('cray-python/%s.%s.%s' % (local_py_maj_ver, local_py_min_ver, local_py_rev_ver),
-     EXTERNAL_MODULE),
+    ('cray-python/3.6.5.7', EXTERNAL_MODULE),
 ]
 
-patches = ['Boost-1.70.0-python%s.patch' % local_py_maj_ver]
+patches = ['Boost-1.70.0-python%(pymajver)s.patch']
 
 # CURRENTLY DISABLED, SINCE IT LEADS TO COMPATIBILITY ISSUES (e. g. with ParaView, HPX)
 #
@@ -46,7 +41,7 @@ patches = ['Boost-1.70.0-python%s.patch' % local_py_maj_ver]
 # for python3 the corresponding lib is libboost_python36.so
 sanity_check_paths = {
     'files': ['lib/libboost_system.so', 'lib/libboost_mpi.so',
-              'lib/libboost_python%s%s.so' % (local_py_maj_ver, local_py_min_ver)],
+              'lib/libboost_python%%(pymajver)s%s.so' % _pyminver],
     'dirs': ['include/boost']
 }
 

--- a/easybuild/easyconfigs/c/CP2K/CP2K-6.1-CrayGNU-19.10-cuda-10.1.eb
+++ b/easybuild/easyconfigs/c/CP2K/CP2K-6.1-CrayGNU-19.10-cuda-10.1.eb
@@ -4,14 +4,7 @@ easyblock = 'MakeCp'
 name = 'CP2K'
 version = '6.1'
 local_release = '%s.0' % version
-local_cudaversion = '10.1'
-versionsuffix = '-cuda-%s' % local_cudaversion
-
-local_py_maj_ver = '2'
-local_py_min_ver = '7'
-local_py_rev_ver = '15.7'
-local_pyshortver = "%s.%s" % (local_py_maj_ver, local_py_min_ver)
-local_pyver      = "%s.%s.%s" % (local_py_maj_ver, local_py_min_ver, local_py_rev_ver)
+versionsuffix = '-cuda-%(cudashortver)s'
 
 homepage = 'http://www.cp2k.org/'
 description = """
@@ -37,14 +30,14 @@ source_urls = [
 ]
 
 builddependencies = [
-    ('cudatoolkit/10.1.105_3.27-7.0.1.1_4.1__ga311ce7', EXTERNAL_MODULE),
     ('cray-fftw', EXTERNAL_MODULE),
-    ('cray-python/%s' % local_pyver, EXTERNAL_MODULE),
+    ('cray-python/2.7.15.7', EXTERNAL_MODULE),
     ('flex', '2.6.4'),
     ('Bison', '3.3.2'),
 ]
 
 dependencies = [
+    ('cudatoolkit/10.1.105_3.27-7.0.1.1_4.1__ga311ce7', EXTERNAL_MODULE),
     ('ELPA', '2016.11.001.pre'),
     ('Libint', '1.1.4'),
     ('libxc', '4.2.3'),

--- a/easybuild/easyconfigs/c/CP2K/CP2K-6.1-CrayGNU-19.10.eb
+++ b/easybuild/easyconfigs/c/CP2K/CP2K-6.1-CrayGNU-19.10.eb
@@ -5,12 +5,6 @@ name = 'CP2K'
 version = '6.1'
 local_release = '%s.0' % version
 
-local_py_maj_ver = '2'
-local_py_min_ver = '7'
-local_py_rev_ver = '15.7'
-local_pyshortver = "%s.%s" % (local_py_maj_ver, local_py_min_ver)
-local_pyver      = "%s.%s.%s" % (local_py_maj_ver, local_py_min_ver, local_py_rev_ver)
-
 homepage = 'http://www.cp2k.org/'
 description = """
     CP2K is a freely available (GPL) program, written in Fortran 95, to
@@ -30,7 +24,7 @@ source_urls = ['https://github.com/%(namelower)s/%(namelower)s/releases/download
 
 builddependencies = [
     ('cray-fftw', EXTERNAL_MODULE),
-    ('cray-python/%s' % local_pyver, EXTERNAL_MODULE),
+    ('cray-python/2.7.15.7', EXTERNAL_MODULE),
     ('flex', '2.6.4'),
     ('Bison', '3.3.2'),
 ]

--- a/easybuild/easyconfigs/c/CP2K/CP2K-7.1-CrayGNU-19.10-cuda-10.1.eb
+++ b/easybuild/easyconfigs/c/CP2K/CP2K-7.1-CrayGNU-19.10-cuda-10.1.eb
@@ -3,7 +3,7 @@ easyblock = 'MakeCp'
 
 name = 'CP2K'
 version = '7.1'
-versionsuffix = '-cuda-10.1'
+versionsuffix = '-cuda-%(cudashortver)s'
 
 homepage = 'http://www.cp2k.org/'
 description = """
@@ -27,11 +27,11 @@ patches = [
 builddependencies = [
     ('cray-fftw/3.3.8.3', EXTERNAL_MODULE),
     ('cray-libsci/19.06.1', EXTERNAL_MODULE),
-    ('cudatoolkit/10.1.105_3.27-7.0.1.1_4.1__ga311ce7', EXTERNAL_MODULE),
     ('flex', '2.6.4'),
     ('Bison', '3.3.2'),
 ]
 dependencies = [
+    ('cudatoolkit/10.1.105_3.27-7.0.1.1_4.1__ga311ce7', EXTERNAL_MODULE),
     ('ELPA', '2019.11.001'),
     ('Libint-CP2K', '2.6.0'),
     ('libxc', '4.3.4'),

--- a/easybuild/easyconfigs/c/CP2K/CP2K-7.1-CrayIntel-19.10-cuda-10.1.eb
+++ b/easybuild/easyconfigs/c/CP2K/CP2K-7.1-CrayIntel-19.10-cuda-10.1.eb
@@ -4,8 +4,7 @@ easyblock = 'MakeCp'
 name = 'CP2K'
 version = '7.1'
 local_release = '%s.0' % version
-local_cudaversion = '10.1'
-versionsuffix = '-cuda-%s' % local_cudaversion
+versionsuffix = '-cuda-%(cudashortver)s'
 
 homepage = 'http://www.cp2k.org/'
 description = """
@@ -31,12 +30,12 @@ source_urls = [
 ]
 
 builddependencies = [
-    ('cudatoolkit/10.1.105_3.27-7.0.1.1_4.1__ga311ce7', EXTERNAL_MODULE),
     ('flex', '2.6.4'),
     ('Bison', '3.3.2'),
 ]
 
 dependencies = [
+    ('cudatoolkit/10.1.105_3.27-7.0.1.1_4.1__ga311ce7', EXTERNAL_MODULE),
     ('ELPA', '2019.11.001'),
     ('Libint-CP2K', '2.6.0'),
     ('libxc', '4.3.4'),

--- a/easybuild/easyconfigs/c/cftime/cftime-1.0.0-CrayGNU-19.10-python2.eb
+++ b/easybuild/easyconfigs/c/cftime/cftime-1.0.0-CrayGNU-19.10-python2.eb
@@ -13,22 +13,15 @@ source_urls = ['https://github.com/Unidata/cftime/archive/']
 sources = ['v%(version)s.tar.gz']
 checksums = ['2ec37b5e5126b70a3328a40fd903ff6303e232ec3bb2c5d7272580f6cd50e0d6']
 
-local_py_maj_ver = '2'
-local_py_min_ver = '7'
-local_py_rev_ver = '15.7'
-local_pyver = '%s.%s.%s' % (local_py_maj_ver, local_py_min_ver, local_py_rev_ver)
-local_pyshortver = '%s.%s' % (local_py_maj_ver, local_py_min_ver)
-local_pysuff = '-python%s' % local_py_maj_ver
-
-versionsuffix = local_pysuff
+versionsuffix = '-python%(pymajver)s'
 dependencies = [
-    ('cray-python/%s' % local_pyver, EXTERNAL_MODULE),
+    ('cray-python/2.7.15.7', EXTERNAL_MODULE),
     ('cURL', '7.61.1'),
 ]
 
 sanity_check_paths = {
     'files':  [],
-    'dirs': ['lib/python%s/site-packages' % local_pyshortver],
+    'dirs': ['lib/python%(pyshortver)s/site-packages'],
 }
 
 moduleclass = 'data'

--- a/easybuild/easyconfigs/c/cftime/cftime-1.0.2.1-CrayGNU-19.10-python3.eb
+++ b/easybuild/easyconfigs/c/cftime/cftime-1.0.2.1-CrayGNU-19.10-python3.eb
@@ -13,22 +13,15 @@ source_urls = [PYPI_SOURCE]
 sources = [SOURCE_TAR_GZ]
 checksums = ['2c81d4879a2c1753961d647e55e0125039ddeda195944c3d526f2cf087dfb7bb']
 
-local_py_maj_ver = '3'
-local_py_min_ver = '6'
-local_py_rev_ver = '5.7'
-local_pyver = '%s.%s.%s' % (local_py_maj_ver, local_py_min_ver, local_py_rev_ver)
-local_pyshortver = '%s.%s' % (local_py_maj_ver, local_py_min_ver)
-local_pysuff = '-python%s' % local_py_maj_ver
-
-versionsuffix = local_pysuff
+versionsuffix = '-python%(pymajver)s'
 dependencies = [
-    ('cray-python/%s' % local_pyver, EXTERNAL_MODULE),
+    ('cray-python/3.6.5.7', EXTERNAL_MODULE),
     ('cURL', '7.61.1'),
 ]
 
 sanity_check_paths = {
     'files':  [],
-    'dirs': ['lib/python%s/site-packages' % local_pyshortver],
+    'dirs': ['lib/python%(pyshortver)s/site-packages'],
 }
 
 moduleclass = 'data'

--- a/easybuild/easyconfigs/d/dask/dask-1.0.0-CrayGNU-19.10-python3.eb
+++ b/easybuild/easyconfigs/d/dask/dask-1.0.0-CrayGNU-19.10-python3.eb
@@ -1,14 +1,10 @@
-easyblock = 'Bundle'
+easyblock = 'PythonBundle'
 
 name = 'dask'
 version = '1.0.0'
 
-local_py_maj_ver = '3'
-local_py_min_ver = '6'
-local_py_rev_ver = '5.7'
-
-local_pyver = '%s.%s.%s' % (local_py_maj_ver, local_py_min_ver, local_py_rev_ver)
-versionsuffix = '-python%s' % (local_py_maj_ver)
+versionsuffix = '-python%(pymajver)s'
+_pyminver = '6'
 
 homepage = 'http://github.com/dask/dask/'
 description = """Dask provides multi-core execution on larger-than-memory datasets using blocked algorithms
@@ -17,97 +13,41 @@ description = """Dask provides multi-core execution on larger-than-memory datase
 toolchain = {'name': 'CrayGNU', 'version': '19.10'}
 toolchainopts = {'verbose': False}
 
-# this is a bundle of Python packages
-exts_defaultclass = 'PythonPackage'
-
 dependencies = [
-    ('PyExtensions', '%s' % local_pyver),
+    ('cray-python/3.6.5.7', EXTERNAL_MODULE),
+    ('PyExtensions', '%(pyver)s'),
 ]
 
+exts_default_options = {
+    'req_py_majver': '%(pymajver)s',
+    'req_py_minver': '%s' % _pyminver,
+    'source_urls': [PYPI_SOURCE]
+}
 
 exts_list = [
-    ('cloudpickle', '0.2.1', {
-        'req_py_majver': '3',
-        'req_py_minver': '6',
-        'source_urls': ['https://pypi.python.org/packages/source/c/cloudpickle'],
-    }),
-    ('distributed', '1.24.0', {
-        'req_py_majver': '3',
-        'req_py_minver': '6',
-        'source_urls': ['https://pypi.python.org/packages/source/d/distributed'],
-    }),
-    ('partd', '0.3.8', {
-        'req_py_majver': '3',
-        'req_py_minver': '6',
-        'source_urls': ['https://pypi.python.org/packages/source/p/partd'],
-    }),
-    ('click', '6.6', {
-        'req_py_majver': '3',
-        'req_py_minver': '6',
-        'source_urls': ['https://pypi.python.org/packages/source/c/click'],
-    }),
-    ('PyYAML', '3.13', {
-        'req_py_majver': '3',
-        'req_py_minver': '6',
-        'source_urls': ['https://pypi.python.org/packages/source/p/pyyaml'],
+    ('HeapDict', '1.0.1'),
+    ('zict', '2.0.0'),
+    ('psutil', '5.7.0'),
+    ('tornado', '6.0.4'),
+    ('sortedcontainers', '2.1.0'),
+    ('msgpack', '1.0.0'),
+    ('tblib', '1.6.0'),
+    ('PyYAML', '5.3.1', {
         'modulename': 'yaml',
     }),
-    ('zict', '0.1.3', {
-        'req_py_majver': '3',
-        'req_py_minver': '6',
-        'source_urls': ['https://pypi.python.org/packages/source/z/zict'],
-    }),
-    ('tornado', '4.5.1', {
-        'req_py_majver': '3',
-        'req_py_minver': '6',
-        'source_urls': ['https://pypi.python.org/packages/source/t/tornado'],
-    }),
-    ('msgpack', '0.5.6', {
-        'req_py_majver': '3',
-        'req_py_minver': '6',
-        'source_urls': ['https://pypi.python.org/packages/source/m/msgpack'],
-    }),
-    ('tblib', '1.3.2', {
-        'req_py_majver': '3',
-        'req_py_minver': '6',
-        'source_urls': ['https://pypi.python.org/packages/source/t/tblib'],
-    }),
-    ('psutil', '5.4.8', {
-        'req_py_majver': '3',
-        'req_py_minver': '6',
-        'source_urls': ['https://pypi.python.org/packages/source/p/psutil'],
-    }),
-    ('sortedcontainers', '2.0.5', {
-        'req_py_majver': '3',
-        'req_py_minver': '6',
-        'source_urls': ['https://pypi.python.org/packages/source/s/sortedcontainers'],
-    }),
-    ('locket', '0.2.0', {
-        'req_py_majver': '3',
-        'req_py_minver': '6',
-        'source_urls': ['https://pypi.python.org/packages/source/l/locket'],
-    }),
-    ('HeapDict', '1.0.0', {
-        'req_py_majver': '3',
-        'req_py_minver': '6',
-        'source_urls': ['https://pypi.python.org/packages/source/h/heapdict'],
-    }),
-   (name, version, {
-        'req_py_majver': '3',
-        'req_py_minver': '6',
-        'source_urls': ['https://pypi.python.org/packages/source/d/dask'],
+    ('click', '7.1.2'),
+    (name, version, {
         'checksums': ['a1fa4a3b2d7ce4dd0c68db4b68dadf2c283ff54d98bd72c556fc462000449ff7'],
     }),
+    ('cloudpickle', '1.4.1'),
+    ('distributed', '1.24.0'),
+    ('locket', '0.2.0'),
+    ('partd', '0.3.8'),
 ]
-
-# specify that Bundle easyblock should run a full sanity check, rather than just trying to load the module
-local_full_sanity_check = True
 
 sanity_check_paths = {
     'files': [],
-    'dirs': ['lib/python%s.%s/site-packages' % (local_py_maj_ver, local_py_min_ver)],
+    'dirs': ['lib/python%(pyshortver)s/site-packages'],
 }
-
-modextrapaths = {'PYTHONPATH': ['lib/python%s.%s/site-packages' % (local_py_maj_ver, local_py_min_ver)]}
 
 moduleclass = 'data'

--- a/easybuild/easyconfigs/d/dask/dask-2.2.0-CrayGNU-19.10-python3.eb
+++ b/easybuild/easyconfigs/d/dask/dask-2.2.0-CrayGNU-19.10-python3.eb
@@ -1,14 +1,10 @@
-easyblock = 'Bundle'
+easyblock = 'PythonBundle'
 
 name = 'dask'
 version = '2.2.0'
 
-local_py_maj_ver = '3'
-local_py_min_ver = '6'
-local_py_rev_ver = '5.7'
-
-local_pyver = '%s.%s.%s' % (local_py_maj_ver, local_py_min_ver, local_py_rev_ver)
-versionsuffix = '-python%s' % (local_py_maj_ver)
+versionsuffix = '-python%(pymajver)s'
+_pyminver = '6'
 
 homepage = 'http://github.com/dask/dask/'
 description = """Dask provides multi-core execution on larger-than-memory datasets using blocked algorithms
@@ -17,161 +13,51 @@ description = """Dask provides multi-core execution on larger-than-memory datase
 toolchain = {'name': 'CrayGNU', 'version': '19.10'}
 toolchainopts = {'verbose': False}
 
-# this is a bundle of Python packages
-exts_defaultclass = 'PythonPackage'
-
 dependencies = [
-    ('PyExtensions', '%s' % local_pyver),
+    ('cray-python/3.6.5.7', EXTERNAL_MODULE),
+    ('PyExtensions', '%(pyver)s'),
 ]
 
+exts_default_options = {
+    'req_py_majver': '%(pymajver)s',
+    'req_py_minver': '%s' % _pyminver,
+    'use_pip': True,
+    'source_urls': [PYPI_SOURCE]
+}
 
 exts_list = [
-   (name, version, {
-        'req_py_majver': '3',
-        'use_pip': True,
-        'req_py_minver': '6',
-        'source_urls': ['https://pypi.python.org/packages/source/d/dask'],
-    }),
-    ('cloudpickle', '1.2.1', {
-        'req_py_majver': '3',
-        'req_py_minver': '6',
-        'use_pip': True,        
-        'source_urls': ['https://pypi.python.org/packages/source/c/cloudpickle'],
-    }),
-    ('locket', '0.2.0', {
-        'req_py_majver': '3',
-        'req_py_minver': '6',
-        'use_pip': True,        
-        'source_urls': ['https://pypi.python.org/packages/source/l/locket'],
-    }),
-    ('partd', '1.0.0', {
-        'req_py_majver': '3',
-        'req_py_minver': '6',
-        'use_pip': True,        
-        'source_urls': ['https://pypi.python.org/packages/source/p/partd'],
-    }),
-    ('click', '6.6', {
-        'req_py_majver': '3',
-        'req_py_minver': '6',
-        'use_pip': True,        
-        'source_urls': ['https://pypi.python.org/packages/source/c/click'],
-    }),
+    (name, version),
+    ('cloudpickle', '1.2.1'),
+    ('locket', '0.2.0'),
+    ('partd', '1.0.0'),
+    ('click', '6.6'),
     ('PyYAML', '5.1.2', {
-        'req_py_majver': '3',
-        'req_py_minver': '6',
-        'use_pip': True,        
-        'source_urls': ['https://pypi.python.org/packages/source/p/pyyaml'],
         'modulename': 'yaml',
     }),
-    ('HeapDict', '1.0.0', {
-        'req_py_majver': '3',
-        'req_py_minver': '6',
-        'use_pip': True,        
-        'source_urls': ['https://pypi.python.org/packages/source/h/heapdict'],
-    }),
-    ('zict', '1.0.0', {
-        'req_py_majver': '3',
-        'req_py_minver': '6',
-        'use_pip': True,        
-        'source_urls': ['https://pypi.python.org/packages/source/z/zict'],
-    }),
-    ('tornado', '6.0.3', {
-        'req_py_majver': '3',
-        'req_py_minver': '6',
-        'use_pip': True,        
-        'source_urls': ['https://pypi.python.org/packages/source/t/tornado'],
-    }),
-    ('msgpack', '0.6.1', {
-        'req_py_majver': '3',
-        'req_py_minver': '6',
-        'use_pip': True,        
-        'source_urls': ['https://pypi.python.org/packages/source/m/msgpack'],
-    }),
-    ('tblib', '1.4.0', {
-        'req_py_majver': '3',
-        'req_py_minver': '6',
-        'use_pip': True,        
-        'source_urls': ['https://pypi.python.org/packages/source/t/tblib'],
-    }),
-    ('psutil', '5.6.3', {
-        'req_py_majver': '3',
-        'req_py_minver': '6',
-        'use_pip': True,        
-        'source_urls': ['https://pypi.python.org/packages/source/p/psutil'],
-    }),
-    ('sortedcontainers', '2.1.0', {
-        'req_py_majver': '3',
-        'req_py_minver': '6',
-        'use_pip': True,        
-        'source_urls': ['https://pypi.python.org/packages/source/s/sortedcontainers'],
-    }),
-    ('distributed', '2.2.0', {
-        'req_py_majver': '3',
-        'req_py_minver': '6',
-        'use_pip': True,        
-        'source_urls': ['https://pypi.python.org/packages/source/d/distributed'],
-    }),
-    ('MarkupSafe', '1.1.1', {
-        'req_py_majver': '3',
-        'req_py_minver': '6',
-        'use_pip': True,
-        'source_urls': ['https://pypi.python.org/packages/source/m/MarkupSafe/'],
-        }),
-    ('Jinja2', '2.10.1', {
-        'req_py_majver': '3',
-        'req_py_minver': '6',
-        'use_pip': True,
-        'source_urls': ['https://pypi.python.org/packages/source/j/Jinja2/'],
-        }),
-    ('bokeh', '1.3.4', {
-        'req_py_majver': '3',
-        'req_py_minver': '6',
-        'use_pip': True,        
-        'source_urls': ['https://pypi.python.org/packages/source/b/bokeh/'],
-        }),
-    ('packaging', '19.1', {
-        'req_py_majver': '3',
-        'req_py_minver': '6',
-        'use_pip': True,        
-        'source_urls': ['https://pypi.python.org/packages/source/p/packaging/'],
-        }),
+    ('HeapDict', '1.0.0'),
+    ('zict', '1.0.0'),
+    ('tornado', '6.0.3'),
+    ('msgpack', '0.6.1'),
+    ('tblib', '1.4.0'),
+    ('psutil', '5.6.3'),
+    ('sortedcontainers', '2.1.0'),
+    ('distributed', '2.2.0'),
+    ('MarkupSafe', '1.1.1'),
+    ('Jinja2', '2.10.1'),
+    ('bokeh', '1.3.4'),
+    ('packaging', '19.1'),
     ('Pillow', '6.1.0', {
-        'req_py_majver': '3',
-        'req_py_minver': '6',
-        'use_pip': True,        
         'modulename': 'PIL',
-        'source_urls': ['https://pypi.python.org/packages/source/p/Pillow/'],
-        }),
-    ('fsspec', '0.4.1', {
-        'req_py_majver': '3',
-        'req_py_minver': '6',
-        'use_pip': True,        
-        'source_urls': ['https://pypi.python.org/packages/source/f/fsspec/'],
-        }),
-
+    }),
+    ('fsspec', '0.4.1'),
 # dask jobqueue, twr
-    ('dask-jobqueue', '0.6.2', {
-        'req_py_majver': '3',
-        'req_py_minver': '6',
-        'use_pip': True,        
-        'source_urls': ['https://pypi.python.org/packages/source/d/dask_jobqueue/'],
-        }),
-    ('docrep', '0.2.7', {
-        'req_py_majver': '3',
-        'req_py_minver': '6',
-        'use_pip': True,        
-        'source_urls': ['https://pypi.python.org/packages/source/d/docrep/'],
-        }),
+    ('dask-jobqueue', '0.6.2'),
+    ('docrep', '0.2.7'),
 ]
-
-# specify that Bundle easyblock should run a full sanity check, rather than just trying to load the module
-local_full_sanity_check = True 
 
 sanity_check_paths = {
     'files': [],
-    'dirs': ['lib/python%s.%s/site-packages' % (local_py_maj_ver, local_py_min_ver)],
+    'dirs': ['lib/python%(pyshortver)s/site-packages'],
 }
-
-modextrapaths = {'PYTHONPATH': ['lib/python%s.%s/site-packages' % (local_py_maj_ver, local_py_min_ver)]}
 
 moduleclass = 'data'

--- a/easybuild/easyconfigs/g/GROMACS/GROMACS-2018.6-CrayGNU-19.10-cuda-10.1.eb
+++ b/easybuild/easyconfigs/g/GROMACS/GROMACS-2018.6-CrayGNU-19.10-cuda-10.1.eb
@@ -14,8 +14,7 @@
 easyblock = 'CMakeMake'
 name = 'GROMACS'
 version = "2018.6"
-local_cudaversion = '10.1'
-versionsuffix = '-cuda-%s' % local_cudaversion
+versionsuffix = '-cuda-%(cudashortver)s'
 
 homepage = 'http://www.gromacs.org'
 description = """GROMACS is a versatile package to perform molecular dynamics,
@@ -36,9 +35,9 @@ skipsteps = ['test']
 # CMake dependency with dummy toolchain
 builddependencies = [
     ('CMake', '3.14.1', '', True),
-    ('cudatoolkit/10.1.105_3.27-7.0.1.1_4.1__ga311ce7', EXTERNAL_MODULE),
 ]
 dependencies = [
+    ('cudatoolkit/10.1.105_3.27-7.0.1.1_4.1__ga311ce7', EXTERNAL_MODULE),
     ('craype-accel-nvidia60', EXTERNAL_MODULE)
 ]
 

--- a/easybuild/easyconfigs/g/GROMACS/GROMACS-2019.1-CrayGNU-19.10-cuda-10.1.eb
+++ b/easybuild/easyconfigs/g/GROMACS/GROMACS-2019.1-CrayGNU-19.10-cuda-10.1.eb
@@ -13,8 +13,7 @@
 #
 name = 'GROMACS'
 version = "2019.1"
-local_cudaversion = '10.1'
-versionsuffix = '-cuda-%s' % local_cudaversion
+versionsuffix = '-cuda-%(cudashortver)s'
 
 homepage = 'http://www.gromacs.org'
 description = """GROMACS is a versatile package to perform molecular dynamics,
@@ -33,9 +32,9 @@ skipsteps = ['test']
 # CMake dependency with dummy toolchain
 builddependencies = [
     ('CMake', '3.14.1', '', True),
-    ('cudatoolkit/10.1.105_3.27-7.0.1.1_4.1__ga311ce7', EXTERNAL_MODULE),
 ]
 dependencies = [
+    ('cudatoolkit/10.1.105_3.27-7.0.1.1_4.1__ga311ce7', EXTERNAL_MODULE),
     ('craype-accel-nvidia60', EXTERNAL_MODULE)
 ]
 

--- a/easybuild/easyconfigs/g/GROMACS/GROMACS-2020-CrayGNU-19.10-cuda-10.1.eb
+++ b/easybuild/easyconfigs/g/GROMACS/GROMACS-2020-CrayGNU-19.10-cuda-10.1.eb
@@ -14,8 +14,7 @@
 easyblock = 'CMakeMake'
 name = 'GROMACS'
 version = "2020"
-cudaversion = '10.1'
-versionsuffix = '-cuda-%s' % cudaversion
+versionsuffix = '-cuda-%(cudashortver)s'
 
 homepage = 'http://www.gromacs.org'
 description = """GROMACS is a versatile package to perform molecular dynamics,
@@ -37,10 +36,10 @@ skipsteps = ['test']
 # CMake dependency with dummy toolchain
 builddependencies = [
     ('CMake', '3.14.1', '', True),
-    ('cudatoolkit/10.1.105_3.27-7.0.1.1_4.1__ga311ce7', EXTERNAL_MODULE),
 ]
 
 dependencies = [
+    ('cudatoolkit/10.1.105_3.27-7.0.1.1_4.1__ga311ce7', EXTERNAL_MODULE),
     ('craype-accel-nvidia60', EXTERNAL_MODULE),
     ('cray-libsci', EXTERNAL_MODULE)
 ]

--- a/easybuild/easyconfigs/g/GROMACS/GROMACS-2020.1-CrayGNU-19.10-cuda-10.1.eb
+++ b/easybuild/easyconfigs/g/GROMACS/GROMACS-2020.1-CrayGNU-19.10-cuda-10.1.eb
@@ -14,8 +14,7 @@
 easyblock = 'CMakeMake'
 name = 'GROMACS'
 version = "2020.1"
-cudaversion = '10.1'
-versionsuffix = '-cuda-%s' % cudaversion
+versionsuffix = '-cuda-%(cudashortver)s'
 
 homepage = 'http://www.gromacs.org'
 description = """GROMACS is a versatile package to perform molecular dynamics,
@@ -37,10 +36,10 @@ skipsteps = ['test']
 # CMake dependency with dummy toolchain
 builddependencies = [
     ('CMake', '3.14.1', '', True),
-    ('cudatoolkit/10.1.105_3.27-7.0.1.1_4.1__ga311ce7', EXTERNAL_MODULE),
 ]
 
 dependencies = [
+    ('cudatoolkit/10.1.105_3.27-7.0.1.1_4.1__ga311ce7', EXTERNAL_MODULE),
     ('craype-accel-nvidia60', EXTERNAL_MODULE),
     ('cray-libsci', EXTERNAL_MODULE)
 ]

--- a/easybuild/easyconfigs/h/HPX/HPX-1.4.0-CrayGNU-19.10-cuda-10.1-APEX.eb
+++ b/easybuild/easyconfigs/h/HPX/HPX-1.4.0-CrayGNU-19.10-cuda-10.1-APEX.eb
@@ -3,8 +3,8 @@ easyblock = 'CMakeMake'
 
 name = 'HPX'
 version = '1.4.0'
-local_cudaversion = '10.1'
-versionsuffix = '-cuda-%s-APEX' % local_cudaversion
+# local_cudaversion = '10.1'
+versionsuffix = '-cuda-%(cudashortver)s-APEX'
 checksums = ['241a1c47fafba751848fac12446e7bf4ad3d342d5eb2fa1ef94dd904acc329ed']
 
 homepage = 'http://stellar-group.org/libraries/hpx'

--- a/easybuild/easyconfigs/h/HPX/HPX-1.4.0-CrayGNU-19.10-cuda-10.1-APEX.eb
+++ b/easybuild/easyconfigs/h/HPX/HPX-1.4.0-CrayGNU-19.10-cuda-10.1-APEX.eb
@@ -3,7 +3,6 @@ easyblock = 'CMakeMake'
 
 name = 'HPX'
 version = '1.4.0'
-# local_cudaversion = '10.1'
 versionsuffix = '-cuda-%(cudashortver)s-APEX'
 checksums = ['241a1c47fafba751848fac12446e7bf4ad3d342d5eb2fa1ef94dd904acc329ed']
 

--- a/easybuild/easyconfigs/h/HPX/HPX-1.4.0-CrayGNU-19.10-cuda-10.1-nonetworking.eb
+++ b/easybuild/easyconfigs/h/HPX/HPX-1.4.0-CrayGNU-19.10-cuda-10.1-nonetworking.eb
@@ -3,8 +3,7 @@ easyblock = 'CMakeMake'
 
 name = 'HPX'
 version = '1.4.0'
-local_cudaversion = '10.1'
-versionsuffix = '-cuda-%s-nonetworking' % local_cudaversion
+versionsuffix = '-cuda-%(cudashortver)s-nonetworking'
 checksums = ['241a1c47fafba751848fac12446e7bf4ad3d342d5eb2fa1ef94dd904acc329ed']
 
 homepage = 'http://stellar-group.org/libraries/hpx'

--- a/easybuild/easyconfigs/h/HPX/HPX-1.4.0-CrayGNU-19.10-cuda-10.1.eb
+++ b/easybuild/easyconfigs/h/HPX/HPX-1.4.0-CrayGNU-19.10-cuda-10.1.eb
@@ -4,7 +4,7 @@ easyblock = 'CMakeMake'
 name = 'HPX'
 version = '1.4.0'
 local_cudaversion = '10.1'
-versionsuffix = '-cuda-%s' % local_cudaversion
+versionsuffix = '-cuda-%(cudashortver)s'
 checksums = ['241a1c47fafba751848fac12446e7bf4ad3d342d5eb2fa1ef94dd904acc329ed']
 
 homepage = 'http://stellar-group.org/libraries/hpx'

--- a/easybuild/easyconfigs/h/HPX/HPX-1.4.0-CrayGNU-19.10-cuda-10.1.eb
+++ b/easybuild/easyconfigs/h/HPX/HPX-1.4.0-CrayGNU-19.10-cuda-10.1.eb
@@ -3,7 +3,6 @@ easyblock = 'CMakeMake'
 
 name = 'HPX'
 version = '1.4.0'
-local_cudaversion = '10.1'
 versionsuffix = '-cuda-%(cudashortver)s'
 checksums = ['241a1c47fafba751848fac12446e7bf4ad3d342d5eb2fa1ef94dd904acc329ed']
 

--- a/easybuild/easyconfigs/h/Horovod/Horovod-0.16.4-CrayGNU-19.10-tf-1.14.0.eb
+++ b/easybuild/easyconfigs/h/Horovod/Horovod-0.16.4-CrayGNU-19.10-tf-1.14.0.eb
@@ -3,14 +3,6 @@ easyblock = 'PythonPackage'
 name = 'Horovod'
 version = '0.16.4'
 
-local_py_maj_ver = '3'
-local_py_min_ver = '6'
-local_py_rev_ver = '5.7'
-
-local_pyver = '%s.%s.%s' % (local_py_maj_ver, local_py_min_ver, local_py_rev_ver)
-local_pyshortver = '%s.%s' % (local_py_maj_ver, local_py_min_ver)
-
-local_cudaver = '10.1.168'
 local_tfver = '1.14.0'
 versionsuffix = '-tf-%s' % local_tfver
 
@@ -25,8 +17,9 @@ sources = [SOURCELOWER_TAR_GZ]
 checksums = ['871de9f0dfef7ddda637ee78ce7d95494340f7f8eb9fbd0c3cf13df7e68c5812']
 
 dependencies = [
-    ('cray-python/%s' % local_pyver, EXTERNAL_MODULE),
-    ('TensorFlow', local_tfver, '-cuda-%s-python%s' % (local_cudaver, local_py_maj_ver)),
+    ('CUDA', '10.1.168', '', True),
+    ('cray-python/3.6.5.7', EXTERNAL_MODULE),
+    ('TensorFlow', local_tfver, '-cuda-%(cudaver)s-python%(pymajver)s'),
 ]
 
 skipsteps = ['build']
@@ -40,7 +33,7 @@ preinstallopts += "export HOROVOD_WITHOUT_PYTORCH=1 && "
 
 sanity_check_paths = {
     'files': [],
-    'dirs': ['lib/python%s/site-packages' % local_pyshortver],
+    'dirs': ['lib/python%(pyshortver)s/site-packages'],
 }
 
 moduleclass = 'tools'

--- a/easybuild/easyconfigs/h/Horovod/Horovod-0.18.1-CrayGNU-19.10-tf-2.0.0.eb
+++ b/easybuild/easyconfigs/h/Horovod/Horovod-0.18.1-CrayGNU-19.10-tf-2.0.0.eb
@@ -3,14 +3,6 @@ easyblock = 'PythonPackage'
 name = 'Horovod'
 version = '0.18.1'
 
-py_maj_ver = '3'
-py_min_ver = '6'
-py_rev_ver = '5.7'
-
-pyver = '%s.%s.%s' % (py_maj_ver, py_min_ver, py_rev_ver)
-pyshortver = '%s.%s' % (py_maj_ver, py_min_ver)
-
-cudaver = '10.1.168'
 tfver = '2.0.0'
 versionsuffix = '-tf-%s' % tfver
 
@@ -25,9 +17,10 @@ sources = [SOURCELOWER_TAR_GZ]
 checksums = ['26a7751b090caabeba27808786b106cc672bc0aef3e7993361e99479c08beeb3']
 
 dependencies = [
-    ('cray-python/%s' % pyver, EXTERNAL_MODULE),
+    ('cray-python/3.6.5.7', EXTERNAL_MODULE),
+    ('CUDA', '10.1.168', '', True),
     ('numpy', '1.17.2'),
-    ('TensorFlow', tfver, '-cuda-%s' % cudaver),
+    ('TensorFlow', tfver, '-cuda-%(cudaver)s'),
 ]
 
 skipsteps = ['build']
@@ -42,7 +35,7 @@ preinstallopts += "export HOROVOD_WITHOUT_PYTORCH=1 && "
 
 sanity_check_paths = {
     'files': [],
-    'dirs': ['lib/python%s/site-packages' % pyshortver],
+    'dirs': ['lib/python%(pyshortver)s/site-packages'],
 }
 
 moduleclass = 'tools'

--- a/easybuild/easyconfigs/i/IPython/IPython-7.7.0-CrayGNU-19.10-python3.eb
+++ b/easybuild/easyconfigs/i/IPython/IPython-7.7.0-CrayGNU-19.10-python3.eb
@@ -1,19 +1,12 @@
 # @author: twrobinson, sarafael, gppezzi
 
-easyblock = 'Bundle'
+easyblock = 'PythonBundle'
 
 name = 'IPython'
-
-local_py_maj_ver = '3'
-local_py_min_ver = '6'
-local_py_rev_ver = '5.7'
-
-local_pyver = '%s.%s.%s' % (local_py_maj_ver, local_py_min_ver, local_py_rev_ver)
-local_pyshortver = '%s.%s' % (local_py_maj_ver, local_py_min_ver)
-
 version = '7.7.0'
 
-versionsuffix = '-python%s' % local_py_maj_ver
+_pyminver = '6'
+versionsuffix = '-python%(pymajver)s'
 
 homepage = 'https://pypi.python.org/pypi'
 description = """This module is a bundle of Python packages on Cray systems based on the module cray-python"""
@@ -22,80 +15,31 @@ toolchain = {'name': 'CrayGNU', 'version': '19.10'}
 toolchainopts = {'pic': True, 'verbose': False}
 
 dependencies = [
-    ('PyExtensions', '%s' % local_pyver),
+    ('cray-python/3.6.5.7', EXTERNAL_MODULE),
+    ('PyExtensions', '%(pyver)s'),
 ]
 
-
-# bundle of Python packages
-exts_defaultclass = 'PythonPackage'
-
+exts_default_options = {
+    'req_py_majver': '%(pymajver)s',
+    'req_py_minver': '%s' % _pyminver,
+    'source_urls': [PYPI_SOURCE]
+}
 
 exts_list = [
-    ('decorator', '4.4.0', {
-        'req_py_majver': '3',
-        'req_py_minver': '6',
-        'source_urls': ['https://pypi.python.org/packages/source/d/decorator/'],
-    }),
-    ('wcwidth', '0.1.7', {
-        'req_py_majver': '3',
-        'req_py_minver': '6',
-        'source_urls': ['https://pypi.python.org/packages/source/w/wcwidth/'],
-    }),
-    ('prompt_toolkit', '2.0.9', {
-        'req_py_majver': '3',
-        'req_py_minver': '6',
-        'source_urls': ['https://pypi.python.org/packages/source/p/prompt_toolkit/'],
-    }),
-    ('pickleshare', '0.7.5', {
-        'req_py_majver': '3',
-        'req_py_minver': '6',
-        'source_urls': ['https://pypi.python.org/packages/source/p/pickleshare/'],
-    }),
-    ('parso', '0.5.1', {
-        'req_py_majver': '3',
-        'req_py_minver': '6',
-        'source_urls': ['https://pypi.python.org/packages/source/p/parso/'],
-    }),
-    ('jedi', '0.14.1', {
-        'req_py_majver': '3',
-        'req_py_minver': '6',
-        'source_urls': ['https://pypi.python.org/packages/source/j/jedi/'],
-    }),
-    ('ptyprocess', '0.6.0', {
-        'req_py_majver': '3',
-        'req_py_minver': '6',
-        'source_urls': ['https://pypi.python.org/packages/source/p/ptyprocess/'],
-    }),
-    ('pexpect', '4.7.0', {
-        'req_py_majver': '3',
-        'req_py_minver': '6',
-        'source_urls': ['https://pypi.python.org/packages/source/p/pexpect/'],
-    }),
-    ('ipython_genutils', '0.2.0', {
-        'req_py_majver': '3',
-        'req_py_minver': '6',
-        'source_urls': ['https://pypi.python.org/packages/source/i/ipython_genutils/'],
-    }),
-    ('traitlets', '4.3.2', {
-        'req_py_majver': '3',
-        'req_py_minver': '6',
-        'source_urls': ['https://pypi.python.org/packages/source/t/traitlets/'],
-    }),
-    ('backcall', '0.1.0', {
-        'req_py_majver': '3',
-        'req_py_minver': '6',
-        'source_urls': ['https://pypi.python.org/packages/source/b/backcall/'],
-    }),
-    ('Pygments', '2.4.0', {
-        'req_py_majver': '3',
-        'req_py_minver': '6',
-        'source_urls': ['https://pypi.python.org/packages/source/p/Pygments/'],
-    }),
+    ('decorator', '4.4.0'),
+    ('wcwidth', '0.1.7'),
+    ('prompt_toolkit', '2.0.9'),
+    ('pickleshare', '0.7.5'),
+    ('parso', '0.5.1'),
+    ('jedi', '0.14.1'),
+    ('ptyprocess', '0.6.0'),
+    ('pexpect', '4.7.0'),
+    ('ipython_genutils', '0.2.0'),
+    ('traitlets', '4.3.2'),
+    ('backcall', '0.1.0'),
+    ('Pygments', '2.4.0'),
     ('ipython', version, {
-        'req_py_majver': '3',
-        'req_py_minver': '6',
         'modulename': 'IPython',
-        'source_urls': ['https://pypi.python.org/packages/source/i/ipython/'],
         'patches': ['ipython-7.7.0-jupyter.patch'],
     }),
 ]
@@ -103,11 +47,9 @@ exts_list = [
 # specify that Bundle easyblock should run a full sanity check, rather than just trying to load the module
 local_full_sanity_check = True
 
-modextrapaths = {'PYTHONPATH': ['lib/python%s/site-packages' % local_pyshortver]}
-
 sanity_check_paths = {
     'files': [],
-    'dirs': ['lib/python%s/site-packages' % local_pyshortver]
+    'dirs': ['lib/python%(pyshortver)s/site-packages']
 }
 
 sanity_check_commands = [

--- a/easybuild/easyconfigs/i/ipyparallel/ipyparallel-6.2.4-CrayGNU-19.10-python3.eb
+++ b/easybuild/easyconfigs/i/ipyparallel/ipyparallel-6.2.4-CrayGNU-19.10-python3.eb
@@ -3,15 +3,11 @@ easyblock = 'PythonPackage'
 name = 'ipyparallel'
 version = '6.2.4'
 
-local_py_maj_ver = '3'
-local_py_min_ver = '6'
-local_py_rev_ver = '5.7'
+versionsuffix = '-python%(pymajver)s'
+_pyminver = '6'
 
-local_pyver = '%s.%s.%s' % (local_py_maj_ver, local_py_min_ver, local_py_rev_ver)
-versionsuffix = '-python%s' % (local_py_maj_ver)
-
-req_py_majver = local_py_maj_ver
-req_py_minver = local_py_min_ver
+req_py_majver = '%(pymajver)s'
+req_py_minver = _pyminver
 
 homepage = 'https://pypi.org/project/ipyparallel'
 description = """Use multiple instances of IPython in parallel, interactively."""
@@ -24,13 +20,13 @@ sources = [SOURCE_TAR_GZ]
 use_pip = True
 
 dependencies = [
-    ('cray-python/%s' % local_pyver, EXTERNAL_MODULE),
+    ('cray-python/3.6.5.7', EXTERNAL_MODULE),
     ('jupyterlab', '1.1.1')
 ]
 
 sanity_check_paths = {
     'files': [],
-    'dirs': ['lib/python%s.%s/site-packages' % (local_py_maj_ver, local_py_min_ver)],
+    'dirs': ['lib/python%(pyshortver)s/site-packages'],
 }
 
 moduleclass = 'devel'

--- a/easybuild/easyconfigs/j/Julia/Julia-1.2.0-CrayGNU-19.10-cuda-10.1.eb
+++ b/easybuild/easyconfigs/j/Julia/Julia-1.2.0-CrayGNU-19.10-cuda-10.1.eb
@@ -1,8 +1,7 @@
 # Recipe for linux, x86_64 created by Samuel Omlin (CSCS), Victor Holanda Rusu (CSCS)
 name = 'Julia'
 version = '1.2.0'
-cudaversion = '10.1'
-versionsuffix = '-cuda-%s' % cudaversion
+versionsuffix = '-cuda-%(cudashortver)s'
 
 arch_name = 'gpu'
 
@@ -16,10 +15,8 @@ source_urls = ['https://julialang-s3.julialang.org/bin/linux/x64/%(version_major
 sources = ['%(namelower)s-%(version)s-linux-x86_64.tar.gz']
 checksums = ['926ced5dec5d726ed0d2919e849ff084a320882fb67ab048385849f9483afc47']
 
-builddependencies = [
-    ('cudatoolkit/10.1.105_3.27-7.0.1.1_4.1__ga311ce7', EXTERNAL_MODULE),
-]
 dependencies = [
+    ('cudatoolkit/10.1.105_3.27-7.0.1.1_4.1__ga311ce7', EXTERNAL_MODULE),
     ('craype-accel-nvidia60', EXTERNAL_MODULE)
 ]
 

--- a/easybuild/easyconfigs/j/JuliaExtensions/JuliaExtensions-1.2.0-CrayGNU-19.10-cuda-10.1.eb
+++ b/easybuild/easyconfigs/j/JuliaExtensions/JuliaExtensions-1.2.0-CrayGNU-19.10-cuda-10.1.eb
@@ -3,8 +3,7 @@ easyblock = 'JuliaBundle'
 
 name = 'JuliaExtensions'
 version = '1.2.0'
-cudaversion = '10.1'
-versionsuffix = '-cuda-%s' % cudaversion
+versionsuffix = '-cuda-%(cudashortver)s'
 
 arch_name = 'gpu'
 
@@ -15,6 +14,7 @@ toolchain = { 'name' : 'CrayGNU', 'version' : '19.10' }
 toolchainopts = {'pic': True, 'verbose': True}
 
 dependencies = [
+    ('cudatoolkit/10.1.105_3.27-7.0.1.1_4.1__ga311ce7', EXTERNAL_MODULE),
     ('Julia', version, versionsuffix),
 ]
 
@@ -32,6 +32,5 @@ exts_list = [
         'source_urls': ['https://github.com/JuliaIO/HDF5.jl/archive/'],
     }),
 ]
-
 
 moduleclass = 'tools'

--- a/easybuild/easyconfigs/j/jupyterhub/jupyterhub-1.0.0-CrayGNU-19.10.eb
+++ b/easybuild/easyconfigs/j/jupyterhub/jupyterhub-1.0.0-CrayGNU-19.10.eb
@@ -1,154 +1,64 @@
 # @author: robinson
 
-easyblock = 'Bundle'
+easyblock = 'PythonBundle'
 
 name = 'jupyterhub'
-
-local_py_maj_ver = '3'
-local_py_min_ver = '6'
-local_py_rev_ver = '5.7'
-
-local_pyver = '%s.%s.%s' % (local_py_maj_ver, local_py_min_ver, local_py_rev_ver)
-local_pyshortver = '%s.%s' % (local_py_maj_ver, local_py_min_ver)
-
 version = '1.0.0'
+_pyminver = '6'
 
 homepage = 'https://pypi.python.org/pypi'
 description = """This module is a bundle of Python packages on Cray systems based on the module cray-python"""
 
-
 toolchain = {'name': 'CrayGNU', 'version': '19.10'}
 toolchainopts = {'pic': True, 'verbose': False}
 
-
 dependencies = [
-    ('PyExtensions', '%s' % local_pyver),
+    ('cray-python/3.6.5.7', EXTERNAL_MODULE),
+    ('PyExtensions', '%(pyver)s'),
     ('configurable-http-proxy', '3.1.1')
 ]
 
-# bundle of Python packages
-exts_defaultclass = 'PythonPackage'
+exts_default_options = {
+    'req_py_majver': '%(pymajver)s',
+    'req_py_minver': '%s' % _pyminver,
+    'source_urls': [PYPI_SOURCE]
+}
 
 exts_list = [
-    ('pamela', '0.3.0', {
-        'req_py_majver': '3',
-        'req_py_minver': '6',
-        'source_urls': ['https://pypi.python.org/packages/source/p/pamela/'],
-    }),
-    ('tornado', '5.1.1', {
-            'req_py_majver': '3',
-            'req_py_minver': '6',
-            'source_urls': ['https://pypi.python.org/packages/source/t/tornado/'],
-        }),
-    ('decorator', '4.3.0', {
-            'req_py_majver': '3',
-            'req_py_minver': '6',
-            'source_urls': ['https://pypi.python.org/packages/source/d/decorator/'],
-        }),
-    ('ipython_genutils', '0.2.0', {
-            'req_py_majver': '3',
-            'req_py_minver': '6',
-            'source_urls': ['https://pypi.python.org/packages/source/i/ipython_genutils/'],
-        }),
-    ('traitlets', '4.3.2', {
-            'req_py_majver': '3',
-            'req_py_minver': '6',
-            'source_urls': ['https://pypi.python.org/packages/source/t/traitlets/'],
-        }),
+    ('pamela', '0.3.0'),
+    ('tornado', '5.1.1'),
+    ('decorator', '4.3.0'),
+    ('ipython_genutils', '0.2.0'),
+    ('traitlets', '4.3.2'),
     ('python-oauth2', '1.1.0', {
-            'req_py_majver': '3',
-            'req_py_minver': '6',
-            'modulename': 'oauth2',
-            'source_urls': ['https://pypi.python.org/packages/source/p/python-oauth2/'],
-        }),
-    ('SQLAlchemy', '1.2.12', {
-            'req_py_majver': '3',
-            'req_py_minver': '6',
-            'source_urls': ['https://pypi.python.org/packages/source/s/SQLAlchemy/'],
-        }),
-    ('MarkupSafe', '1.0', {
-            'req_py_majver': '3',
-            'req_py_minver': '6',
-            'source_urls': ['https://pypi.python.org/packages/source/m/MarkupSafe/'],
-        }),
-    ('Mako', '1.0.7', {
-            'req_py_majver': '3',
-            'req_py_minver': '6',
-            'source_urls': ['https://pypi.python.org/packages/source/m/Mako/'],
-        }),
+        'modulename': 'oauth2',
+    }),
+    ('SQLAlchemy', '1.2.12'),
+    ('MarkupSafe', '1.0'),
+    ('Mako', '1.0.7'),
     ('python-editor', '1.0.3', {
-            'req_py_majver': '3',
-            'req_py_minver': '6',
-            'modulename': 'editor',
-            'source_urls': ['https://pypi.python.org/packages/source/p/python-editor/'],
-        }),
+        'modulename': 'editor',
+    }),
     ('python-dateutil', '2.7.3', {
-            'req_py_majver': '3',
-            'req_py_minver': '6',
-            'modulename': 'dateutil',
-            'source_urls': ['https://pypi.python.org/packages/source/p/python-dateutil/'],
-        }),
-    ('alembic', '1.0.0', {
-            'req_py_majver': '3',
-            'req_py_minver': '6',
-            'source_urls': ['https://pypi.python.org/packages/source/a/alembic/'],
-        }),
-    ('prometheus_client', '0.4.1', {
-            'req_py_majver': '3',
-            'req_py_minver': '6',
-            'source_urls': ['https://pypi.python.org/packages/source/p/prometheus_client/'],
-        }),
-    ('async_generator', '1.10', {
-            'req_py_majver': '3',
-            'req_py_minver': '6',
-            'source_urls': ['https://pypi.python.org/packages/source/a/async_generator/'],
-        }),
-    ('chardet', '3.0.4', {
-            'req_py_majver': '3',
-            'req_py_minver': '6',
-            'source_urls': ['https://pypi.python.org/packages/source/c/chardet/'],
-        }),
-    ('certifi', '2018.8.24', {
-            'req_py_majver': '3',
-            'req_py_minver': '6',
-            'source_urls': ['https://pypi.python.org/packages/source/c/certifi/'],
-        }),
-    ('idna', '2.7', {
-            'req_py_majver': '3',
-            'req_py_minver': '6',
-            'source_urls': ['https://pypi.python.org/packages/source/i/idna/'],
-        }),
-    ('urllib3', '1.23', {
-            'req_py_majver': '3',
-            'req_py_minver': '6',
-            'source_urls': ['https://pypi.python.org/packages/source/u/urllib3/'],
-        }),
-    ('requests', '2.19.1', {
-            'req_py_majver': '3',
-            'req_py_minver': '6',
-            'source_urls': ['https://pypi.python.org/packages/source/r/requests/'],
-        }),
-    ('Jinja2', '2.10', {
-            'req_py_majver': '3',
-            'req_py_minver': '6',
-            'source_urls': ['https://pypi.python.org/packages/source/j/Jinja2/'],
-        }),
+        'modulename': 'dateutil',
+    }),
+    ('alembic', '1.0.0'),
+    ('prometheus_client', '0.4.1'),
+    ('async_generator', '1.10'),
+    ('chardet', '3.0.4'),
+    ('certifi', '2018.8.24'),
+    ('idna', '2.7'),
+    ('urllib3', '1.23'),
+    ('requests', '2.19.1'),
+    ('Jinja2', '2.10'),
     ('jupyterhub', version, {
-            'req_py_majver': '3',
-            'req_py_minver': '6',
-            'use_pip': True,
-            'source_urls': ['https://pypi.python.org/packages/source/j/jupyterhub/'],
-        }),
+        'use_pip': True,
+    }),
 ]
-
-# specify that Bundle easyblock should run a full sanity check, rather than just trying to load the module
-local_full_sanity_check = True
-
-modextrapaths = {'PYTHONPATH': ['lib/python%s/site-packages' % local_pyshortver]}
 
 sanity_check_paths = {
     'files': [],
-    'dirs': ['lib/python%s/site-packages' % local_pyshortver]
+    'dirs': ['lib/python%(pyshortver)s/site-packages']
 }
 
 moduleclass = 'tools'

--- a/easybuild/easyconfigs/j/jupyterlab/jupyterlab-1.1.1-CrayGNU-19.10-batchspawner.eb
+++ b/easybuild/easyconfigs/j/jupyterlab/jupyterlab-1.1.1-CrayGNU-19.10-batchspawner.eb
@@ -1,17 +1,11 @@
-# @author: robinson 
+# @author: robinson
 
-easyblock = 'Bundle'
+easyblock = 'PythonBundle'
 
 name = 'jupyterlab'
 version = '1.1.1'
 versionsuffix = '-batchspawner'
-
-local_py_maj_ver = '3'
-local_py_min_ver = '6'
-local_py_rev_ver = '5.7'
-
-local_pyver = '%s.%s.%s' % (local_py_maj_ver, local_py_min_ver, local_py_rev_ver)
-local_pyshortver = '%s.%s' % (local_py_maj_ver, local_py_min_ver)
+_pyminver = '6'
 
 homepage = 'https://github.com/jupyterlab/jupyterlab'
 description = "An extensible environment for interactive and reproducible computing, based on the Jupyter Notebook and Architecture."
@@ -20,507 +14,156 @@ toolchain = {'name': 'CrayGNU', 'version': '19.10'}
 toolchainopts = {'pic': True, 'verbose': False}
 
 dependencies = [
+    ('cray-python/3.6.5.7', EXTERNAL_MODULE),
     ('libffi', '3.2.1', '', True),
-    ('PyExtensions', '%s' % local_pyver),
-    ('IPython', '7.7.0', '-python%s' % local_py_maj_ver),
+    ('PyExtensions', '%(pyver)s'),
+    ('IPython', '7.7.0', '-python%(pymajver)s'),
     ('configurable-http-proxy', '3.1.1'),
-    ('dask', '2.2.0', '-python%s' % local_py_maj_ver),
+    ('dask', '2.2.0', '-python%(pymajver)s'),
     ('graphviz', '2.40.1', '', True),
 ]
 
-# bundle of Python packages
-exts_defaultclass = 'PythonPackage'
+exts_default_options = {
+    'req_py_majver': '%(pymajver)s',
+    'req_py_minver': '%s' % _pyminver,
+    'source_urls': [PYPI_SOURCE],
+    'use_pip': True,
+}
 
 exts_list = [
 
 #jupyterlab packages besides ipython and its deps
-    ('pyrsistent', '0.15.4', {
-        'req_py_majver': '3',
-        'req_py_minver': '6',
-        'use_pip': True,
-        'source_urls': ['https://pypi.python.org/packages/source/p/pyrsistent/'],
-        }),
+    ('pyrsistent', '0.15.4'),
     ('attrs', '19.1.0', {
-        'req_py_majver': '3',
-        'req_py_minver': '6',
-        'use_pip': True,
         'modulename': 'attr',
-        'source_urls': ['https://pypi.python.org/packages/source/a/attrs/'],
         }),
-    ('jsonschema', '3.0.1', {
-        'req_py_majver': '3',
-        'req_py_minver': '6',
-        'use_pip': True,
-        'source_urls': ['https://pypi.python.org/packages/source/j/jsonschema/'],
-        }),
-    ('json5', '0.8.5', {
-        'req_py_majver': '3',
-        'req_py_minver': '6',
-        'use_pip': True,
-        'source_urls': ['https://pypi.python.org/packages/source/j/json5/'],
-        }),
-    ('Send2Trash', '1.5.0', {
-        'req_py_majver': '3',
-        'req_py_minver': '6',
-        'use_pip': True,
-        'source_urls': ['https://pypi.python.org/packages/source/s/Send2Trash/'],
-        }),
-    ('tornado', '6.0.3', {
-        'req_py_majver': '3',
-        'req_py_minver': '6',
-        'use_pip': True,
-        'source_urls': ['https://pypi.python.org/packages/source/t/tornado/'],
-        }),
+    ('jsonschema', '3.0.1'),
+    ('json5', '0.8.5'),
+    ('Send2Trash', '1.5.0'),
+    ('tornado', '6.0.3'),
     ('pyzmq', '18.0.2', {
-        'req_py_majver': '3',
-        'req_py_minver': '6',
-        'use_pip': True,
         'modulename': 'zmq',
-        'source_urls': ['https://pypi.python.org/packages/source/p/pyzmq/'],
         }),
     ('python-dateutil', '2.8.0', {
-        'req_py_majver': '3',
-        'req_py_minver': '6',
-        'use_pip': True,
         'modulename':  'dateutil',
-        'source_urls': ['https://pypi.python.org/packages/source/p/python-dateutil/'],
         }),
-    ('jupyter_core', '4.5.0', {
-        'req_py_majver': '3',
-        'req_py_minver': '6',
-        'use_pip': True,
-        'source_urls': ['https://pypi.python.org/packages/source/j/jupyter_core/'],
-        }),
-    ('jupyter_client', '5.3.1', {
-        'req_py_majver': '3',
-        'req_py_minver': '6',
-        'use_pip': True,
-        'source_urls': ['https://pypi.python.org/packages/source/j/jupyter_client/'],
-        }),
-    ('MarkupSafe', '1.1.1', {
-        'req_py_majver': '3',
-        'req_py_minver': '6',
-        'use_pip': True,
-        'source_urls': ['https://pypi.python.org/packages/source/m/MarkupSafe/'],
-        }),
-    ('Jinja2', '2.10.1', {
-        'req_py_majver': '3',
-        'req_py_minver': '6',
-        'use_pip': True,
-        'source_urls': ['https://pypi.python.org/packages/source/j/Jinja2/'],
-        }),
-    ('webencodings', '0.5.1', {
-        'req_py_majver': '3',
-        'req_py_minver': '6',
-        'use_pip': True,
-        'source_urls': ['https://pypi.python.org/packages/source/w/webencodings/'],
-        }),
-    ('bleach', '3.1.0', {
-        'req_py_majver': '3',
-        'req_py_minver': '6',
-        'use_pip': True,
-        'source_urls': ['https://pypi.python.org/packages/source/b/bleach/'],
-        }),
-    ('defusedxml', '0.6.0', {
-        'req_py_majver': '3',
-        'req_py_minver': '6',
-        'use_pip': True,
-        'source_urls': ['https://pypi.python.org/packages/source/d/defusedxml/'],
-        }),
-    ('entrypoints', '0.3', {
-        'req_py_majver': '3',
-        'req_py_minver': '6',
-        'use_pip': True,
-        'source_urls': ['https://pypi.python.org/packages/source/e/entrypoints/'],
-        }),
-    ('mistune', '0.8.4', {
-        'req_py_majver': '3',
-        'req_py_minver': '6',
-        'use_pip': True,
-        'source_urls': ['https://pypi.python.org/packages/source/m/mistune/'],
-        }),
-    ('nbformat', '4.4.0', {
-        'req_py_majver': '3',
-        'req_py_minver': '6',
-        'use_pip': True,
-        'source_urls': ['https://pypi.python.org/packages/source/n/nbformat/'],
-        }),
-    ('pandocfilters', '1.4.2', {
-        'req_py_majver': '3',
-        'req_py_minver': '6',
-        'use_pip': True,
-        'source_urls': ['https://pypi.python.org/packages/source/p/pandocfilters/'],
-        }),
-    ('testpath', '0.4.2', {
-        'req_py_majver': '3',
-        'req_py_minver': '6',
-        'use_pip': True,
-        'source_urls': ['https://pypi.python.org/packages/source/t/testpath/'],
-        }),
-    ('nbconvert', '5.5.0', {
-        'req_py_majver': '3',
-        'req_py_minver': '6',
-        'use_pip': True,
-        'source_urls': ['https://pypi.python.org/packages/source/n/nbconvert/'],
-        }),
-    ('prometheus_client', '0.7.1', {
-        'req_py_majver': '3',
-        'req_py_minver': '6',
-        'use_pip': True,
-        'source_urls': ['https://pypi.python.org/packages/source/p/prometheus_client/'],
-        }),
-    ('terminado', '0.8.2', {
-        'req_py_majver': '3',
-        'req_py_minver': '6',
-        'use_pip': True,
-        'source_urls': ['https://pypi.python.org/packages/source/t/terminado/'],
-        }),
-    ('jupyterlab_server', '1.0.0', {
-        'req_py_majver': '3',
-        'req_py_minver': '6',
-        'use_pip': True,
-        'source_urls': ['https://pypi.python.org/packages/source/j/jupyterlab_server/'],
-        }),
-    ('ipykernel', '5.1.1', {
-        'req_py_majver': '3',
-        'req_py_minver': '6',
-        'use_pip': True,
-        'source_urls': ['https://pypi.python.org/packages/source/i/ipykernel/'],
-        }),
-    ('notebook', '6.0.0', {
-        'req_py_majver': '3',
-        'req_py_minver': '6',
-        'use_pip': True,
-        'source_urls': ['https://pypi.python.org/packages/source/n/notebook/'],
-        }),
+    ('jupyter_core', '4.5.0'),
+    ('jupyter_client', '5.3.1'),
+    ('MarkupSafe', '1.1.1'),
+    ('Jinja2', '2.10.1'),
+    ('webencodings', '0.5.1'),
+    ('bleach', '3.1.0'),
+    ('defusedxml', '0.6.0'),
+    ('entrypoints', '0.3'),
+    ('mistune', '0.8.4'),
+    ('nbformat', '4.4.0'),
+    ('pandocfilters', '1.4.2'),
+    ('testpath', '0.4.2'),
+    ('nbconvert', '5.5.0'),
+    ('prometheus_client', '0.7.1'),
+    ('terminado', '0.8.2'),
+    ('jupyterlab_server', '1.0.0'),
+    ('ipykernel', '5.1.1'),
+    ('notebook', '6.0.0'),
     (name, version, {
-        'req_py_majver': '3',
-        'req_py_minver': '6',
-        'use_pip': True,
         'installopts': ' --install-option=--skip-npm ',
-        'source_urls': ['https://pypi.python.org/packages/source/j/jupyterlab/'],
         }),
 
 # jupyterhub and its deps
-    ('SQLAlchemy', '1.3.6', {
-        'req_py_majver': '3',
-        'req_py_minver': '6',
-        'use_pip': True,
-        'source_urls': ['https://pypi.python.org/packages/source/s/SQLAlchemy/'],
-        }),
-    ('Mako', '1.0.14', {
-        'req_py_majver': '3',
-        'req_py_minver': '6',
-        'use_pip': True,
-        'source_urls': ['https://pypi.python.org/packages/source/m/Mako/'],
-        }),
-    ('alembic', '1.0.11', {
-        'req_py_majver': '3',
-        'req_py_minver': '6',
-        'use_pip': True,
-        'source_urls': ['https://pypi.python.org/packages/source/a/alembic/'],
-        }),
+    ('SQLAlchemy', '1.3.6'),
+    ('Mako', '1.0.14'),
+    ('alembic', '1.0.11'),
     ('python-editor', '1.0.4', {
-        'req_py_majver': '3',
-        'req_py_minver': '6',
-        'use_pip': True,
         'modulename': 'editor',
-        'source_urls': ['https://pypi.python.org/packages/source/p/python-editor/'],
         }),
-    ('async_generator', '1.10', {
-        'req_py_majver': '3',
-        'req_py_minver': '6',
-        'use_pip': True,
-        'source_urls': ['https://pypi.python.org/packages/source/a/async_generator/'],
-        }),
-    ('pycparser', '2.19', {
-        'req_py_majver': '3',
-        'req_py_minver': '6',
-        'use_pip': True,
-        'source_urls': ['https://pypi.python.org/packages/source/p/pycparser/'],
-        }),
+    ('async_generator', '1.10'),
+    ('pycparser', '2.19'),
     ('cffi', '1.12.3', {
-        'req_py_majver': '3',
-        'req_py_minver': '6',
         'use_pip': False,
-        'source_urls': ['https://pypi.python.org/packages/source/c/cffi/'],
         }),
-    ('asn1crypto', '0.24.0', {
-        'req_py_majver': '3',
-        'req_py_minver': '6',
-        'use_pip': True,
-        'source_urls': ['https://pypi.python.org/packages/source/a/asn1crypto/'],
-        }),
-    ('cryptography', '2.7', {
-        'req_py_majver': '3',
-        'req_py_minver': '6',
-        'use_pip': True,
-        'source_urls': ['https://pypi.python.org/packages/source/c/cryptography/'],
-        }),
+    ('asn1crypto', '0.24.0'),
+    ('cryptography', '2.7'),
     ('pyOpenSSL', '19.0.0', {
-        'req_py_majver': '3',
-        'req_py_minver': '6',
-        'use_pip': True,
         'modulename': "OpenSSL",
-        'source_urls': ['https://pypi.python.org/packages/source/p/pyOpenSSL/'],
         }),
-    ('certipy', '0.1.3', {
-        'req_py_majver': '3',
-        'req_py_minver': '6',
-        'use_pip': True,
-        'source_urls': ['https://pypi.python.org/packages/source/c/certipy/'],
-        }),
-    ('entrypoints', '0.3', {
-        'req_py_majver': '3',
-        'req_py_minver': '6',
-        'use_pip': True,
-        'source_urls': ['https://pypi.python.org/packages/source/e/entrypoint/'],
-        }),
-    ('oauthlib', '3.0.2', {
-        'req_py_majver': '3',
-        'req_py_minver': '6',
-        'use_pip': True,
-        'source_urls': ['https://pypi.python.org/packages/source/o/oauthlib/'],
-        }),
-    ('pamela', '1.0.0', {
-        'req_py_majver': '3',
-        'req_py_minver': '6',
-        'use_pip': True,
-        'source_urls': ['https://pypi.python.org/packages/source/p/pamela/'],
-        }),
-    ('urllib3', '1.25.3', {
-        'req_py_majver': '3',
-        'req_py_minver': '6',
-        'use_pip': True,
-        'source_urls': ['https://pypi.python.org/packages/source/u/urllib3/'],
-        }),
-    ('idna', '2.8', {
-        'req_py_majver': '3',
-        'req_py_minver': '6',
-        'use_pip': True,
-        'source_urls': ['https://pypi.python.org/packages/source/i/idna/'],
-        }),
-    ('chardet', '3.0.4', {
-        'req_py_majver': '3',
-        'req_py_minver': '6',
-        'use_pip': True,
-        'source_urls': ['https://pypi.python.org/packages/source/c/chardet/'],
-        }),
-    ('certifi', '2019.6.16', {
-        'req_py_majver': '3',
-        'req_py_minver': '6',
-        'use_pip': True,
-        'source_urls': ['https://pypi.python.org/packages/source/c/certifi/'],
-        }),
-    ('requests', '2.22.0', {
-        'req_py_majver': '3',
-        'req_py_minver': '6',
-        'use_pip': True,
-        'source_urls': ['https://pypi.python.org/packages/source/r/requests/'],
-        }),
-    ('jupyterhub', '1.0.0', {
-        'req_py_majver': '3',
-        'req_py_minver': '6',
-        'use_pip': True,
-        'source_urls': ['https://pypi.python.org/packages/source/j/jupyterhub/'],
-        }),
+    ('certipy', '0.1.3'),
+    ('entrypoints', '0.3'),
+    ('oauthlib', '3.0.2'),
+    ('pamela', '1.0.0'),
+    ('urllib3', '1.25.3'),
+    ('idna', '2.8'),
+    ('chardet', '3.0.4'),
+    ('certifi', '2019.6.16'),
+    ('requests', '2.22.0'),
+    ('jupyterhub', '1.0.0'),
 
 # widgets: note the lab extensions below
-    ('widgetsnbextension', '3.5.1', {
-        'req_py_majver': '3',
-        'req_py_minver': '6',
-        'source_urls': ['https://pypi.python.org/packages/source/w/widgetsnbextension/'],
-        }),
-    ('ipywidgets', '7.5.1', {
-        'req_py_majver': '3',
-        'req_py_minver': '6',
-        'source_urls': ['https://pypi.python.org/packages/source/i/ipywidgets/'],
-        }),
-# ipympl matplotlib widgets, requires lab extension 
-    ('ipympl', '0.3.3', {
-        'req_py_majver': '3',
-        'req_py_minver': '6',
-        'source_urls': ['https://pypi.python.org/packages/source/i/ipympl/'],
-        }),
+    ('widgetsnbextension', '3.5.1'),
+    ('ipywidgets', '7.5.1'),
+# ipympl matplotlib widgets, requires lab extension
+    ('ipympl', '0.3.3'),
 
 # plotly, requires the lab extension below
-    ('retrying', '1.3.3', {
-        'req_py_majver': '3',
-        'req_py_minver': '6',
-        'source_urls': ['https://pypi.python.org/packages/source/r/retrying/'],
-        }),
-    ('plotly', '4.0.0', {
-        'req_py_majver': '3',
-        'req_py_minver': '6',
-        'source_urls': ['https://pypi.python.org/packages/source/p/plotly/'],
-        }),
+    ('retrying', '1.3.3'),
+    ('plotly', '4.0.0'),
 
 # bokeh, requires the labextension below
     ('PyYAML', '5.1.2', {
-        'req_py_majver': '3',
-        'req_py_minver': '6',
         'modulename': 'yaml',
-        'source_urls': ['https://pypi.python.org/packages/source/p/PyYAML/'],
         }),
-    ('bokeh', '1.3.4', {
-        'req_py_majver': '3',
-        'req_py_minver': '6',
-        'source_urls': ['https://pypi.python.org/packages/source/b/bokeh/'],
-        }),
-    ('packaging', '19.1', {
-        'req_py_majver': '3',
-        'req_py_minver': '6',
-        'source_urls': ['https://pypi.python.org/packages/source/p/packaging/'],
-        }),
+    ('bokeh', '1.3.4'),
+    ('packaging', '19.1'),
     ('Pillow', '6.1.0', {
-        'req_py_majver': '3',
-        'req_py_minver': '6',
         'modulename': 'PIL',
-        'source_urls': ['https://pypi.python.org/packages/source/p/Pillow/'],
-        }),    
-    
+        }),
+
 # bqplot: requires the labextension below
-    ('traittypes', '0.2.1', {
-        'req_py_majver': '3',
-        'req_py_minver': '6',
-        'source_urls': ['https://pypi.python.org/packages/source/t/traittypes/'],
-        }),
-    ('bqplot', '0.11.6', {
-        'req_py_majver': '3',
-        'req_py_minver': '6',
-        'source_urls': ['https://pypi.python.org/packages/source/b/bqplot/'],
-        }),
+    ('traittypes', '0.2.1'),
+    ('bqplot', '0.11.6'),
 
 # nbresuse for jupyterlab-system-monitor extension
-    ('psutil', '5.6.3', {
-        'req_py_majver': '3',
-        'req_py_minver': '6',
-        'source_urls': ['https://pypi.python.org/packages/source/p/psutil/'],
-        }),
-    ('nbresuse', '0.3.2', {
-       'req_py_majver': '3',
-        'req_py_minver': '6',
-        'source_urls': ['https://pypi.python.org/packages/source/n/nbresuse/'],
-        }),
+    ('psutil', '5.6.3'),
+    ('nbresuse', '0.3.2'),
 
 # jupyterlab-slrum extension to implement common slurm commands in the notebook, not yet supported with JLab 1.0
-#    ('jupyterlab_slurm', '0.1.1', {
-#        'req_py_majver': '3',
-#        'req_py_minver': '6',
-#        'source_urls': ['https://pypi.python.org/packages/source/j/jupyterlab-slurm/'],
-#        }),
+#    ('jupyterlab_slurm', '0.1.1'),
 
 # qgrid widgets: note that 1.1.1 is not yet supported with JupyterLab 1.x - commented for now, twr
-#    ('qgrid', '1.1.1', {
-#        'req_py_majver': '3',
-#        'req_py_minver': '6',
-#        'source_urls': ['https://pypi.python.org/packages/source/q/qgrid/'],
-#        }),
+#    ('qgrid', '1.1.1'),
 
 # graphviz, for dask graph visualization
-     ('graphviz', '0.12', {
-         'req_py_majver': '3',
-         'req_py_minver': '6',
-         'use_pip': True,
-         'source_urls': ['https://pypi.python.org/packages/source/g/graphviz/'],
-         'source_tmpl': 'graphviz-%(version)s.zip',
-         }),
+    ('graphviz', '0.12', {
+        'source_tmpl': 'graphviz-%(version)s.zip',
+        }),
 
 # dask-labextension
-# This package provides a JupyterLab extension to manage Dask clusters, 
-# as well as embed Dask's dashboard plots directly into JupyterLab panes    
-    ('simpervisor', '0.3', {
-        'req_py_majver': '3',
-        'req_py_minver': '6',
-        'use_pip': True,        
-        'source_urls': ['https://pypi.python.org/packages/source/s/simpervisor/'],
-        }),
-    ('multidict', '4.5.2', {
-        'req_py_majver': '3',
-        'req_py_minver': '6',
-        'use_pip': True,        
-        'source_urls': ['https://pypi.python.org/packages/source/m/multidict/'],
-        }),
-    ('yarl', '1.3.0', {
-        'req_py_majver': '3',
-        'req_py_minver': '6',
-        'use_pip': True, 
-        'source_urls': ['https://pypi.python.org/packages/source/y/yarl/'],
-        }),
-    ('typing_extensions', '3.7.4', {
-        'req_py_majver': '3',
-        'req_py_minver': '6',
-        'use_pip': True,        
-        'source_urls': ['https://pypi.python.org/packages/source/t/typing_extensions/'],
-        }),
-    ('async-timeout', '3.0.1', {
-        'req_py_majver': '3',
-        'req_py_minver': '6',
-        'use_pip': True,        
-        'source_urls': ['https://pypi.python.org/packages/source/a/async-timeout/'],
-        }),
+# This package provides a JupyterLab extension to manage Dask clusters,
+# as well as embed Dask's dashboard plots directly into JupyterLab panes
+    ('simpervisor', '0.3'),
+    ('multidict', '4.5.2'),
+    ('yarl', '1.3.0'),
+    ('typing_extensions', '3.7.4'),
+    ('async-timeout', '3.0.1'),
     ('idna-ssl', '1.1.0', {
-        'req_py_majver': '3',
-        'req_py_minver': '6',
-        'use_pip': True,        
         'modulename': 'idna_ssl',
-        'source_urls': ['https://pypi.python.org/packages/source/i/idna-ssl/'],
         }),
-   ('aiohttp', '3.5.4', {
-        'req_py_majver': '3',
-        'req_py_minver': '6',
-        'use_pip': True,        
-        'source_urls': ['https://pypi.python.org/packages/source/a/aiohttp/'],
-        }),
-   ('jupyter-server-proxy', '1.1.0', {
-        'req_py_majver': '3',
-        'req_py_minver': '6',
-        'use_pip': True,        
-        'source_urls': ['https://pypi.python.org/packages/source/j/jupyter-server-proxy/'],
-        }),
-    ('dask_labextension', '1.0.3', {
-        'req_py_majver': '3',
-        'req_py_minver': '6',
-        'use_pip': True,        
-        'source_urls': ['https://pypi.python.org/packages/source/d/dask-labextension/'],
-        }),
-    
+    ('aiohttp', '3.5.4'),
+    ('jupyter-server-proxy', '1.1.0'),
+    ('dask_labextension', '1.0.3'),
+
 # kernels
 # bash kernel, requires kernel install below, twr
-    ('bash_kernel', '0.7.2', {
-        'req_py_majver': '3',
-        'req_py_minver': '6',
-        'use_pip': True,
-        'source_urls': ['https://pypi.python.org/packages/source/b/bash_kernel/'],
-        }),
-     ('batchspawner', '68a1fcd', {
-        'req_py_majver': '3',
-        'req_py_minver': '6',
-        'use_pip': True,
-        'source_urls': ['https://github.com/jupyterhub/batchspawner/tarball/68a1fcd'],
-        }),
-    ('ipyparallel', '6.2.4', {
-        'req_py_majver': '3',
-        'req_py_minver': '6',
-        'use_pip': True,
-        'source_urls': ['https://pypi.python.org/packages/source/i/ipyparallel/'],
-        }),
-    ('docopt', '0.6.2', {
-        'req_py_majver': '3',
-        'req_py_minver': '6',
-        'use_pip': True,
-        'source_urls': ['https://pypi.python.org/packages/source/d/docopt/'],
-        }),
+    ('bash_kernel', '0.7.2'),
+    ('batchspawner', '68a1fcd'),
+    ('ipyparallel', '6.2.4'),
+    ('docopt', '0.6.2'),
 ]
-
-# specify that Bundle easyblock should run a full sanity check, rather than just trying to load the module
-local_full_sanity_check = True
 
 # For Julia packages needed for Jupyter
 #twr julia_depot_path = "%(installdir)s/share/julia/site/"
 
 modextrapaths = {
-    'PYTHONPATH': ['lib/python%s/site-packages' % local_pyshortver],
+    'PYTHONPATH': ['lib/python%(pyshortver)s/site-packages'],
     'JUPYTER_PATH': 'share/jupyter',
 }
 
@@ -535,8 +178,8 @@ modextravars = {
 postinstallcmds = ["export YARN_CACHE_FOLDER=/tmp/$USER/yarn_cache;"
                    "export JUPYTERLAB_DIR=%(installdir)s/share/jupyter/lab/;"
                    "export PYTHONPATH=%(installdir)s/lib/python3.6/site-packages:$PYTHONPATH;"
-#                  "export JUPYTER_PATH=%(installdir)s/share/jupyter/;" 
-                   "export JUPYTER_DATA_DIR=%(installdir)s/share/jupyter/;" 
+#                  "export JUPYTER_PATH=%(installdir)s/share/jupyter/;"
+                   "export JUPYTER_DATA_DIR=%(installdir)s/share/jupyter/;"
                    "export JULIA_DEPOT_PATH=%(installdir)s/share/julia/site/;"
                    "export JUPYTER=%(installdir)s/bin/jupyter;"
                    "%(installdir)s/bin/jupyter-labextension install -y @jupyter-widgets/jupyterlab-manager@1.0 --no-build;"
@@ -570,7 +213,7 @@ postinstallcmds = ["export YARN_CACHE_FOLDER=/tmp/$USER/yarn_cache;"
                    ]
 sanity_check_paths = {
     'files': [],
-    'dirs': ['lib/python%s/site-packages' % local_pyshortver,
+    'dirs': ['lib/python%(pyshortver)s/site-packages',
              'share/jupyter/lab/extensions',
              'share/jupyter/lab/schemas',
              'share/jupyter/lab/staging',

--- a/easybuild/easyconfigs/j/jupyterlab/jupyterlab-1.1.1-CrayGNU-19.10.eb
+++ b/easybuild/easyconfigs/j/jupyterlab/jupyterlab-1.1.1-CrayGNU-19.10.eb
@@ -25,7 +25,8 @@ dependencies = [
 exts_default_options = {
     'req_py_majver': '%(pymajver)s',
     'req_py_minver': '%s' % _pyminver,
-    'source_urls': [PYPI_SOURCE]
+    'source_urls': [PYPI_SOURCE],
+    'use_pip': True,
 }
 
 exts_list = [

--- a/easybuild/easyconfigs/j/jupyterlab/jupyterlab-1.1.1-CrayGNU-19.10.eb
+++ b/easybuild/easyconfigs/j/jupyterlab/jupyterlab-1.1.1-CrayGNU-19.10.eb
@@ -1,16 +1,10 @@
-# @author: robinson 
+# @author: robinson
 
-easyblock = 'Bundle'
+easyblock = 'PythonBundle'
 
 name = 'jupyterlab'
 version = '1.1.1'
-
-local_py_maj_ver = '3'
-local_py_min_ver = '6'
-local_py_rev_ver = '5.7'
-
-local_pyver = '%s.%s.%s' % (local_py_maj_ver, local_py_min_ver, local_py_rev_ver)
-local_pyshortver = '%s.%s' % (local_py_maj_ver, local_py_min_ver)
+_pyminver = '6'
 
 homepage = 'https://github.com/jupyterlab/jupyterlab'
 description = "An extensible environment for interactive and reproducible computing, based on the Jupyter Notebook and Architecture."
@@ -19,490 +13,258 @@ toolchain = {'name': 'CrayGNU', 'version': '19.10'}
 toolchainopts = {'pic': True, 'verbose': False}
 
 dependencies = [
+    ('cray-python/3.6.5.7', EXTERNAL_MODULE),
     ('libffi', '3.2.1', '', True),
-    ('PyExtensions', '%s' % local_pyver),
-    ('IPython', '7.7.0', '-python%s' % local_py_maj_ver),
+    ('PyExtensions', '%(pyver)s'),
+    ('IPython', '7.7.0', '-python%(pymajver)s'),
     ('configurable-http-proxy', '3.1.1'),
-    ('dask', '2.2.0', '-python%s' % local_py_maj_ver),
+    ('dask', '2.2.0', '-python%(pymajver)s'),
     ('graphviz', '2.40.1', '', True),
 ]
 
-# bundle of Python packages
-exts_defaultclass = 'PythonPackage'
+exts_default_options = {
+    'req_py_majver': '%(pymajver)s',
+    'req_py_minver': '%s' % _pyminver,
+    'source_urls': [PYPI_SOURCE]
+}
 
 exts_list = [
 
 #jupyterlab packages besides ipython and its deps
     ('pyrsistent', '0.15.4', {
-        'req_py_majver': '3',
-        'req_py_minver': '6',
         'use_pip': True,
-        'source_urls': ['https://pypi.python.org/packages/source/p/pyrsistent/'],
         }),
     ('attrs', '19.1.0', {
-        'req_py_majver': '3',
-        'req_py_minver': '6',
         'use_pip': True,
         'modulename': 'attr',
-        'source_urls': ['https://pypi.python.org/packages/source/a/attrs/'],
         }),
     ('jsonschema', '3.0.1', {
-        'req_py_majver': '3',
-        'req_py_minver': '6',
         'use_pip': True,
-        'source_urls': ['https://pypi.python.org/packages/source/j/jsonschema/'],
         }),
     ('json5', '0.8.5', {
-        'req_py_majver': '3',
-        'req_py_minver': '6',
         'use_pip': True,
-        'source_urls': ['https://pypi.python.org/packages/source/j/json5/'],
         }),
     ('Send2Trash', '1.5.0', {
-        'req_py_majver': '3',
-        'req_py_minver': '6',
         'use_pip': True,
-        'source_urls': ['https://pypi.python.org/packages/source/s/Send2Trash/'],
         }),
     ('tornado', '6.0.3', {
-        'req_py_majver': '3',
-        'req_py_minver': '6',
         'use_pip': True,
-        'source_urls': ['https://pypi.python.org/packages/source/t/tornado/'],
         }),
     ('pyzmq', '18.0.2', {
-        'req_py_majver': '3',
-        'req_py_minver': '6',
         'use_pip': True,
         'modulename': 'zmq',
-        'source_urls': ['https://pypi.python.org/packages/source/p/pyzmq/'],
         }),
     ('python-dateutil', '2.8.0', {
-        'req_py_majver': '3',
-        'req_py_minver': '6',
         'use_pip': True,
         'modulename':  'dateutil',
-        'source_urls': ['https://pypi.python.org/packages/source/p/python-dateutil/'],
         }),
     ('jupyter_core', '4.5.0', {
-        'req_py_majver': '3',
-        'req_py_minver': '6',
         'use_pip': True,
-        'source_urls': ['https://pypi.python.org/packages/source/j/jupyter_core/'],
         }),
     ('jupyter_client', '5.3.1', {
-        'req_py_majver': '3',
-        'req_py_minver': '6',
         'use_pip': True,
-        'source_urls': ['https://pypi.python.org/packages/source/j/jupyter_client/'],
         }),
     ('MarkupSafe', '1.1.1', {
-        'req_py_majver': '3',
-        'req_py_minver': '6',
         'use_pip': True,
-        'source_urls': ['https://pypi.python.org/packages/source/m/MarkupSafe/'],
         }),
     ('Jinja2', '2.10.1', {
-        'req_py_majver': '3',
-        'req_py_minver': '6',
         'use_pip': True,
-        'source_urls': ['https://pypi.python.org/packages/source/j/Jinja2/'],
         }),
     ('webencodings', '0.5.1', {
-        'req_py_majver': '3',
-        'req_py_minver': '6',
         'use_pip': True,
-        'source_urls': ['https://pypi.python.org/packages/source/w/webencodings/'],
         }),
     ('bleach', '3.1.0', {
-        'req_py_majver': '3',
-        'req_py_minver': '6',
         'use_pip': True,
-        'source_urls': ['https://pypi.python.org/packages/source/b/bleach/'],
         }),
     ('defusedxml', '0.6.0', {
-        'req_py_majver': '3',
-        'req_py_minver': '6',
         'use_pip': True,
-        'source_urls': ['https://pypi.python.org/packages/source/d/defusedxml/'],
         }),
     ('entrypoints', '0.3', {
-        'req_py_majver': '3',
-        'req_py_minver': '6',
         'use_pip': True,
-        'source_urls': ['https://pypi.python.org/packages/source/e/entrypoints/'],
         }),
     ('mistune', '0.8.4', {
-        'req_py_majver': '3',
-        'req_py_minver': '6',
         'use_pip': True,
-        'source_urls': ['https://pypi.python.org/packages/source/m/mistune/'],
         }),
     ('nbformat', '4.4.0', {
-        'req_py_majver': '3',
-        'req_py_minver': '6',
         'use_pip': True,
-        'source_urls': ['https://pypi.python.org/packages/source/n/nbformat/'],
         }),
     ('pandocfilters', '1.4.2', {
-        'req_py_majver': '3',
-        'req_py_minver': '6',
         'use_pip': True,
-        'source_urls': ['https://pypi.python.org/packages/source/p/pandocfilters/'],
         }),
     ('testpath', '0.4.2', {
-        'req_py_majver': '3',
-        'req_py_minver': '6',
         'use_pip': True,
-        'source_urls': ['https://pypi.python.org/packages/source/t/testpath/'],
         }),
     ('nbconvert', '5.5.0', {
-        'req_py_majver': '3',
-        'req_py_minver': '6',
         'use_pip': True,
-        'source_urls': ['https://pypi.python.org/packages/source/n/nbconvert/'],
         }),
     ('prometheus_client', '0.7.1', {
-        'req_py_majver': '3',
-        'req_py_minver': '6',
         'use_pip': True,
-        'source_urls': ['https://pypi.python.org/packages/source/p/prometheus_client/'],
         }),
     ('terminado', '0.8.2', {
-        'req_py_majver': '3',
-        'req_py_minver': '6',
         'use_pip': True,
-        'source_urls': ['https://pypi.python.org/packages/source/t/terminado/'],
         }),
     ('jupyterlab_server', '1.0.0', {
-        'req_py_majver': '3',
-        'req_py_minver': '6',
         'use_pip': True,
-        'source_urls': ['https://pypi.python.org/packages/source/j/jupyterlab_server/'],
         }),
     ('ipykernel', '5.1.1', {
-        'req_py_majver': '3',
-        'req_py_minver': '6',
         'use_pip': True,
-        'source_urls': ['https://pypi.python.org/packages/source/i/ipykernel/'],
         }),
     ('notebook', '6.0.0', {
-        'req_py_majver': '3',
-        'req_py_minver': '6',
         'use_pip': True,
-        'source_urls': ['https://pypi.python.org/packages/source/n/notebook/'],
         }),
     (name, version, {
-        'req_py_majver': '3',
-        'req_py_minver': '6',
         'use_pip': True,
         'installopts': ' --install-option=--skip-npm ',
-        'source_urls': ['https://pypi.python.org/packages/source/j/jupyterlab/'],
         }),
 
 # jupyterhub and its deps
     ('SQLAlchemy', '1.3.6', {
-        'req_py_majver': '3',
-        'req_py_minver': '6',
         'use_pip': True,
-        'source_urls': ['https://pypi.python.org/packages/source/s/SQLAlchemy/'],
         }),
     ('Mako', '1.0.14', {
-        'req_py_majver': '3',
-        'req_py_minver': '6',
         'use_pip': True,
-        'source_urls': ['https://pypi.python.org/packages/source/m/Mako/'],
         }),
     ('alembic', '1.0.11', {
-        'req_py_majver': '3',
-        'req_py_minver': '6',
         'use_pip': True,
-        'source_urls': ['https://pypi.python.org/packages/source/a/alembic/'],
         }),
     ('python-editor', '1.0.4', {
-        'req_py_majver': '3',
-        'req_py_minver': '6',
         'use_pip': True,
         'modulename': 'editor',
-        'source_urls': ['https://pypi.python.org/packages/source/p/python-editor/'],
         }),
     ('async_generator', '1.10', {
-        'req_py_majver': '3',
-        'req_py_minver': '6',
         'use_pip': True,
-        'source_urls': ['https://pypi.python.org/packages/source/a/async_generator/'],
         }),
     ('pycparser', '2.19', {
-        'req_py_majver': '3',
-        'req_py_minver': '6',
         'use_pip': True,
-        'source_urls': ['https://pypi.python.org/packages/source/p/pycparser/'],
         }),
     ('cffi', '1.12.3', {
-        'req_py_majver': '3',
-        'req_py_minver': '6',
         'use_pip': False,
-        'source_urls': ['https://pypi.python.org/packages/source/c/cffi/'],
         }),
     ('asn1crypto', '0.24.0', {
-        'req_py_majver': '3',
-        'req_py_minver': '6',
         'use_pip': True,
-        'source_urls': ['https://pypi.python.org/packages/source/a/asn1crypto/'],
         }),
     ('cryptography', '2.7', {
-        'req_py_majver': '3',
-        'req_py_minver': '6',
         'use_pip': True,
-        'source_urls': ['https://pypi.python.org/packages/source/c/cryptography/'],
         }),
     ('pyOpenSSL', '19.0.0', {
-        'req_py_majver': '3',
-        'req_py_minver': '6',
         'use_pip': True,
         'modulename': "OpenSSL",
-        'source_urls': ['https://pypi.python.org/packages/source/p/pyOpenSSL/'],
         }),
     ('certipy', '0.1.3', {
-        'req_py_majver': '3',
-        'req_py_minver': '6',
         'use_pip': True,
-        'source_urls': ['https://pypi.python.org/packages/source/c/certipy/'],
         }),
     ('entrypoints', '0.3', {
-        'req_py_majver': '3',
-        'req_py_minver': '6',
         'use_pip': True,
-        'source_urls': ['https://pypi.python.org/packages/source/e/entrypoint/'],
         }),
     ('oauthlib', '3.0.2', {
-        'req_py_majver': '3',
-        'req_py_minver': '6',
         'use_pip': True,
-        'source_urls': ['https://pypi.python.org/packages/source/o/oauthlib/'],
         }),
     ('pamela', '1.0.0', {
-        'req_py_majver': '3',
-        'req_py_minver': '6',
         'use_pip': True,
-        'source_urls': ['https://pypi.python.org/packages/source/p/pamela/'],
         }),
     ('urllib3', '1.25.3', {
-        'req_py_majver': '3',
-        'req_py_minver': '6',
         'use_pip': True,
-        'source_urls': ['https://pypi.python.org/packages/source/u/urllib3/'],
         }),
     ('idna', '2.8', {
-        'req_py_majver': '3',
-        'req_py_minver': '6',
         'use_pip': True,
-        'source_urls': ['https://pypi.python.org/packages/source/i/idna/'],
         }),
     ('chardet', '3.0.4', {
-        'req_py_majver': '3',
-        'req_py_minver': '6',
         'use_pip': True,
-        'source_urls': ['https://pypi.python.org/packages/source/c/chardet/'],
         }),
     ('certifi', '2019.6.16', {
-        'req_py_majver': '3',
-        'req_py_minver': '6',
         'use_pip': True,
-        'source_urls': ['https://pypi.python.org/packages/source/c/certifi/'],
         }),
     ('requests', '2.22.0', {
-        'req_py_majver': '3',
-        'req_py_minver': '6',
         'use_pip': True,
-        'source_urls': ['https://pypi.python.org/packages/source/r/requests/'],
         }),
     ('jupyterhub', '1.0.0', {
-        'req_py_majver': '3',
-        'req_py_minver': '6',
         'use_pip': True,
-        'source_urls': ['https://pypi.python.org/packages/source/j/jupyterhub/'],
         }),
 
 # widgets: note the lab extensions below
-    ('widgetsnbextension', '3.5.1', {
-        'req_py_majver': '3',
-        'req_py_minver': '6',
-        'source_urls': ['https://pypi.python.org/packages/source/w/widgetsnbextension/'],
-        }),
-    ('ipywidgets', '7.5.1', {
-        'req_py_majver': '3',
-        'req_py_minver': '6',
-        'source_urls': ['https://pypi.python.org/packages/source/i/ipywidgets/'],
-        }),
-# ipympl matplotlib widgets, requires lab extension 
-    ('ipympl', '0.3.3', {
-        'req_py_majver': '3',
-        'req_py_minver': '6',
-        'source_urls': ['https://pypi.python.org/packages/source/i/ipympl/'],
-        }),
+    ('widgetsnbextension', '3.5.1'),
+    ('ipywidgets', '7.5.1'),
+# ipympl matplotlib widgets, requires lab extension
+    ('ipympl', '0.3.3'),
 
 # plotly, requires the lab extension below
-    ('retrying', '1.3.3', {
-        'req_py_majver': '3',
-        'req_py_minver': '6',
-        'source_urls': ['https://pypi.python.org/packages/source/r/retrying/'],
-        }),
-    ('plotly', '4.0.0', {
-        'req_py_majver': '3',
-        'req_py_minver': '6',
-        'source_urls': ['https://pypi.python.org/packages/source/p/plotly/'],
-        }),
+    ('retrying', '1.3.3'),
+    ('plotly', '4.0.0'),
 
 # bokeh, requires the labextension below
     ('PyYAML', '5.1.2', {
-        'req_py_majver': '3',
-        'req_py_minver': '6',
         'modulename': 'yaml',
-        'source_urls': ['https://pypi.python.org/packages/source/p/PyYAML/'],
         }),
-    ('bokeh', '1.3.4', {
-        'req_py_majver': '3',
-        'req_py_minver': '6',
-        'source_urls': ['https://pypi.python.org/packages/source/b/bokeh/'],
-        }),
-    ('packaging', '19.1', {
-        'req_py_majver': '3',
-        'req_py_minver': '6',
-        'source_urls': ['https://pypi.python.org/packages/source/p/packaging/'],
-        }),
+    ('bokeh', '1.3.4'),
+    ('packaging', '19.1'),
     ('Pillow', '6.1.0', {
-        'req_py_majver': '3',
-        'req_py_minver': '6',
         'modulename': 'PIL',
-        'source_urls': ['https://pypi.python.org/packages/source/p/Pillow/'],
-        }),    
-    
+        }),
+
 # bqplot: requires the labextension below
-    ('traittypes', '0.2.1', {
-        'req_py_majver': '3',
-        'req_py_minver': '6',
-        'source_urls': ['https://pypi.python.org/packages/source/t/traittypes/'],
-        }),
-    ('bqplot', '0.11.6', {
-        'req_py_majver': '3',
-        'req_py_minver': '6',
-        'source_urls': ['https://pypi.python.org/packages/source/b/bqplot/'],
-        }),
+    ('traittypes', '0.2.1'),
+    ('bqplot', '0.11.6'),
 
 # nbresuse for jupyterlab-system-monitor extension
-    ('psutil', '5.6.3', {
-        'req_py_majver': '3',
-        'req_py_minver': '6',
-        'source_urls': ['https://pypi.python.org/packages/source/p/psutil/'],
-        }),
-    ('nbresuse', '0.3.2', {
-       'req_py_majver': '3',
-        'req_py_minver': '6',
-        'source_urls': ['https://pypi.python.org/packages/source/n/nbresuse/'],
-        }),
+    ('psutil', '5.6.3'),
+    ('nbresuse', '0.3.2'),
 
 # jupyterlab-slrum extension to implement common slurm commands in the notebook, not yet supported with JLab 1.0
-#    ('jupyterlab_slurm', '0.1.1', {
-#        'req_py_majver': '3',
-#        'req_py_minver': '6',
-#        'source_urls': ['https://pypi.python.org/packages/source/j/jupyterlab-slurm/'],
-#        }),
+#    ('jupyterlab_slurm', '0.1.1'),
 
 # qgrid widgets: note that 1.1.1 is not yet supported with JupyterLab 1.x - commented for now, twr
-#    ('qgrid', '1.1.1', {
-#        'req_py_majver': '3',
-#        'req_py_minver': '6',
-#        'source_urls': ['https://pypi.python.org/packages/source/q/qgrid/'],
-#        }),
+#    ('qgrid', '1.1.1'),
 
 # graphviz, for dask graph visualization
      ('graphviz', '0.12', {
-         'req_py_majver': '3',
-         'req_py_minver': '6',
          'use_pip': True,
-         'source_urls': ['https://pypi.python.org/packages/source/g/graphviz/'],
          'source_tmpl': 'graphviz-%(version)s.zip',
          }),
 
 # dask-labextension
-# This package provides a JupyterLab extension to manage Dask clusters, 
-# as well as embed Dask's dashboard plots directly into JupyterLab panes    
+# This package provides a JupyterLab extension to manage Dask clusters,
+# as well as embed Dask's dashboard plots directly into JupyterLab panes
     ('simpervisor', '0.3', {
-        'req_py_majver': '3',
-        'req_py_minver': '6',
-        'use_pip': True,        
-        'source_urls': ['https://pypi.python.org/packages/source/s/simpervisor/'],
+        'use_pip': True,
         }),
     ('multidict', '4.5.2', {
-        'req_py_majver': '3',
-        'req_py_minver': '6',
-        'use_pip': True,        
-        'source_urls': ['https://pypi.python.org/packages/source/m/multidict/'],
+        'use_pip': True,
         }),
     ('yarl', '1.3.0', {
-        'req_py_majver': '3',
-        'req_py_minver': '6',
-        'use_pip': True, 
-        'source_urls': ['https://pypi.python.org/packages/source/y/yarl/'],
+        'use_pip': True,
         }),
     ('typing_extensions', '3.7.4', {
-        'req_py_majver': '3',
-        'req_py_minver': '6',
-        'use_pip': True,        
-        'source_urls': ['https://pypi.python.org/packages/source/t/typing_extensions/'],
+        'use_pip': True,
         }),
     ('async-timeout', '3.0.1', {
-        'req_py_majver': '3',
-        'req_py_minver': '6',
-        'use_pip': True,        
-        'source_urls': ['https://pypi.python.org/packages/source/a/async-timeout/'],
+        'use_pip': True,
         }),
     ('idna-ssl', '1.1.0', {
-        'req_py_majver': '3',
-        'req_py_minver': '6',
-        'use_pip': True,        
+        'use_pip': True,
         'modulename': 'idna_ssl',
-        'source_urls': ['https://pypi.python.org/packages/source/i/idna-ssl/'],
         }),
-   ('aiohttp', '3.5.4', {
-        'req_py_majver': '3',
-        'req_py_minver': '6',
-        'use_pip': True,        
-        'source_urls': ['https://pypi.python.org/packages/source/a/aiohttp/'],
+    ('aiohttp', '3.5.4', {
+        'use_pip': True,
         }),
-   ('jupyter-server-proxy', '1.1.0', {
-        'req_py_majver': '3',
-        'req_py_minver': '6',
-        'use_pip': True,        
-        'source_urls': ['https://pypi.python.org/packages/source/j/jupyter-server-proxy/'],
+    ('jupyter-server-proxy', '1.1.0', {
+        'use_pip': True,
         }),
     ('dask_labextension', '1.0.3', {
-        'req_py_majver': '3',
-        'req_py_minver': '6',
-        'use_pip': True,        
-        'source_urls': ['https://pypi.python.org/packages/source/d/dask-labextension/'],
+        'use_pip': True,
         }),
-    
+
 # kernels
 # bash kernel, requires kernel install below, twr
     ('bash_kernel', '0.7.2', {
-        'req_py_majver': '3',
-        'req_py_minver': '6',
         'use_pip': True,
-        'source_urls': ['https://pypi.python.org/packages/source/b/bash_kernel/'],
         }),
-    
 ]
-
-# specify that Bundle easyblock should run a full sanity check, rather than just trying to load the module
-local_full_sanity_check = True
 
 # For Julia packages needed for Jupyter
 #twr julia_depot_path = "%(installdir)s/share/julia/site/"
 
 modextrapaths = {
-    'PYTHONPATH': ['lib/python%s/site-packages' % local_pyshortver],
+    'PYTHONPATH': ['lib/python%(pyshortver)s/site-packages'],
     'JUPYTER_PATH': 'share/jupyter',
 }
 
@@ -517,8 +279,8 @@ modextravars = {
 postinstallcmds = ["export YARN_CACHE_FOLDER=/tmp/$USER/yarn_cache;"
                    "export JUPYTERLAB_DIR=%(installdir)s/share/jupyter/lab/;"
                    "export PYTHONPATH=%(installdir)s/lib/python3.6/site-packages:$PYTHONPATH;"
-#                  "export JUPYTER_PATH=%(installdir)s/share/jupyter/;" 
-                   "export JUPYTER_DATA_DIR=%(installdir)s/share/jupyter/;" 
+#                  "export JUPYTER_PATH=%(installdir)s/share/jupyter/;"
+                   "export JUPYTER_DATA_DIR=%(installdir)s/share/jupyter/;"
                    "export JULIA_DEPOT_PATH=%(installdir)s/share/julia/site/;"
                    "export JUPYTER=%(installdir)s/bin/jupyter;"
                    "%(installdir)s/bin/jupyter-labextension install -y @jupyter-widgets/jupyterlab-manager@1.0 --no-build;"
@@ -548,7 +310,7 @@ postinstallcmds = ["export YARN_CACHE_FOLDER=/tmp/$USER/yarn_cache;"
                    ]
 sanity_check_paths = {
     'files': [],
-    'dirs': ['lib/python%s/site-packages' % local_pyshortver,
+    'dirs': ['lib/python%(pyshortver)s/site-packages',
              'share/jupyter/lab/extensions',
              'share/jupyter/lab/schemas',
              'share/jupyter/lab/staging',

--- a/easybuild/easyconfigs/j/jupyterlab/jupyterlab-1.2.4-CrayGNU-19.10-cuda-10.1-batchspawner.eb
+++ b/easybuild/easyconfigs/j/jupyterlab/jupyterlab-1.2.4-CrayGNU-19.10-cuda-10.1-batchspawner.eb
@@ -35,161 +35,78 @@ dependencies = [
 exts_default_options = {
     'req_py_majver': '%(pymajver)s',
     'req_py_minver': '%s' % _pyminver,
-    'source_urls': [PYPI_SOURCE]
+    'source_urls': [PYPI_SOURCE],
+    'use_pip': True,
 }
 
 exts_list = [
 
 #jupyterlab packages besides ipython and its deps
-    ('pyrsistent', '0.15.4', {
-        'use_pip': True,
-        }),
+    ('pyrsistent', '0.15.4'),
     ('attrs', '19.1.0', {
-        'use_pip': True,
         'modulename': 'attr',
         }),
-    ('jsonschema', '3.0.1', {
-        'use_pip': True,
-        }),
-    ('json5', '0.8.5', {
-        'use_pip': True,
-        }),
-    ('Send2Trash', '1.5.0', {
-        'use_pip': True,
-        }),
-    ('tornado', '6.0.3', {
-        'use_pip': True,
-        }),
+    ('jsonschema', '3.0.1'),
+    ('json5', '0.8.5'),
+    ('Send2Trash', '1.5.0'),
+    ('tornado', '6.0.3'),
     ('pyzmq', '18.0.2', {
-        'use_pip': True,
         'modulename': 'zmq',
         }),
     ('python-dateutil', '2.8.0', {
-        'use_pip': True,
+
         'modulename':  'dateutil',
         }),
-    ('jupyter_core', '4.5.0', {
-        'use_pip': True,
-        }),
-    ('jupyter_client', '5.3.1', {
-        'use_pip': True,
-        }),
-    ('MarkupSafe', '1.1.1', {
-        'use_pip': True,
-        }),
-    ('Jinja2', '2.10.1', {
-        'use_pip': True,
-        }),
-    ('webencodings', '0.5.1', {
-        'use_pip': True,
-        }),
-    ('bleach', '3.1.0', {
-        'use_pip': True,
-        }),
-    ('defusedxml', '0.6.0', {
-        'use_pip': True,
-        }),
-    ('entrypoints', '0.3', {
-        'use_pip': True,
-        }),
-    ('mistune', '0.8.4', {
-        'use_pip': True,
-        }),
-    ('nbformat', '4.4.0', {
-        'use_pip': True,
-        }),
-    ('pandocfilters', '1.4.2', {
-        'use_pip': True,
-        }),
-    ('testpath', '0.4.2', {
-        'use_pip': True,
-        }),
-    ('nbconvert', '5.5.0', {
-        'use_pip': True,
-        }),
-    ('prometheus_client', '0.7.1', {
-        'use_pip': True,
-        }),
-    ('terminado', '0.8.2', {
-        'use_pip': True,
-        }),
-    ('jupyterlab_server', '1.0.0', {
-        'use_pip': True,
-        }),
-    ('ipykernel', '5.1.1', {
-        'use_pip': True,
-        }),
-    ('notebook', '6.0.0', {
-        'use_pip': True,
-        }),
+    ('jupyter_core', '4.5.0'),
+    ('jupyter_client', '5.3.1'),
+    ('MarkupSafe', '1.1.1'),
+    ('Jinja2', '2.10.1'),
+    ('webencodings', '0.5.1'),
+    ('bleach', '3.1.0'),
+    ('defusedxml', '0.6.0'),
+    ('entrypoints', '0.3'),
+    ('mistune', '0.8.4'),
+    ('nbformat', '4.4.0'),
+    ('pandocfilters', '1.4.2'),
+    ('testpath', '0.4.2'),
+    ('nbconvert', '5.5.0'),
+    ('prometheus_client', '0.7.1'),
+    ('terminado', '0.8.2'),
+    ('jupyterlab_server', '1.0.0'),
+    ('ipykernel', '5.1.1'),
+    ('notebook', '6.0.0'),
     (name, version, {
-        'use_pip': True,
         'installopts': ' --install-option=--skip-npm ',
         }),
 
 # jupyterhub and its deps
-    ('SQLAlchemy', '1.3.6', {
-        'use_pip': True,
-        }),
-    ('Mako', '1.0.14', {
-        'use_pip': True,
-        }),
-    ('alembic', '1.0.11', {
-        'use_pip': True,
-        }),
+    ('SQLAlchemy', '1.3.6'),
+    ('Mako', '1.0.14'),
+    ('alembic', '1.0.11'),
     ('python-editor', '1.0.4', {
-        'use_pip': True,
+
         'modulename': 'editor',
         }),
-    ('async_generator', '1.10', {
-        'use_pip': True,
-        }),
-    ('pycparser', '2.19', {
-        'use_pip': True,
-        }),
+    ('async_generator', '1.10'),
+    ('pycparser', '2.19'),
     ('cffi', '1.12.3', {
         'use_pip': False,
         }),
-    ('asn1crypto', '0.24.0', {
-        'use_pip': True,
-        }),
-    ('cryptography', '2.7', {
-        'use_pip': True,
-        }),
+    ('asn1crypto', '0.24.0'),
+    ('cryptography', '2.7'),
     ('pyOpenSSL', '19.0.0', {
-        'use_pip': True,
         'modulename': "OpenSSL",
         }),
-    ('certipy', '0.1.3', {
-        'use_pip': True,
-        }),
-    ('entrypoints', '0.3', {
-        'use_pip': True,
-        }),
-    ('oauthlib', '3.0.2', {
-        'use_pip': True,
-        }),
-    ('pamela', '1.0.0', {
-        'use_pip': True,
-        }),
-    ('urllib3', '1.25.3', {
-        'use_pip': True,
-        }),
-    ('idna', '2.8', {
-        'use_pip': True,
-        }),
-    ('chardet', '3.0.4', {
-        'use_pip': True,
-        }),
-    ('certifi', '2019.6.16', {
-        'use_pip': True,
-        }),
-    ('requests', '2.22.0', {
-        'use_pip': True,
-        }),
-    ('jupyterhub', '1.0.0', {
-        'use_pip': True,
-        }),
+    ('certipy', '0.1.3'),
+    ('entrypoints', '0.3'),
+    ('oauthlib', '3.0.2'),
+    ('pamela', '1.0.0'),
+    ('urllib3', '1.25.3'),
+    ('idna', '2.8'),
+    ('chardet', '3.0.4'),
+    ('certifi', '2019.6.16'),
+    ('requests', '2.22.0'),
+    ('jupyterhub', '1.0.0'),
 
 # widgets: note the lab extensions below
     ('widgetsnbextension', '3.5.1'),
@@ -203,32 +120,26 @@ exts_list = [
     ('colorcet', '2.0.2'),
     ('zstandard', '0.13.0'),
     ('itk-core', '5.0.1', {
-        'use_pip': True,
         'source_tmpl': 'itk_core-%(version)s-cp36-cp36m-manylinux1_x86_64.whl',
         'unpack_sources': False,
         'modulename': 'itk',
         }),
     ('itk-numerics', '5.0.1', {
-        'use_pip': True,
         'source_tmpl': 'itk_numerics-%(version)s-cp36-cp36m-manylinux1_x86_64.whl',
         'unpack_sources': False,
         'modulename': 'itk'
         }),
     ('itk-filtering', '5.0.1', {
-        'use_pip': True,
         'source_tmpl': 'itk_filtering-%(version)s-cp36-cp36m-manylinux1_x86_64.whl',
         'unpack_sources': False,
         'modulename': 'itk'
         }),
     ('itk-meshtopolydata', '0.5.1', {
-        'use_pip': True,
         'source_tmpl': 'itk_meshtopolydata-%(version)s-cp36-cp36m-manylinux1_x86_64.whl',
         'unpack_sources': False,
         'modulename': 'itk'
         }),
-    ('ipydatawidgets', '4.0.1', {
-        'use_pip': True,
-        }),
+    ('ipydatawidgets', '4.0.1'),
     ('traittypes', '0.2.1'),
     ('itkwidgets', '0.25.0'),
 
@@ -262,60 +173,34 @@ exts_list = [
 
 # graphviz, for dask graph visualization
      ('graphviz', '0.12', {
-        'use_pip': True,
         'source_tmpl': 'graphviz-%(version)s.zip',
         }),
 
 # dask-labextension
 # This package provides a JupyterLab extension to manage Dask clusters,
 # as well as embed Dask's dashboard plots directly into JupyterLab panes
-    ('simpervisor', '0.3', {
-        'use_pip': True,
-        }),
-    ('multidict', '4.5.2', {
-        'use_pip': True,
-        }),
-    ('yarl', '1.3.0', {
-        'use_pip': True,
-        }),
-    ('typing_extensions', '3.7.4', {
-        'use_pip': True,
-        }),
-    ('async-timeout', '3.0.1', {
-        'use_pip': True,
-        }),
+    ('simpervisor', '0.3'),
+    ('multidict', '4.5.2'),
+    ('yarl', '1.3.0'),
+    ('typing_extensions', '3.7.4'),
+    ('async-timeout', '3.0.1'),
     ('idna-ssl', '1.1.0', {
-        'use_pip': True,
         'modulename': 'idna_ssl',
         }),
-   ('aiohttp', '3.5.4', {
-        'use_pip': True,
-        }),
-   ('jupyter-server-proxy', '1.1.0', {
-        'use_pip': True,
-        }),
-    ('dask_labextension', '1.0.3', {
-        'use_pip': True,
-        }),
+    ('aiohttp', '3.5.4'),
+    ('jupyter-server-proxy', '1.1.0'),
+    ('dask_labextension', '1.0.3'),
 
 # jupyterlab-nvdashboard, twr
 # A JupyterLab extension for displaying dashboards of GPU usage. From RAPIDS.
-   ('pynvml', '8.0.4', {
-        'use_pip': True,
-        }),
-    ('jupyterlab-nvdashboard', '0.1.11', {
-        'use_pip': True,
-        }),
+    ('pynvml', '8.0.4'),
+    ('jupyterlab-nvdashboard', '0.1.11'),
 
 
 # kernels
 # bash kernel, requires kernel install below, twr
-    ('bash_kernel', '0.7.2', {
-        'use_pip': True,
-        }),
-     ('batchspawner', '68a1fcd', {
-        'use_pip': True,
-        }),
+    ('bash_kernel', '0.7.2'),
+    ('batchspawner', '68a1fcd'),
 ]
 
 # For Julia packages needed for Jupyter

--- a/easybuild/easyconfigs/j/jupyterlab/jupyterlab-1.2.4-CrayGNU-19.10-cuda-10.1-batchspawner.eb
+++ b/easybuild/easyconfigs/j/jupyterlab/jupyterlab-1.2.4-CrayGNU-19.10-cuda-10.1-batchspawner.eb
@@ -1,18 +1,12 @@
 # @author: robinson (omlins and hvictor for IJulia)
 
-easyblock = 'Bundle'
+easyblock = 'PythonBundle'
 
 name = 'jupyterlab'
 version = '1.2.4'
 _cudaversion = '10.1'
 versionsuffix = '-cuda-%s-batchspawner' % _cudaversion
-
-_py_maj_ver = '3'
-_py_min_ver = '6'
-_py_rev_ver = '5.7'
-
-_pyver = '%s.%s.%s' % (_py_maj_ver, _py_min_ver, _py_rev_ver)
-_pyshortver = '%s.%s' % (_py_maj_ver, _py_min_ver)
+_pyminver = '6'
 
 _jl_maj_ver = '1'
 _jl_min_ver = '2'
@@ -28,585 +22,309 @@ toolchain = {'name': 'CrayGNU', 'version': '19.10'}
 toolchainopts = {'pic': True, 'verbose': False}
 
 dependencies = [
+    ('cray-python/3.6.5.7', EXTERNAL_MODULE),
     ('libffi', '3.2.1', '', True),
-    ('PyExtensions', _pyver),
-    ('IPython', '7.7.0', '-python%s' % _py_maj_ver),
+    ('PyExtensions', '%(pyver)s'),
+    ('IPython', '7.7.0', '-python%(pymajver)s'),
     ('JuliaExtensions', _jlver, '-cuda-%s' % _cudaversion),
     ('configurable-http-proxy', '3.1.1'),
-    ('dask', '2.2.0', '-python%s' % _py_maj_ver),
+    ('dask', '2.2.0', '-python%(pymajver)s'),
     ('graphviz', '2.40.1', '', True),
 ]
 
-# bundle of Python packages
-exts_defaultclass = 'PythonPackage'
+exts_default_options = {
+    'req_py_majver': '%(pymajver)s',
+    'req_py_minver': '%s' % _pyminver,
+    'source_urls': [PYPI_SOURCE]
+}
 
 exts_list = [
 
 #jupyterlab packages besides ipython and its deps
     ('pyrsistent', '0.15.4', {
-        'req_py_majver': '3',
-        'req_py_minver': '6',
         'use_pip': True,
-        'source_urls': ['https://pypi.python.org/packages/source/p/pyrsistent/'],
         }),
     ('attrs', '19.1.0', {
-        'req_py_majver': '3',
-        'req_py_minver': '6',
         'use_pip': True,
         'modulename': 'attr',
-        'source_urls': ['https://pypi.python.org/packages/source/a/attrs/'],
         }),
     ('jsonschema', '3.0.1', {
-        'req_py_majver': '3',
-        'req_py_minver': '6',
         'use_pip': True,
-        'source_urls': ['https://pypi.python.org/packages/source/j/jsonschema/'],
         }),
     ('json5', '0.8.5', {
-        'req_py_majver': '3',
-        'req_py_minver': '6',
         'use_pip': True,
-        'source_urls': ['https://pypi.python.org/packages/source/j/json5/'],
         }),
     ('Send2Trash', '1.5.0', {
-        'req_py_majver': '3',
-        'req_py_minver': '6',
         'use_pip': True,
-        'source_urls': ['https://pypi.python.org/packages/source/s/Send2Trash/'],
         }),
     ('tornado', '6.0.3', {
-        'req_py_majver': '3',
-        'req_py_minver': '6',
         'use_pip': True,
-        'source_urls': ['https://pypi.python.org/packages/source/t/tornado/'],
         }),
     ('pyzmq', '18.0.2', {
-        'req_py_majver': '3',
-        'req_py_minver': '6',
         'use_pip': True,
         'modulename': 'zmq',
-        'source_urls': ['https://pypi.python.org/packages/source/p/pyzmq/'],
         }),
     ('python-dateutil', '2.8.0', {
-        'req_py_majver': '3',
-        'req_py_minver': '6',
         'use_pip': True,
         'modulename':  'dateutil',
-        'source_urls': ['https://pypi.python.org/packages/source/p/python-dateutil/'],
         }),
     ('jupyter_core', '4.5.0', {
-        'req_py_majver': '3',
-        'req_py_minver': '6',
         'use_pip': True,
-        'source_urls': ['https://pypi.python.org/packages/source/j/jupyter_core/'],
         }),
     ('jupyter_client', '5.3.1', {
-        'req_py_majver': '3',
-        'req_py_minver': '6',
         'use_pip': True,
-        'source_urls': ['https://pypi.python.org/packages/source/j/jupyter_client/'],
         }),
     ('MarkupSafe', '1.1.1', {
-        'req_py_majver': '3',
-        'req_py_minver': '6',
         'use_pip': True,
-        'source_urls': ['https://pypi.python.org/packages/source/m/MarkupSafe/'],
         }),
     ('Jinja2', '2.10.1', {
-        'req_py_majver': '3',
-        'req_py_minver': '6',
         'use_pip': True,
-        'source_urls': ['https://pypi.python.org/packages/source/j/Jinja2/'],
         }),
     ('webencodings', '0.5.1', {
-        'req_py_majver': '3',
-        'req_py_minver': '6',
         'use_pip': True,
-        'source_urls': ['https://pypi.python.org/packages/source/w/webencodings/'],
         }),
     ('bleach', '3.1.0', {
-        'req_py_majver': '3',
-        'req_py_minver': '6',
         'use_pip': True,
-        'source_urls': ['https://pypi.python.org/packages/source/b/bleach/'],
         }),
     ('defusedxml', '0.6.0', {
-        'req_py_majver': '3',
-        'req_py_minver': '6',
         'use_pip': True,
-        'source_urls': ['https://pypi.python.org/packages/source/d/defusedxml/'],
         }),
     ('entrypoints', '0.3', {
-        'req_py_majver': '3',
-        'req_py_minver': '6',
         'use_pip': True,
-        'source_urls': ['https://pypi.python.org/packages/source/e/entrypoints/'],
         }),
     ('mistune', '0.8.4', {
-        'req_py_majver': '3',
-        'req_py_minver': '6',
         'use_pip': True,
-        'source_urls': ['https://pypi.python.org/packages/source/m/mistune/'],
         }),
     ('nbformat', '4.4.0', {
-        'req_py_majver': '3',
-        'req_py_minver': '6',
         'use_pip': True,
-        'source_urls': ['https://pypi.python.org/packages/source/n/nbformat/'],
         }),
     ('pandocfilters', '1.4.2', {
-        'req_py_majver': '3',
-        'req_py_minver': '6',
         'use_pip': True,
-        'source_urls': ['https://pypi.python.org/packages/source/p/pandocfilters/'],
         }),
     ('testpath', '0.4.2', {
-        'req_py_majver': '3',
-        'req_py_minver': '6',
         'use_pip': True,
-        'source_urls': ['https://pypi.python.org/packages/source/t/testpath/'],
         }),
     ('nbconvert', '5.5.0', {
-        'req_py_majver': '3',
-        'req_py_minver': '6',
         'use_pip': True,
-        'source_urls': ['https://pypi.python.org/packages/source/n/nbconvert/'],
         }),
     ('prometheus_client', '0.7.1', {
-        'req_py_majver': '3',
-        'req_py_minver': '6',
         'use_pip': True,
-        'source_urls': ['https://pypi.python.org/packages/source/p/prometheus_client/'],
         }),
     ('terminado', '0.8.2', {
-        'req_py_majver': '3',
-        'req_py_minver': '6',
         'use_pip': True,
-        'source_urls': ['https://pypi.python.org/packages/source/t/terminado/'],
         }),
     ('jupyterlab_server', '1.0.0', {
-        'req_py_majver': '3',
-        'req_py_minver': '6',
         'use_pip': True,
-        'source_urls': ['https://pypi.python.org/packages/source/j/jupyterlab_server/'],
         }),
     ('ipykernel', '5.1.1', {
-        'req_py_majver': '3',
-        'req_py_minver': '6',
         'use_pip': True,
-        'source_urls': ['https://pypi.python.org/packages/source/i/ipykernel/'],
         }),
     ('notebook', '6.0.0', {
-        'req_py_majver': '3',
-        'req_py_minver': '6',
         'use_pip': True,
-        'source_urls': ['https://pypi.python.org/packages/source/n/notebook/'],
         }),
     (name, version, {
-        'req_py_majver': '3',
-        'req_py_minver': '6',
         'use_pip': True,
         'installopts': ' --install-option=--skip-npm ',
-        'source_urls': ['https://pypi.python.org/packages/source/j/jupyterlab/'],
         }),
 
 # jupyterhub and its deps
     ('SQLAlchemy', '1.3.6', {
-        'req_py_majver': '3',
-        'req_py_minver': '6',
         'use_pip': True,
-        'source_urls': ['https://pypi.python.org/packages/source/s/SQLAlchemy/'],
         }),
     ('Mako', '1.0.14', {
-        'req_py_majver': '3',
-        'req_py_minver': '6',
         'use_pip': True,
-        'source_urls': ['https://pypi.python.org/packages/source/m/Mako/'],
         }),
     ('alembic', '1.0.11', {
-        'req_py_majver': '3',
-        'req_py_minver': '6',
         'use_pip': True,
-        'source_urls': ['https://pypi.python.org/packages/source/a/alembic/'],
         }),
     ('python-editor', '1.0.4', {
-        'req_py_majver': '3',
-        'req_py_minver': '6',
         'use_pip': True,
         'modulename': 'editor',
-        'source_urls': ['https://pypi.python.org/packages/source/p/python-editor/'],
         }),
     ('async_generator', '1.10', {
-        'req_py_majver': '3',
-        'req_py_minver': '6',
         'use_pip': True,
-        'source_urls': ['https://pypi.python.org/packages/source/a/async_generator/'],
         }),
     ('pycparser', '2.19', {
-        'req_py_majver': '3',
-        'req_py_minver': '6',
         'use_pip': True,
-        'source_urls': ['https://pypi.python.org/packages/source/p/pycparser/'],
         }),
     ('cffi', '1.12.3', {
-        'req_py_majver': '3',
-        'req_py_minver': '6',
         'use_pip': False,
-        'source_urls': ['https://pypi.python.org/packages/source/c/cffi/'],
         }),
     ('asn1crypto', '0.24.0', {
-        'req_py_majver': '3',
-        'req_py_minver': '6',
         'use_pip': True,
-        'source_urls': ['https://pypi.python.org/packages/source/a/asn1crypto/'],
         }),
     ('cryptography', '2.7', {
-        'req_py_majver': '3',
-        'req_py_minver': '6',
         'use_pip': True,
-        'source_urls': ['https://pypi.python.org/packages/source/c/cryptography/'],
         }),
     ('pyOpenSSL', '19.0.0', {
-        'req_py_majver': '3',
-        'req_py_minver': '6',
         'use_pip': True,
         'modulename': "OpenSSL",
-        'source_urls': ['https://pypi.python.org/packages/source/p/pyOpenSSL/'],
         }),
     ('certipy', '0.1.3', {
-        'req_py_majver': '3',
-        'req_py_minver': '6',
         'use_pip': True,
-        'source_urls': ['https://pypi.python.org/packages/source/c/certipy/'],
         }),
     ('entrypoints', '0.3', {
-        'req_py_majver': '3',
-        'req_py_minver': '6',
         'use_pip': True,
-        'source_urls': ['https://pypi.python.org/packages/source/e/entrypoint/'],
         }),
     ('oauthlib', '3.0.2', {
-        'req_py_majver': '3',
-        'req_py_minver': '6',
         'use_pip': True,
-        'source_urls': ['https://pypi.python.org/packages/source/o/oauthlib/'],
         }),
     ('pamela', '1.0.0', {
-        'req_py_majver': '3',
-        'req_py_minver': '6',
         'use_pip': True,
-        'source_urls': ['https://pypi.python.org/packages/source/p/pamela/'],
         }),
     ('urllib3', '1.25.3', {
-        'req_py_majver': '3',
-        'req_py_minver': '6',
         'use_pip': True,
-        'source_urls': ['https://pypi.python.org/packages/source/u/urllib3/'],
         }),
     ('idna', '2.8', {
-        'req_py_majver': '3',
-        'req_py_minver': '6',
         'use_pip': True,
-        'source_urls': ['https://pypi.python.org/packages/source/i/idna/'],
         }),
     ('chardet', '3.0.4', {
-        'req_py_majver': '3',
-        'req_py_minver': '6',
         'use_pip': True,
-        'source_urls': ['https://pypi.python.org/packages/source/c/chardet/'],
         }),
     ('certifi', '2019.6.16', {
-        'req_py_majver': '3',
-        'req_py_minver': '6',
         'use_pip': True,
-        'source_urls': ['https://pypi.python.org/packages/source/c/certifi/'],
         }),
     ('requests', '2.22.0', {
-        'req_py_majver': '3',
-        'req_py_minver': '6',
         'use_pip': True,
-        'source_urls': ['https://pypi.python.org/packages/source/r/requests/'],
         }),
     ('jupyterhub', '1.0.0', {
-        'req_py_majver': '3',
-        'req_py_minver': '6',
         'use_pip': True,
-        'source_urls': ['https://pypi.python.org/packages/source/j/jupyterhub/'],
         }),
 
 # widgets: note the lab extensions below
-    ('widgetsnbextension', '3.5.1', {
-        'req_py_majver': '3',
-        'req_py_minver': '6',
-        'source_urls': ['https://pypi.python.org/packages/source/w/widgetsnbextension/'],
-        }),
-    ('ipywidgets', '7.5.1', {
-        'req_py_majver': '3',
-        'req_py_minver': '6',
-        'source_urls': ['https://pypi.python.org/packages/source/i/ipywidgets/'],
-        }),
-# ipympl matplotlib widgets, requires lab extension 
-    ('ipympl', '0.3.3', {
-        'req_py_majver': '3',
-        'req_py_minver': '6',
-        'source_urls': ['https://pypi.python.org/packages/source/i/ipympl/'],
-        }),
+    ('widgetsnbextension', '3.5.1'),
+    ('ipywidgets', '7.5.1'),
+# ipympl matplotlib widgets, requires lab extension
+    ('ipympl', '0.3.3'),
 
 # itkwidgets
-    ('param', '1.9.2', {
-        'req_py_majver': '3',
-        'req_py_minver': '6',
-        'source_urls': ['https://pypi.python.org/packages/source/p/param/'],
-        }),
-    ('pyct', '0.4.6', {
-        'req_py_majver': '3',
-        'req_py_minver': '6',
-        'source_urls': ['https://pypi.python.org/packages/source/p/pyct/'],
-        }),
-    ('colorcet', '2.0.2', {
-        'req_py_majver': '3',
-        'req_py_minver': '6',
-        'source_urls': ['https://pypi.python.org/packages/source/c/colorcet/'],
-        }),
-    ('zstandard', '0.13.0', {
-        'req_py_majver': '3',
-        'req_py_minver': '6',
-        'source_urls': ['https://pypi.python.org/packages/source/z/zstandard/'],
-        }),
+    ('param', '1.9.2'),
+    ('pyct', '0.4.6'),
+    ('colorcet', '2.0.2'),
+    ('zstandard', '0.13.0'),
     ('itk-core', '5.0.1', {
-        'req_py_majver': '3',
-        'req_py_minver': '6',
         'use_pip': True,
         'source_tmpl': 'itk_core-%(version)s-cp36-cp36m-manylinux1_x86_64.whl',
         'unpack_sources': False,
-        'source_urls': ['https://pypi.python.org/packages/source/i/itk-core/'],
         'modulename': 'itk',
         }),
     ('itk-numerics', '5.0.1', {
-        'req_py_majver': '3',
-        'req_py_minver': '6',
         'use_pip': True,
         'source_tmpl': 'itk_numerics-%(version)s-cp36-cp36m-manylinux1_x86_64.whl',
         'unpack_sources': False,
-        'source_urls': ['https://pypi.python.org/packages/source/i/itk-numerics/'],
         'modulename': 'itk'
         }),
     ('itk-filtering', '5.0.1', {
-        'req_py_majver': '3',
-        'req_py_minver': '6',
         'use_pip': True,
         'source_tmpl': 'itk_filtering-%(version)s-cp36-cp36m-manylinux1_x86_64.whl',
         'unpack_sources': False,
-        'source_urls': ['https://pypi.python.org/packages/source/i/itk-filtering/'],
         'modulename': 'itk'
         }),
     ('itk-meshtopolydata', '0.5.1', {
-        'req_py_majver': '3',
-        'req_py_minver': '6',
         'use_pip': True,
         'source_tmpl': 'itk_meshtopolydata-%(version)s-cp36-cp36m-manylinux1_x86_64.whl',
         'unpack_sources': False,
-        'source_urls': ['https://pypi.python.org/packages/source/i/itk-meshtopolydata/'],
         'modulename': 'itk'
         }),
     ('ipydatawidgets', '4.0.1', {
-        'req_py_majver': '3',
-        'req_py_minver': '6',
         'use_pip': True,
-        'source_urls': ['https://pypi.python.org/packages/source/i/ipydatawidgets/'],
         }),
-    ('itkwidgets', '0.25.0', {
-        'req_py_majver': '3',
-        'req_py_minver': '6',
-        'source_urls': ['https://pypi.python.org/packages/source/i/itkwidgets/'],
-        }),
-    
-    
+    ('traittypes', '0.2.1'),
+    ('itkwidgets', '0.25.0'),
+
+
 # plotly, requires the lab extension below
-    ('retrying', '1.3.3', {
-        'req_py_majver': '3',
-        'req_py_minver': '6',
-        'source_urls': ['https://pypi.python.org/packages/source/r/retrying/'],
-        }),
-    ('plotly', '4.0.0', {
-        'req_py_majver': '3',
-        'req_py_minver': '6',
-        'source_urls': ['https://pypi.python.org/packages/source/p/plotly/'],
-        }),
+    ('retrying', '1.3.3'),
+    ('plotly', '4.0.0'),
 
 # bokeh, requires the labextension below
     ('PyYAML', '5.1.2', {
-        'req_py_majver': '3',
-        'req_py_minver': '6',
         'modulename': 'yaml',
-        'source_urls': ['https://pypi.python.org/packages/source/p/PyYAML/'],
         }),
-    ('bokeh', '1.3.4', {
-        'req_py_majver': '3',
-        'req_py_minver': '6',
-        'source_urls': ['https://pypi.python.org/packages/source/b/bokeh/'],
-        }),
-    ('packaging', '19.1', {
-        'req_py_majver': '3',
-        'req_py_minver': '6',
-        'source_urls': ['https://pypi.python.org/packages/source/p/packaging/'],
-        }),
+    ('bokeh', '1.3.4'),
+    ('packaging', '19.1'),
     ('Pillow', '6.1.0', {
-        'req_py_majver': '3',
-        'req_py_minver': '6',
         'modulename': 'PIL',
-        'source_urls': ['https://pypi.python.org/packages/source/p/Pillow/'],
-        }),    
-    
+        }),
+
 # bqplot: requires the labextension below
-    ('traittypes', '0.2.1', {
-        'req_py_majver': '3',
-        'req_py_minver': '6',
-        'source_urls': ['https://pypi.python.org/packages/source/t/traittypes/'],
-        }),
-    ('bqplot', '0.11.6', {
-        'req_py_majver': '3',
-        'req_py_minver': '6',
-        'source_urls': ['https://pypi.python.org/packages/source/b/bqplot/'],
-        }),
+    ('bqplot', '0.11.6'),
 
 # nbresuse for jupyterlab-system-monitor extension
-    ('psutil', '5.6.3', {
-        'req_py_majver': '3',
-        'req_py_minver': '6',
-        'source_urls': ['https://pypi.python.org/packages/source/p/psutil/'],
-        }),
-    ('nbresuse', '0.3.2', {
-       'req_py_majver': '3',
-        'req_py_minver': '6',
-        'source_urls': ['https://pypi.python.org/packages/source/n/nbresuse/'],
-        }),
+    ('psutil', '5.6.3'),
+    ('nbresuse', '0.3.2'),
 
 # jupyterlab-slrum extension to implement common slurm commands in the notebook, not yet supported with JLab 1.x
-#    ('jupyterlab_slurm', '0.1.1', {
-#        'req_py_majver': '3',
-#        'req_py_minver': '6',
-#        'source_urls': ['https://pypi.python.org/packages/source/j/jupyterlab-slurm/'],
-#        }),
+#    ('jupyterlab_slurm', '0.1.1'),
 
 # qgrid widgets: note that 1.1.1 is not yet supported with JupyterLab 1.x - commented for now, twr
-#    ('qgrid', '1.1.1', {
-#        'req_py_majver': '3',
-#        'req_py_minver': '6',
-#        'source_urls': ['https://pypi.python.org/packages/source/q/qgrid/'],
-#        }),
+#    ('qgrid', '1.1.1'),
 
 # graphviz, for dask graph visualization
      ('graphviz', '0.12', {
-         'req_py_majver': '3',
-         'req_py_minver': '6',
-         'use_pip': True,
-         'source_urls': ['https://pypi.python.org/packages/source/g/graphviz/'],
-         'source_tmpl': 'graphviz-%(version)s.zip',
-         }),
+        'use_pip': True,
+        'source_tmpl': 'graphviz-%(version)s.zip',
+        }),
 
 # dask-labextension
-# This package provides a JupyterLab extension to manage Dask clusters, 
-# as well as embed Dask's dashboard plots directly into JupyterLab panes    
+# This package provides a JupyterLab extension to manage Dask clusters,
+# as well as embed Dask's dashboard plots directly into JupyterLab panes
     ('simpervisor', '0.3', {
-        'req_py_majver': '3',
-        'req_py_minver': '6',
-        'use_pip': True,        
-        'source_urls': ['https://pypi.python.org/packages/source/s/simpervisor/'],
+        'use_pip': True,
         }),
     ('multidict', '4.5.2', {
-        'req_py_majver': '3',
-        'req_py_minver': '6',
-        'use_pip': True,        
-        'source_urls': ['https://pypi.python.org/packages/source/m/multidict/'],
+        'use_pip': True,
         }),
     ('yarl', '1.3.0', {
-        'req_py_majver': '3',
-        'req_py_minver': '6',
-        'use_pip': True, 
-        'source_urls': ['https://pypi.python.org/packages/source/y/yarl/'],
+        'use_pip': True,
         }),
     ('typing_extensions', '3.7.4', {
-        'req_py_majver': '3',
-        'req_py_minver': '6',
-        'use_pip': True,        
-        'source_urls': ['https://pypi.python.org/packages/source/t/typing_extensions/'],
+        'use_pip': True,
         }),
     ('async-timeout', '3.0.1', {
-        'req_py_majver': '3',
-        'req_py_minver': '6',
-        'use_pip': True,        
-        'source_urls': ['https://pypi.python.org/packages/source/a/async-timeout/'],
+        'use_pip': True,
         }),
     ('idna-ssl', '1.1.0', {
-        'req_py_majver': '3',
-        'req_py_minver': '6',
-        'use_pip': True,        
+        'use_pip': True,
         'modulename': 'idna_ssl',
-        'source_urls': ['https://pypi.python.org/packages/source/i/idna-ssl/'],
         }),
    ('aiohttp', '3.5.4', {
-        'req_py_majver': '3',
-        'req_py_minver': '6',
-        'use_pip': True,        
-        'source_urls': ['https://pypi.python.org/packages/source/a/aiohttp/'],
+        'use_pip': True,
         }),
    ('jupyter-server-proxy', '1.1.0', {
-        'req_py_majver': '3',
-        'req_py_minver': '6',
-        'use_pip': True,        
-        'source_urls': ['https://pypi.python.org/packages/source/j/jupyter-server-proxy/'],
+        'use_pip': True,
         }),
     ('dask_labextension', '1.0.3', {
-        'req_py_majver': '3',
-        'req_py_minver': '6',
-        'use_pip': True,        
-        'source_urls': ['https://pypi.python.org/packages/source/d/dask-labextension/'],
+        'use_pip': True,
         }),
 
 # jupyterlab-nvdashboard, twr
 # A JupyterLab extension for displaying dashboards of GPU usage. From RAPIDS.
    ('pynvml', '8.0.4', {
-        'req_py_majver': '3',
-        'req_py_minver': '6',
-        'use_pip': True,        
-        'source_urls': ['https://pypi.python.org/packages/source/p/pynvml/'],
+        'use_pip': True,
         }),
     ('jupyterlab-nvdashboard', '0.1.11', {
-        'req_py_majver': '3',
-        'req_py_minver': '6',
-        'use_pip': True,        
-        'source_urls': ['https://pypi.python.org/packages/source/j/jupyterlab-nvdashboard/'],
+        'use_pip': True,
         }),
 
 
 # kernels
 # bash kernel, requires kernel install below, twr
     ('bash_kernel', '0.7.2', {
-        'req_py_majver': '3',
-        'req_py_minver': '6',
         'use_pip': True,
-        'source_urls': ['https://pypi.python.org/packages/source/b/bash_kernel/'],
         }),
      ('batchspawner', '68a1fcd', {
-        'req_py_majver': '3',
-        'req_py_minver': '6',
         'use_pip': True,
-        'source_urls': ['https://github.com/jupyterhub/batchspawner/tarball/68a1fcd'],
         }),
 ]
-
-# specify that Bundle easyblock should run a full sanity check, rather than just trying to load the module
-_full_sanity_check = True
 
 # For Julia packages needed for Jupyter
 _ijulia_depot = "%(installdir)s/share/IJulia"
 _ijulia_projectdir = "%s/environments/$EBJULIA_ENV_NAME" % _ijulia_depot
 _ijulia_projectdir_tcl = "%s/environments/$::env(EBJULIA_ENV_NAME)" % _ijulia_depot
 
-
 modextrapaths = {
-    'PYTHONPATH': ['lib/python%s/site-packages' % _pyshortver],
+    'PYTHONPATH': ['lib/python%(pyshortver)s/site-packages'],
     'JUPYTER_PATH': 'share/jupyter',
 }
 
@@ -652,10 +370,10 @@ rm -r $YARN_CACHE_FOLDER;
 # Bash kernel - https://github.com/takluyver/bash_kernel
 python3 -m bash_kernel.install --prefix=%%(installdir)s/;
 # new batchspawner requires compute side components, TWR 121219
-#git clone https://github.com/jupyterhub/batchspawner.git %%(builddir)s/batchspawner && 
-#cd %%(builddir)s/batchspawner && 
-#git checkout 68a1fcd3524f8990ba465fae4226da34f1e926b7 && 
-#pip install . --prefix=%%(installdir)s 
+#git clone https://github.com/jupyterhub/batchspawner.git %%(builddir)s/batchspawner &&
+#cd %%(builddir)s/batchspawner &&
+#git checkout 68a1fcd3524f8990ba465fae4226da34f1e926b7 &&
+#pip install . --prefix=%%(installdir)s
 # IJulia kernel - https://github.com/JuliaLang/IJulia.jl
 # installs ijulia in JULIA_DEPOT_PATH and kernel in $JUPYTER_DATA_DIR/kernels
 unset EBJULIA_USER_DEPOT_PATH;
@@ -670,7 +388,7 @@ file=%%(installdir)s/share/jupyter/kernels/julia-%s/kernel.json; cp $file ${file
 
 sanity_check_paths = {
     'files': [],
-    'dirs': ['lib/python%s/site-packages' % _pyshortver,
+    'dirs': ['lib/python%(pyshortver)s/site-packages',
              'share/jupyter/lab/extensions',
              'share/jupyter/lab/schemas',
              'share/jupyter/lab/staging',

--- a/easybuild/easyconfigs/l/LAMMPS/LAMMPS-22Aug2018-CrayGNU-19.10-cuda-10.1.eb
+++ b/easybuild/easyconfigs/l/LAMMPS/LAMMPS-22Aug2018-CrayGNU-19.10-cuda-10.1.eb
@@ -4,13 +4,7 @@ easyblock = 'MakeCp'
 name = 'LAMMPS'
 version = '22Aug18'
 local_release = 'stable_22Aug2018'
-local_cudaversion =  '10.1'
-versionsuffix = '-cuda-%s' % local_cudaversion
-local_py_maj_ver = '2'
-local_py_min_ver = '7'
-local_py_rev_ver = '15.7'
-local_pyshortver = "%s.%s" % (local_py_maj_ver, local_py_min_ver)
-local_pyver      = "%s.%s.%s" % (local_py_maj_ver, local_py_min_ver, local_py_rev_ver)
+versionsuffix = '-cuda-%(cudashortver)s'
 
 homepage = 'http://lammps.sandia.gov/'
 description = "LAMMPS (Large-scale Atomic/Molecular Massively Parallel Simulator) is a classical molecular dynamics simulation code designed to run efficiently on parallel computers."
@@ -35,10 +29,13 @@ prebuildopts += ' sed -e \'s/mpicxx/CC -fopenmp/\' ./MAKE/Makefile.mpi > ./MAKE/
 prebuildopts += ' sed -i -e \'s/mpicxx/CC/\' ./MAKE/Makefile.mpi && '
 buildopts = [ ' mpi ', ' omp ' ]
 
+dependencies = [
+    ('cudatoolkit/10.1.105_3.27-7.0.1.1_4.1__ga311ce7', EXTERNAL_MODULE),
+]
+
 builddependencies = [
-    (('cudatoolkit/10.1.105_3.27-7.0.1.1_4.1__ga311ce7', EXTERNAL_MODULE)),
     ('cray-fftw', EXTERNAL_MODULE),
-    ('cray-python/%s' %local_pyver, EXTERNAL_MODULE),
+    ('cray-python/2.7.15.7', EXTERNAL_MODULE),
 ]
 
 files_to_copy = [(['src/lmp*'], "bin")]

--- a/easybuild/easyconfigs/l/LAMMPS/LAMMPS-22Aug2018-CrayGNU-19.10.eb
+++ b/easybuild/easyconfigs/l/LAMMPS/LAMMPS-22Aug2018-CrayGNU-19.10.eb
@@ -4,11 +4,6 @@ easyblock = 'MakeCp'
 name = 'LAMMPS'
 version = '22Aug18'
 local_release = 'stable_22Aug2018'
-local_py_maj_ver = '2'
-local_py_min_ver = '7'
-local_py_rev_ver = '15.7'
-local_pyshortver = "%s.%s" % (local_py_maj_ver, local_py_min_ver)
-local_pyver      = "%s.%s.%s" % (local_py_maj_ver, local_py_min_ver, local_py_rev_ver)
 
 homepage = 'http://lammps.sandia.gov/'
 description = "LAMMPS (Large-scale Atomic/Molecular Massively Parallel Simulator) is a classical molecular dynamics simulation code designed to run efficiently on parallel computers."
@@ -32,7 +27,7 @@ buildopts = [ ' mpi ', ' omp ' ]
 
 builddependencies = [
     ('cray-fftw', EXTERNAL_MODULE),
-    ('cray-python/%s' %local_pyver, EXTERNAL_MODULE),
+    ('cray-python/2.7.15.7', EXTERNAL_MODULE),
 ]
 
 files_to_copy = [(['src/lmp*'], "bin")]

--- a/easybuild/easyconfigs/l/line_profiler/line_profiler-2.1-CrayGNU-19.10-python3.eb
+++ b/easybuild/easyconfigs/l/line_profiler/line_profiler-2.1-CrayGNU-19.10-python3.eb
@@ -4,15 +4,7 @@ easyblock = 'PythonPackage'
 name = 'line_profiler'
 version = '2.1'
 
-local_py_maj_ver = '3'
-local_py_min_ver = '6'
-local_py_rev_ver = '5.7'
-req_py_majver = local_py_maj_ver
-req_py_minver = local_py_min_ver
-local_pyver = '%s.%s.%s' % (local_py_maj_ver, local_py_min_ver, local_py_rev_ver)
-local_pyshortver = '%s.%s' % (local_py_maj_ver, local_py_min_ver)
-
-versionsuffix = '-python%s' % (local_py_maj_ver)
+versionsuffix = '-python%(pymajver)s'
 
 homepage = 'https://github.com/rkern/line_profiler'
 description = """Line-by-line profiler for Python"""
@@ -23,13 +15,16 @@ toolchainopts = {'verbose': False}
 source_urls = ['https://github.com/rkern/%(name)s/archive']
 sources = ['%(version)s.tar.gz']
 
-dependencies = [ ('PyExtensions', local_pyver) ] # Cython
+dependencies = [
+    ('cray-python/3.6.5.7', EXTERNAL_MODULE),
+    ('PyExtensions', '%(pyver)s')
+] # Cython
 
 sanity_check_paths = {
     'files': [],
     'dirs': [(
-        'lib/python%(pv)s/site-packages/%%(name)s-%%(version)s-py%(pv)s'
-        '-linux-x86_64.egg' % {'pv': local_pyshortver}
+        'lib/python%(pyshortver)s/site-packages/%(name)s-%(version)s-py%(pyshortver)s'
+        '-linux-x86_64.egg'
     )],
 }
 

--- a/easybuild/easyconfigs/m/Mako/Mako-1.0.7-CrayGNU-19.10-Python-3.6.eb
+++ b/easybuild/easyconfigs/m/Mako/Mako-1.0.7-CrayGNU-19.10-Python-3.6.eb
@@ -3,15 +3,15 @@ easyblock = 'PythonPackage'
 name = 'Mako'
 version = '1.0.7'
 
-local_py_maj_ver = '3'
-local_py_min_ver = '6'
-local_py_rev_ver = '5.7'
+# local_py_maj_ver = '3'
+# local_py_min_ver = '6'
+# local_py_rev_ver = '5.7'
 
-local_pyver = '%s.%s.%s' % (local_py_maj_ver, local_py_min_ver, local_py_rev_ver)
-local_pyshortver = '%s.%s' % (local_py_maj_ver, local_py_min_ver)
-local_pysuff = '-python%s' % local_py_maj_ver
+# local_pyver = '%s.%s.%s' % (local_py_maj_ver, local_py_min_ver, local_py_rev_ver)
+# local_pyshortver = '%s.%s' % (local_py_maj_ver, local_py_min_ver)
+# local_pysuff = '-python%s' % local_py_maj_ver
 
-versionsuffix = '-Python-%s' % (local_pyshortver)
+versionsuffix = '-Python-%(pyshortver)s'
 
 homepage = 'http://www.makotemplates.org'
 description = """A super-fast templating language that borrows the best ideas from the existing templating languages"""
@@ -23,7 +23,7 @@ sources = [SOURCE_TAR_GZ]
 
 
 dependencies = [
-    ('cray-python/%s' % local_pyver, EXTERNAL_MODULE)
+    ('cray-python/3.6.5.7', EXTERNAL_MODULE)
 ]
 
 sanity_check_paths = {

--- a/easybuild/easyconfigs/m/Mako/Mako-1.0.7-CrayGNU-19.10-Python-3.6.eb
+++ b/easybuild/easyconfigs/m/Mako/Mako-1.0.7-CrayGNU-19.10-Python-3.6.eb
@@ -3,14 +3,6 @@ easyblock = 'PythonPackage'
 name = 'Mako'
 version = '1.0.7'
 
-# local_py_maj_ver = '3'
-# local_py_min_ver = '6'
-# local_py_rev_ver = '5.7'
-
-# local_pyver = '%s.%s.%s' % (local_py_maj_ver, local_py_min_ver, local_py_rev_ver)
-# local_pyshortver = '%s.%s' % (local_py_maj_ver, local_py_min_ver)
-# local_pysuff = '-python%s' % local_py_maj_ver
-
 versionsuffix = '-Python-%(pyshortver)s'
 
 homepage = 'http://www.makotemplates.org'

--- a/easybuild/easyconfigs/m/Mako/Mako-1.1.2-CrayGNU-19.10-python3.eb
+++ b/easybuild/easyconfigs/m/Mako/Mako-1.1.2-CrayGNU-19.10-python3.eb
@@ -3,11 +3,8 @@ easyblock = 'PythonPackage'
 
 name = 'Mako'
 version = '1.1.2'
-req_py_majver = '3'
-req_py_minver = '6'
-local_py_rev_ver = '5.7'
-local_pyver = '%s.%s' % (req_py_majver, req_py_minver)
-versionsuffix = '-python%s' % req_py_majver
+
+versionsuffix = '-python%(pymajver)s'
 
 homepage = 'http://www.makotemplates.org'
 description = """A super-fast templating language that borrows the best ideas
@@ -18,7 +15,7 @@ sources = [SOURCE_TAR_GZ]
 
 dependencies = [
     # ('PyExtensions', '%s.%s' % (local_pyver, local_py_rev_ver)),
-    ('cray-python/%s.%s' % (local_pyver, local_py_rev_ver), EXTERNAL_MODULE)
+    ('cray-python/3.6.5.7', EXTERNAL_MODULE)
 ]
 
 sanity_check_paths = {

--- a/easybuild/easyconfigs/m/magma/magma-2.4.0-CrayIntel-19.10-cuda-10.1.eb
+++ b/easybuild/easyconfigs/m/magma/magma-2.4.0-CrayIntel-19.10-cuda-10.1.eb
@@ -4,8 +4,7 @@ easyblock = 'MakeCp'
 
 name = 'magma'
 version = '2.4.0'
-local_cudaversion = 10.1
-versionsuffix = '-cuda-%s' % local_cudaversion
+versionsuffix = '-cuda-%(cudashortver)s'
 
 homepage = 'http://icl.cs.utk.edu/magma/'
 description = """The MAGMA project aims to develop a dense linear algebra

--- a/easybuild/easyconfigs/n/NAMD/NAMD-2.13-CrayIntel-19.10-cuda-10.1.eb
+++ b/easybuild/easyconfigs/n/NAMD/NAMD-2.13-CrayIntel-19.10-cuda-10.1.eb
@@ -3,8 +3,7 @@ easyblock = 'MakeCp'
 
 name = 'NAMD'
 version = '2.13'
-local_cudaversion = '10.1'
-versionsuffix = '-cuda-%s' % local_cudaversion
+versionsuffix = '-cuda-%(cudashortver)s'
 
 homepage = 'http://www.ks.uiuc.edu/Research/namd/'
 description = """NAMD is a parallel molecular dynamics code designed for
@@ -32,9 +31,9 @@ builddependencies = [
     ('Tcl', '8.6.7'),
     ('cray-fftw', EXTERNAL_MODULE),
     ('craype-hugepages8M', EXTERNAL_MODULE),
-    ('cudatoolkit/10.1.105_3.27-7.0.1.1_4.1__ga311ce7', EXTERNAL_MODULE),
 ]
 dependencies = [
+    ('cudatoolkit/10.1.105_3.27-7.0.1.1_4.1__ga311ce7', EXTERNAL_MODULE),
     ('craype-accel-nvidia60', EXTERNAL_MODULE)
 ]
 

--- a/easybuild/easyconfigs/n/netcdf4-python/netcdf-python-1.4.1-CrayGNU-19.10-python2.eb
+++ b/easybuild/easyconfigs/n/netcdf4-python/netcdf-python-1.4.1-CrayGNU-19.10-python2.eb
@@ -1,4 +1,3 @@
-#
 name = 'netcdf-python'
 version = '1.4.1'
 
@@ -11,23 +10,17 @@ toolchainopts = {'verbose': False}
 source_urls = ['https://pypi.python.org/packages/source/n/netCDF4/']
 sources = ['netCDF4-%(version)s.tar.gz']
 
-local_py_maj_ver = '2'
-local_py_min_ver = '7'
-local_py_rev_ver = '15.7'
-local_pyver = '%s.%s.%s' % (local_py_maj_ver, local_py_min_ver, local_py_rev_ver)
-local_pyshortver = '%s.%s' % (local_py_maj_ver, local_py_min_ver)
-local_pysuff = '-python%s' % local_py_maj_ver
-
-versionsuffix = local_pysuff
+versionsuffix = '-python%(pymajver)s'
 dependencies = [
-    ('cray-python/%s' % local_pyver, EXTERNAL_MODULE),
+    ('cray-python/2.7.15.7', EXTERNAL_MODULE),
     ('cray-netcdf', EXTERNAL_MODULE),
     ('cray-hdf5', EXTERNAL_MODULE),
-    ('cftime', '1.0.0', local_pysuff),
+    ('cftime', '1.0.0', '-python%(pymajver)s'),
 ]
 
 sanity_check_paths = {
-    'files': ['bin/nc3tonc4', 'bin/nc4tonc3', 'bin/ncinfo', 'lib/python%(pv)s/site-packages/netCDF4-%%(version)s-py%(pv)s-linux-x86_64.egg' % {'pv': local_pyshortver}],
+    'files': ['bin/nc3tonc4', 'bin/nc4tonc3', 'bin/ncinfo',
+              'lib/python%(pyshortver)s/site-packages/netCDF4-%(version)s-py%(pyshortver)s-linux-x86_64.egg'],
     'dirs': []
 }
 

--- a/easybuild/easyconfigs/n/netcdf4-python/netcdf-python-1.4.1-CrayGNU-19.10-python3.eb
+++ b/easybuild/easyconfigs/n/netcdf4-python/netcdf-python-1.4.1-CrayGNU-19.10-python3.eb
@@ -1,4 +1,3 @@
-#
 name = 'netcdf-python'
 version = '1.4.1'
 
@@ -11,25 +10,18 @@ toolchainopts = {'verbose': False}
 source_urls = ['https://pypi.python.org/packages/source/n/netCDF4/']
 sources = ['netCDF4-%(version)s.tar.gz']
 
-local_py_maj_ver = '3'
-local_py_min_ver = '6'
-local_py_rev_ver = '5.7'
-local_pyver = '%s.%s.%s' % (local_py_maj_ver, local_py_min_ver, local_py_rev_ver)
-local_pyshortver = '%s.%s' % (local_py_maj_ver, local_py_min_ver)
-local_pysuff = '-python%s' % local_py_maj_ver
-
-versionsuffix = local_pysuff
+versionsuffix = '-python%(pymajver)s'
 dependencies = [
-    ('cray-python/%s' % local_pyver, EXTERNAL_MODULE),
-    ('PyExtensions', '%s' % local_pyver),
+    ('cray-python/3.6.5.7', EXTERNAL_MODULE),
+    ('PyExtensions', '%(pyver)s'),
     ('cray-netcdf', EXTERNAL_MODULE),
     ('cray-hdf5', EXTERNAL_MODULE),
-    ('cftime', '1.0.2.1', local_pysuff),
+    ('cftime', '1.0.2.1', '-python%(pymajver)s'),
 ]
 
 sanity_check_paths = {
     'files': ['bin/nc3tonc4', 'bin/nc4tonc3', 'bin/ncinfo'],
-    'dirs': ['lib/python%(pv)s/site-packages/netCDF4-%%(version)s-py%(pv)s-linux-x86_64.egg' % {'pv': local_pyshortver}]
+    'dirs': ['lib/python%(pyshortver)s/site-packages/netCDF4-%(version)s-py%(pyshortver)s-linux-x86_64.egg']
 }
 
 moduleclass = 'data'

--- a/easybuild/easyconfigs/n/numpy/numpy-1.17.2-CrayGNU-19.10.eb
+++ b/easybuild/easyconfigs/n/numpy/numpy-1.17.2-CrayGNU-19.10.eb
@@ -3,13 +3,6 @@ easyblock = 'PythonPackage'
 name = 'numpy'
 version = '1.17.2'
 
-local_py_maj_ver = '3'
-local_py_min_ver = '6'
-local_py_rev_ver = '5.7'
-
-local_pyver = '%s.%s.%s' % (local_py_maj_ver, local_py_min_ver, local_py_rev_ver)
-local_pyshortver = '%s.%s' % (local_py_maj_ver, local_py_min_ver)
-
 homepage = 'https://github.com/numpy/numpy'
 description = "Horovod is a distributed training framework for TensorFlow."
 
@@ -20,7 +13,7 @@ source_urls = ['https://github.com/numpy/numpy/releases/download/v%s' % version]
 sources = [SOURCELOWER_TAR_GZ]
 
 dependencies = [
-    ('cray-python/%s' % local_pyver, EXTERNAL_MODULE),
+    ('cray-python/3.6.5.7', EXTERNAL_MODULE),
 ]
 
 patches = [('mkl-2019-sitecfg.patch', 1)]
@@ -31,7 +24,7 @@ modextravars = { 'LD_LIBRARY_PATH':'/opt/intel/compilers_and_libraries_2019/linu
 
 sanity_check_paths = {
     'files': [],
-    'dirs': ['lib/python%s/site-packages' % local_pyshortver],
+    'dirs': ['lib/python%(pyshortver)s/site-packages'],
 }
 
 moduleclass = 'tools'

--- a/easybuild/easyconfigs/n/nvtop/nvtop-1.0.0-CrayGNU-19.10-cuda-10.1.eb
+++ b/easybuild/easyconfigs/n/nvtop/nvtop-1.0.0-CrayGNU-19.10-cuda-10.1.eb
@@ -3,7 +3,7 @@ easyblock = 'CMakeMake'
 
 name = 'nvtop'
 version = '1.0.0'
-versionsuffix = '-cuda-10.1'
+versionsuffix = '-cuda-%(cudashortver)s'
 
 homepage = 'https://github.com/Syllo/nvtop'
 description = 'htop-like GPU usage monitor'
@@ -14,6 +14,8 @@ sources = ['%(version)s.tar.gz']
 osdependencies = [('ncurses-devel')]
 builddependencies = [
     ('CMake', '3.14.5', '', True),
+]
+dependencies = [
     ('cudatoolkit/10.1.105_3.27-7.0.1.1_4.1__ga311ce7', EXTERNAL_MODULE),
 ]
 separate_build_dir = True

--- a/easybuild/easyconfigs/p/PyExtensions/PyExtensions-2.7.15.6-CrayGNU-19.10.eb
+++ b/easybuild/easyconfigs/p/PyExtensions/PyExtensions-2.7.15.6-CrayGNU-19.10.eb
@@ -1,12 +1,8 @@
 # contributed by Luca Marsella (CSCS)
-easyblock = 'Bundle'
+easyblock = 'PythonBundle'
 
 name = 'PyExtensions'
-local_py_maj_ver = '2'
-local_py_min_ver = '7'
-local_py_rev_ver = '15.6'
-local_pyver = '%s.%s' % (local_py_maj_ver, local_py_min_ver)
-version = '%s.%s' % (local_pyver, local_py_rev_ver)
+version = '%(pyver)s'
 
 homepage = 'https://pypi.python.org/pypi'
 description = """This module is a bundle of Python packages on Cray systems based on the module cray-python"""
@@ -15,42 +11,33 @@ toolchain = {'name': 'CrayGNU', 'version': '19.10'}
 toolchainopts = {'pic': True, 'verbose' : False }
 
 dependencies = [
-    ('cray-python/%s' % version, EXTERNAL_MODULE),
+    ('cray-python/2.7.15.6', EXTERNAL_MODULE),
 ]
 
-# bundle of Python packages
-exts_defaultclass = 'PythonPackage'
-
-exts_list = [
-     ('Cython', '0.28.4', {
-         'source_urls': ['https://pypi.python.org/packages/source/c/cython/'],
-     }),
-     ('six', '1.11.0', {
-         'source_urls': ['https://pypi.python.org/packages/source/s/six/'],
-     }),
-     ('subprocess32', '3.5.2', {
-         'source_urls': ['https://pypi.python.org/packages/source/s/subprocess32/'],
-     }),
-     ('matplotlib', '2.2.2', {
-         'source_urls': ['https://pypi.python.org/packages/source/m/matplotlib/'],
-     }),
-     ('pandas', '0.23.3', {
-         'source_urls': ['https://pypi.python.org/packages/source/p/pandas/'],
-     }),
-     ('virtualenv', '16.0.0', {
-         'source_urls': ['https://pypi.python.org/packages/source/v/virtualenv/'],
-     }),
- ]
-
-# specify that Bundle easyblock should run a full sanity check, rather than just trying to load the module
-local_full_sanity_check = True
-
-local_pythonpath = 'lib/python%s/site-packages' % local_pyver
-sanity_check_paths = {
-    'files': [],
-    'dirs': [local_pythonpath]
+exts_default_options = {
+    'source_urls': [PYPI_SOURCE]
 }
 
-modextrapaths = {'PYTHONPATH': local_pythonpath}
+exts_list = [
+    ('Cython', '0.28.4'),
+    ('six', '1.11.0'),
+    ('pyparsing', '2.4.7'),
+    ('backports.functools_lru_cache', '1.6.1'),
+    ('subprocess32', '3.5.2'),
+    ('python-dateutil', '2.8.1', {
+        'modulename': 'dateutil',
+    }),
+    ('pytz', '2020.1'),
+    ('kiwisolver', '1.1.0'),
+    ('cycler', '0.10.0'),
+    ('matplotlib', '2.2.2'),
+    ('pandas', '0.23.3'),
+    ('virtualenv', '16.0.0'),
+ ]
+
+sanity_check_paths = {
+    'files': [],
+    'dirs': ['lib/python%(pyshortver)s/site-packages']
+}
 
 moduleclass = 'tools'

--- a/easybuild/easyconfigs/p/PyExtensions/PyExtensions-2.7.15.7-CrayGNU-19.10.eb
+++ b/easybuild/easyconfigs/p/PyExtensions/PyExtensions-2.7.15.7-CrayGNU-19.10.eb
@@ -1,12 +1,8 @@
 # contributed by Luca Marsella (CSCS)
-easyblock = 'Bundle'
+easyblock = 'PythonBundle'
 
 name = 'PyExtensions'
-local_py_maj_ver = '2'
-local_py_min_ver = '7'
-local_py_rev_ver = '15.7'
-local_pyver = '%s.%s' % (local_py_maj_ver, local_py_min_ver)
-version = '%s.%s' % (local_pyver, local_py_rev_ver)
+version = '%(pyver)s'
 
 homepage = 'https://pypi.python.org/pypi'
 description = """This module is a bundle of Python packages on Cray systems based on the module cray-python"""
@@ -15,42 +11,33 @@ toolchain = {'name': 'CrayGNU', 'version': '19.10'}
 toolchainopts = {'pic': True, 'verbose' : False }
 
 dependencies = [
-    ('cray-python/%s' % version, EXTERNAL_MODULE),
+    ('cray-python/2.7.15.7', EXTERNAL_MODULE),
 ]
 
-# bundle of Python packages
-exts_defaultclass = 'PythonPackage'
-
-exts_list = [
-     ('Cython', '0.28.4', {
-         'source_urls': ['https://pypi.python.org/packages/source/c/cython/'],
-     }),
-     ('six', '1.11.0', {
-         'source_urls': ['https://pypi.python.org/packages/source/s/six/'],
-     }),
-     ('subprocess32', '3.5.2', {
-         'source_urls': ['https://pypi.python.org/packages/source/s/subprocess32/'],
-     }),
-     ('matplotlib', '2.2.2', {
-         'source_urls': ['https://pypi.python.org/packages/source/m/matplotlib/'],
-     }),
-     ('pandas', '0.23.3', {
-         'source_urls': ['https://pypi.python.org/packages/source/p/pandas/'],
-     }),
-     ('virtualenv', '16.0.0', {
-         'source_urls': ['https://pypi.python.org/packages/source/v/virtualenv/'],
-     }),
- ]
-
-# specify that Bundle easyblock should run a full sanity check, rather than just trying to load the module
-local_full_sanity_check = True
-
-local_pythonpath = 'lib/python%s/site-packages' % local_pyver
-sanity_check_paths = {
-    'files': [],
-    'dirs': [local_pythonpath]
+exts_default_options = {
+    'source_urls': [PYPI_SOURCE]
 }
 
-modextrapaths = {'PYTHONPATH': local_pythonpath}
+exts_list = [
+    ('Cython', '0.28.4'),
+    ('six', '1.11.0'),
+    ('pyparsing', '2.4.7'),
+    ('backports.functools_lru_cache', '1.6.1'),
+    ('subprocess32', '3.5.2'),
+    ('python-dateutil', '2.8.1', {
+        'modulename': 'dateutil',
+    }),
+    ('pytz', '2020.1'),
+    ('kiwisolver', '1.1.0'),
+    ('cycler', '0.10.0'),
+    ('matplotlib', '2.2.2'),
+    ('pandas', '0.23.3'),
+    ('virtualenv', '16.0.0'),
+ ]
+
+sanity_check_paths = {
+    'files': [],
+    'dirs': ['lib/python%(pyshortver)s/site-packages']
+}
 
 moduleclass = 'tools'

--- a/easybuild/easyconfigs/p/PyExtensions/PyExtensions-3.6.5.6-CrayGNU-19.10.eb
+++ b/easybuild/easyconfigs/p/PyExtensions/PyExtensions-3.6.5.6-CrayGNU-19.10.eb
@@ -1,12 +1,9 @@
 # contributed by Luca Marsella (CSCS)
-easyblock = 'Bundle'
+easyblock = 'PythonBundle'
 
 name = 'PyExtensions'
-local_py_maj_ver = '3'
-local_py_min_ver = '6'
-local_py_rev_ver = '5.6'
-local_pyver = '%s.%s' % (local_py_maj_ver, local_py_min_ver)
-version = '%s.%s' % (local_pyver, local_py_rev_ver)
+version = '%(pyver)s'
+_pyminver = '6'
 
 homepage = 'https://pypi.python.org/pypi'
 description = """This module is a bundle of Python packages on Cray systems based on the module cray-python"""
@@ -15,45 +12,33 @@ toolchain = {'name': 'CrayGNU', 'version': '19.10'}
 toolchainopts = {'pic': True, 'verbose': False}
 
 dependencies = [
-    ('cray-python/%s' % version, EXTERNAL_MODULE),
+    ('cray-python/3.6.5.6', EXTERNAL_MODULE),
     #('libffi', '3.2.1')
 ]
 
-# bundle of Python packages
-exts_defaultclass = 'PythonPackage'
-
-exts_list = [
-    ('Cython', '0.28.4', {
-        'req_py_majver': '3',
-        'req_py_minver': '6',
-        'source_urls': ['https://pypi.python.org/packages/source/c/cython/'],
-    }),
-    ('six', '1.11.0', {
-        'req_py_majver': '3',
-        'req_py_minver': '6',
-        'source_urls': ['https://pypi.python.org/packages/source/s/six/'],
-    }),
-    ('matplotlib', '2.2.2', {
-        'req_py_majver': '3',
-        'req_py_minver': '6',
-        'source_urls': ['https://pypi.python.org/packages/source/m/matplotlib/'],
-    }),
-    ('pandas', '0.23.3', {
-        'req_py_majver': '3',
-        'req_py_minver': '6',
-        'source_urls': ['https://pypi.python.org/packages/source/p/pandas/'],
-    }),
-]
-
-# specify that Bundle easyblock should run a full sanity check, rather than just trying to load the module
-local_full_sanity_check = True
-
-local_pythonpath = 'lib/python%s/site-packages' % local_pyver
-sanity_check_paths = {
-    'files': [],
-    'dirs': [local_pythonpath]
+exts_default_options = {
+    'req_py_majver': '%(pymajver)s',
+    'req_py_minver': '%s' % _pyminver,
+    'source_urls': [PYPI_SOURCE]
 }
 
-modextrapaths = {'PYTHONPATH': local_pythonpath}
+exts_list = [
+    ('Cython', '0.28.4'),
+    ('six', '1.11.0'),
+    ('pyparsing', '2.4.7'),
+    ('kiwisolver', '1.2.0'),
+    ('pytz', '2020.1'),
+    ('cycler', '0.10.0'),
+    ('python-dateutil', '2.8.1', {
+        'modulename': 'dateutil',
+    }),
+    ('matplotlib', '2.2.2'),
+    ('pandas', '0.23.3'),
+]
+
+sanity_check_paths = {
+    'files': [],
+    'dirs': ['lib/python%(pyshortver)s/site-packages']
+}
 
 moduleclass = 'tools'

--- a/easybuild/easyconfigs/p/PyExtensions/PyExtensions-3.6.5.7-CrayGNU-19.10.eb
+++ b/easybuild/easyconfigs/p/PyExtensions/PyExtensions-3.6.5.7-CrayGNU-19.10.eb
@@ -1,12 +1,9 @@
 # contributed by Luca Marsella (CSCS)
-easyblock = 'Bundle'
+easyblock = 'PythonBundle'
 
 name = 'PyExtensions'
-local_py_maj_ver = '3'
-local_py_min_ver = '6'
-local_py_rev_ver = '5.7'
-local_pyver = '%s.%s' % (local_py_maj_ver, local_py_min_ver)
-version = '%s.%s' % (local_pyver, local_py_rev_ver)
+version = '%(pyver)s'
+_pyminver = '6'
 
 homepage = 'https://pypi.python.org/pypi'
 description = """This module is a bundle of Python packages on Cray systems based on the module cray-python"""
@@ -15,45 +12,33 @@ toolchain = {'name': 'CrayGNU', 'version': '19.10'}
 toolchainopts = {'pic': True, 'verbose': False}
 
 dependencies = [
-    ('cray-python/%s' % version, EXTERNAL_MODULE),
+    ('cray-python/3.6.5.7', EXTERNAL_MODULE),
     #('libffi', '3.2.1')
 ]
 
-# bundle of Python packages
-exts_defaultclass = 'PythonPackage'
-
-exts_list = [
-    ('Cython', '0.28.4', {
-        'req_py_majver': '3',
-        'req_py_minver': '6',
-        'source_urls': ['https://pypi.python.org/packages/source/c/cython/'],
-    }),
-    ('six', '1.11.0', {
-        'req_py_majver': '3',
-        'req_py_minver': '6',
-        'source_urls': ['https://pypi.python.org/packages/source/s/six/'],
-    }),
-    ('matplotlib', '2.2.2', {
-        'req_py_majver': '3',
-        'req_py_minver': '6',
-        'source_urls': ['https://pypi.python.org/packages/source/m/matplotlib/'],
-    }),
-    ('pandas', '0.23.3', {
-        'req_py_majver': '3',
-        'req_py_minver': '6',
-        'source_urls': ['https://pypi.python.org/packages/source/p/pandas/'],
-    }),
-]
-
-# specify that Bundle easyblock should run a full sanity check, rather than just trying to load the module
-local_full_sanity_check = True
-
-local_pythonpath = 'lib/python%s/site-packages' % local_pyver
-sanity_check_paths = {
-    'files': [],
-    'dirs': [local_pythonpath]
+exts_default_options = {
+    'req_py_majver': '%(pymajver)s',
+    'req_py_minver': '%s' % _pyminver,
+    'source_urls': [PYPI_SOURCE]
 }
 
-modextrapaths = {'PYTHONPATH': local_pythonpath}
+exts_list = [
+    ('Cython', '0.28.4'),
+    ('six', '1.11.0'),
+    ('pyparsing', '2.4.7'),
+    ('kiwisolver', '1.2.0'),
+    ('pytz', '2020.1'),
+    ('cycler', '0.10.0'),
+    ('python-dateutil', '2.8.1', {
+        'modulename': 'dateutil',
+    }),
+    ('matplotlib', '2.2.2'),
+    ('pandas', '0.23.3'),
+]
+
+sanity_check_paths = {
+    'files': [],
+    'dirs': ['lib/python%(pyshortver)s/site-packages']
+}
 
 moduleclass = 'tools'

--- a/easybuild/easyconfigs/p/PyExtensionsDS/PyExtensionsDS-3.6.5.7-CrayGNU-19.10.eb
+++ b/easybuild/easyconfigs/p/PyExtensionsDS/PyExtensionsDS-3.6.5.7-CrayGNU-19.10.eb
@@ -1,13 +1,9 @@
 # contributed by mschoengens and sarafael (CSCS)
-easyblock = 'Bundle'
+easyblock = 'PythonBundle'
 
 name = 'PyExtensionsDS'
-local_py_maj_ver = '3'
-local_py_min_ver = '6'
-local_py_rev_ver = '5.7'
-local_pyver = '%s.%s.%s' % (local_py_maj_ver, local_py_min_ver, local_py_rev_ver)
-local_pyshortver = '%s.%s' % (local_py_maj_ver, local_py_min_ver)
-version = '%s' % local_pyver
+version = '%(pyver)s'
+_pyminver = '6'
 
 homepage = 'https://pypi.python.org/pypi'
 description = """This module is a bundle of Python packages on Cray systems based on the module cray-python"""
@@ -16,113 +12,44 @@ toolchain = {'name': 'CrayGNU', 'version': '19.10'}
 toolchainopts = {'pic': True, 'verbose': False}
 
 dependencies = [
-    ('cray-python/%s' % local_pyver, EXTERNAL_MODULE),
-    ('h5py', '2.8.0', '-python%s-serial' % local_py_maj_ver),
-    ('PyExtensions', local_pyver),
+    ('cray-python/3.6.5.7', EXTERNAL_MODULE),
+    ('h5py', '2.8.0', '-python%(pymajver)s-serial'),
+    ('PyExtensions', '%(pyver)s'),
 ]
 
-# bundle of Python packages
-exts_defaultclass = 'PythonPackage'
-
-exts_list = [
-    ('backports.weakref', '1.0.post1', {
-        'req_py_majver': '3',
-        'req_py_minver': '6',
-        'source_urls': ['https://pypi.python.org/packages/source/b/backports.weakref/'],
-    }),
-    ('Werkzeug', '0.14.1', {
-        'req_py_majver': '3',
-        'req_py_minver': '6',
-        'source_urls': ['https://pypi.python.org/packages/source/w/werkzeug/'],
-    }),
-    ('absl-py', '0.6.1', {
-        'req_py_majver': '3',
-        'req_py_minver': '6',
-        'source_urls': ['https://pypi.python.org/packages/source/a/absl-py/'],
-        'modulename': 'absl',
-    }),
-    ('Keras_Applications', '1.0.6', {
-        'req_py_majver': '3',
-        'req_py_minver': '6',
-        'source_urls': ['https://pypi.python.org/packages/source/k/keras_applications'],
-    }),
-    ('Keras_Preprocessing', '1.0.5', {
-        'req_py_majver': '3',
-        'req_py_minver': '6',
-        'source_urls': ['https://pypi.python.org/packages/source/k/keras_preprocessing'],
-    }),
-    ('gast', '0.2.0', {
-        'req_py_majver': '3',
-        'req_py_minver': '6',
-        'source_urls': ['https://pypi.python.org/packages/source/g/gast'],
-    }),
-    ('astor', '0.7.1', {
-        'req_py_majver': '3',
-        'req_py_minver': '6',
-        'source_urls': ['https://pypi.python.org/packages/source/a/astor'],
-    }),
-    ('termcolor', '1.1.0', {
-        'req_py_majver': '3',
-        'req_py_minver': '6',
-        'source_urls': ['https://pypi.python.org/packages/source/t/termcolor'],
-    }),
-    ('chardet', '3.0.4', {
-            'req_py_majver': '3',
-            'req_py_minver': '6',
-            'source_urls': ['https://pypi.python.org/packages/source/c/chardet/'],
-    }),
-    ('certifi', '2018.8.24', {
-            'req_py_majver': '3',
-            'req_py_minver': '6',
-            'source_urls': ['https://pypi.python.org/packages/source/c/certifi/'],
-    }),
-    ('idna', '2.7', {
-            'req_py_majver': '3',
-            'req_py_minver': '6',
-            'source_urls': ['https://pypi.python.org/packages/source/i/idna/'],
-    }),
-    ('urllib3', '1.23', {
-            'req_py_majver': '3',
-            'req_py_minver': '6',
-            'source_urls': ['https://pypi.python.org/packages/source/u/urllib3/'],
-    }),
-    ('requests', '2.19.1', {
-            'req_py_majver': '3',
-            'req_py_minver': '6',
-            'source_urls': ['https://pypi.python.org/packages/source/r/requests/'],
-    }),
-    ('wrapt', '1.11.2', {
-            'req_py_majver': '3',
-            'req_py_minver': '6',
-            'source_urls': ['https://pypi.python.org/packages/source/w/wrapt/'],
-    }),
-    ('setuptools', '41.0.1', {
-        'req_py_majver': '3',
-        'req_py_minver': '6',
-        'source_urls': ['https://pypi.python.org/packages/source/s/setuptools'],
-        'source_tmpl': 'setuptools-41.0.1.zip',
-    }),
-    ('Markdown', '3.1.1', {
-        'req_py_majver': '3',
-        'req_py_minver': '6',
-        'source_urls': ['https://pypi.python.org/packages/source/m/markdown'],
-    }),
-    ('wheel', '0.33.4', {
-        'req_py_majver': '3',
-        'req_py_minver': '6',
-        'source_urls': ['https://pypi.python.org/packages/source/w/wheel'],
-    }),
-]
-
-# specify that Bundle easyblock should run a full sanity check, rather than just trying to load the module
-local_full_sanity_check = True
-
-local_pythonpath = 'lib/python%s/site-packages' % local_pyshortver
-sanity_check_paths = {
-    'files': [],
-    'dirs': [local_pythonpath]
+exts_default_options = {
+    'req_py_majver': '%(pymajver)s',
+    'req_py_minver': '%s' % _pyminver,
+    'source_urls': [PYPI_SOURCE]
 }
 
-modextrapaths = {'PYTHONPATH': local_pythonpath}
+exts_list = [
+    ('backports.weakref', '1.0.post1'),
+    ('Werkzeug', '0.14.1'),
+    ('absl-py', '0.6.1', {
+        'modulename': 'absl',
+    }),
+    ('Keras_Applications', '1.0.6'),
+    ('Keras_Preprocessing', '1.0.5'),
+    ('gast', '0.2.0'),
+    ('astor', '0.7.1'),
+    ('termcolor', '1.1.0'),
+    ('chardet', '3.0.4'),
+    ('certifi', '2018.8.24'),
+    ('idna', '2.7'),
+    ('urllib3', '1.23'),
+    ('requests', '2.19.1'),
+    ('wrapt', '1.11.2'),
+    ('setuptools', '41.0.1', {
+        'source_tmpl': 'setuptools-41.0.1.zip',
+    }),
+    ('Markdown', '3.1.1'),
+    ('wheel', '0.33.4'),
+]
+
+sanity_check_paths = {
+    'files': [],
+    'dirs': ['lib/python%(pyshortver)s/site-packages']
+}
 
 moduleclass = 'tools'

--- a/easybuild/easyconfigs/p/prereq/prereq-tf-2.0-CrayGNU-19.10.eb
+++ b/easybuild/easyconfigs/p/prereq/prereq-tf-2.0-CrayGNU-19.10.eb
@@ -1,13 +1,9 @@
 # contributed by mschoengens and sarafael (CSCS)
-easyblock = 'Bundle'
+easyblock = 'PythonBundle'
 
 name = 'prereq'
-py_maj_ver = '3'
-py_min_ver = '6'
-py_rev_ver = '5.7'
-pyver = '%s.%s.%s' % (py_maj_ver, py_min_ver, py_rev_ver)
-pyshortver = '%s.%s' % (py_maj_ver, py_min_ver)
 version = 'tf-2.0'
+_pyminver = '6'
 
 homepage = 'https://pypi.python.org/pypi'
 description = """This module is a bundle of Python packages on Cray systems based on the module cray-python"""
@@ -16,113 +12,48 @@ toolchain = {'name': 'CrayGNU', 'version': '19.10'}
 toolchainopts = {'pic': True, 'verbose': False}
 
 dependencies = [
+    ('cray-python/3.6.5.7', EXTERNAL_MODULE),
     ('numpy', '1.17.2'),
-    ('h5py', '2.8.0', '-python%s-serial' % py_maj_ver),
-    ('PyExtensions', pyver),
+    ('h5py', '2.8.0', '-python%(pymajver)s-serial'),
+    ('PyExtensions', '%(pyver)s'),
 ]
 
-# bundle of Python packages
-exts_defaultclass = 'PythonPackage'
+exts_default_options = {
+    'req_py_majver': '%(pymajver)s',
+    'req_py_minver': '%s' % _pyminver,
+    'source_urls': [PYPI_SOURCE]
+}
 
 exts_list = [
-    ('backports.weakref', '1.0.post1', {
-        'req_py_majver': '3',
-        'req_py_minver': '6',
-        'source_urls': ['https://pypi.python.org/packages/source/b/backports.weakref/'],
-    }),
-    ('Werkzeug', '0.16.0', {
-        'req_py_majver': '3',
-        'req_py_minver': '6',
-        'source_urls': ['https://pypi.python.org/packages/source/w/werkzeug/'],
-    }),
+    ('backports.weakref', '1.0.post1'),
+    ('Werkzeug', '0.16.0'),
     ('absl-py', '0.8.0', {
-        'req_py_majver': '3',
-        'req_py_minver': '6',
-        'source_urls': ['https://pypi.python.org/packages/source/a/absl-py/'],
         'modulename': 'absl',
     }),
-    ('Keras_Applications', '1.0.8', {
-        'req_py_majver': '3',
-        'req_py_minver': '6',
-        'source_urls': ['https://pypi.python.org/packages/source/k/keras_applications'],
-    }),
-    ('Keras_Preprocessing', '1.1.0', {
-        'req_py_majver': '3',
-        'req_py_minver': '6',
-        'source_urls': ['https://pypi.python.org/packages/source/k/keras_preprocessing'],
-    }),
-    ('gast', '0.3.2', {
-        'req_py_majver': '3',
-        'req_py_minver': '6',
-        'source_urls': ['https://pypi.python.org/packages/source/g/gast'],
-    }),
-    ('astor', '0.8.0', {
-        'req_py_majver': '3',
-        'req_py_minver': '6',
-        'source_urls': ['https://pypi.python.org/packages/source/a/astor'],
-    }),
-    ('termcolor', '1.1.0', {
-        'req_py_majver': '3',
-        'req_py_minver': '6',
-        'source_urls': ['https://pypi.python.org/packages/source/t/termcolor'],
-    }),
-    ('chardet', '3.0.4', {
-            'req_py_majver': '3',
-            'req_py_minver': '6',
-            'source_urls': ['https://pypi.python.org/packages/source/c/chardet/'],
-    }),
-    ('certifi', '2019.9.11', {
-            'req_py_majver': '3',
-            'req_py_minver': '6',
-            'source_urls': ['https://pypi.python.org/packages/source/c/certifi/'],
-    }),
-    ('idna', '2.8', {
-            'req_py_majver': '3',
-            'req_py_minver': '6',
-            'source_urls': ['https://pypi.python.org/packages/source/i/idna/'],
-    }),
-    ('urllib3', '1.25.6', {
-            'req_py_majver': '3',
-            'req_py_minver': '6',
-            'source_urls': ['https://pypi.python.org/packages/source/u/urllib3/'],
-    }),
-    ('requests', '2.22.0', {
-            'req_py_majver': '3',
-            'req_py_minver': '6',
-            'source_urls': ['https://pypi.python.org/packages/source/r/requests/'],
-    }),
-    ('wrapt', '1.11.2', {
-            'req_py_majver': '3',
-            'req_py_minver': '6',
-            'source_urls': ['https://pypi.python.org/packages/source/w/wrapt/'],
-    }),
+    ('Keras_Applications', '1.0.8'),
+    ('Keras_Preprocessing', '1.1.0'),
+    ('gast', '0.3.2'),
+    ('astor', '0.8.0'),
+    ('termcolor', '1.1.0'),
+    ('chardet', '3.0.4'),
+    ('certifi', '2019.9.11'),
+    ('idna', '2.8'),
+    ('urllib3', '1.25.6'),
+    ('requests', '2.22.0'),
+    ('wrapt', '1.11.2'),
     ('setuptools', '41.2.0', {
-        'req_py_majver': '3',
-        'req_py_minver': '6',
-        'source_urls': ['https://pypi.python.org/packages/source/s/setuptools'],
         'source_tmpl': 'setuptools-41.0.1.zip',
     }),
-    ('Markdown', '3.1.1', {
-        'req_py_majver': '3',
-        'req_py_minver': '6',
-        'source_urls': ['https://pypi.python.org/packages/source/m/markdown'],
-    }),
-    ('wheel', '0.33.6', {
-        'req_py_majver': '3',
-        'req_py_minver': '6',
-        'source_urls': ['https://pypi.python.org/packages/source/w/wheel'],
-    }),
+    ('Markdown', '3.1.1'),
+    ('wheel', '0.33.6'),
 ]
 
 # specify that Bundle easyblock should run a full sanity check, rather than just trying to load the module
 full_sanity_check = True
 
-pythonpath = 'lib/python%s/site-packages' % pyshortver
 sanity_check_paths = {
     'files': [],
-    'dirs': [pythonpath]
+    'dirs': ['lib/python%(pyshortver)s/site-packages']
 }
-
-modextrapaths = {'PYTHONPATH': pythonpath}
 
 moduleclass = 'tools'

--- a/easybuild/easyconfigs/p/prereq/prereq-tf-2.0-CrayGNU-19.10.eb
+++ b/easybuild/easyconfigs/p/prereq/prereq-tf-2.0-CrayGNU-19.10.eb
@@ -48,9 +48,6 @@ exts_list = [
     ('wheel', '0.33.6'),
 ]
 
-# specify that Bundle easyblock should run a full sanity check, rather than just trying to load the module
-full_sanity_check = True
-
 sanity_check_paths = {
     'files': [],
     'dirs': ['lib/python%(pyshortver)s/site-packages']

--- a/easybuild/easyconfigs/p/protobuf/protobuf-3.6.0-CrayGNU-19.10-python3.eb
+++ b/easybuild/easyconfigs/p/protobuf/protobuf-3.6.0-CrayGNU-19.10-python3.eb
@@ -3,15 +3,10 @@ easyblock = 'PythonPackage'
 name = 'protobuf'
 version = '3.6.0'
 
-local_py_maj_ver = '3'
-local_py_min_ver = '6'
-local_py_rev_ver = '5.7'
+versionsuffix = '-python%(pymajver)s'
 
-local_pyver = '%s.%s.%s' % (local_py_maj_ver, local_py_min_ver, local_py_rev_ver)
-versionsuffix = '-python%s' % (local_py_maj_ver)
-
-req_py_majver = int(local_py_maj_ver)
-req_py_minver = int(local_py_min_ver)
+# req_py_majver = 3
+# req_py_minver = 6
 
 homepage = 'https://github.com/google/protobuf/'
 description = """Python Protocol Buffers runtime library."""
@@ -22,7 +17,8 @@ source_urls = ['https://github.com/google/protobuf/archive/v%(version)s']
 sources = [SOURCE_TAR_GZ]
 
 dependencies = [
-    ('PyExtensions', '%s' % local_pyver),
+    ('cray-python/3.6.5.7', EXTERNAL_MODULE),
+    ('PyExtensions', '%(pyver)s'),
     ('protobuf-core', version)
 ]
 
@@ -30,7 +26,7 @@ start_dir = 'python'
 
 sanity_check_paths = {
     'files': [],
-    'dirs': ['lib/python%s.%s/site-packages' % (local_py_maj_ver, local_py_min_ver)],
+    'dirs': ['lib/python%(pyshortver)s/site-packages'],
 }
 
 options = {'modulename': 'google.protobuf'}

--- a/easybuild/easyconfigs/p/protobuf/protobuf-3.6.0-CrayGNU-19.10-python3.eb
+++ b/easybuild/easyconfigs/p/protobuf/protobuf-3.6.0-CrayGNU-19.10-python3.eb
@@ -5,9 +5,6 @@ version = '3.6.0'
 
 versionsuffix = '-python%(pymajver)s'
 
-# req_py_majver = 3
-# req_py_minver = 6
-
 homepage = 'https://github.com/google/protobuf/'
 description = """Python Protocol Buffers runtime library."""
 

--- a/easybuild/easyconfigs/p/pycuda/pycuda-2018.1.1-CrayGNU-19.10-python2-cuda-10.1.eb
+++ b/easybuild/easyconfigs/p/pycuda/pycuda-2018.1.1-CrayGNU-19.10-python2-cuda-10.1.eb
@@ -4,16 +4,7 @@ easyblock = 'PythonPackage'
 name = 'pycuda'
 version = '2018.1.1'
 
-local_cudaversion = '10.1'
-
-local_py_maj_ver = '2'
-local_py_min_ver = '7'
-local_py_rev_ver = '15.7'
-
-local_pyver = '%s.%s.%s' % (local_py_maj_ver, local_py_min_ver, local_py_rev_ver)
-local_pyshortver = '%s.%s' % (local_py_maj_ver, local_py_min_ver)
-
-versionsuffix = '-python%s-cuda-%s' % (local_py_maj_ver, local_cudaversion)
+versionsuffix = '-python%(pymajver)s-cuda-%(cudashortver)s'
 
 homepage = 'https://pypi.python.org/pypi/pycuda'
 description = """Python wrapper for Nvidia CUDA. PyCUDA lets you access Nvidia
@@ -26,7 +17,7 @@ source_urls = [PYPI_SOURCE]
 sources = [SOURCE_TAR_GZ]
 
 dependencies = [
-    ('cray-python/%s' % local_pyver, EXTERNAL_MODULE),
+    ('cray-python/2.7.15.7', EXTERNAL_MODULE),
     ('cudatoolkit/10.1.105_3.27-7.0.1.1_4.1__ga311ce7', EXTERNAL_MODULE),
 ]
 
@@ -34,7 +25,7 @@ prebuildopts = "python ./configure.py --cuda-root=$EBROOTCUDA"
 
 sanity_check_paths = {
     'files': [],
-    'dirs': ['lib/python%(pv)s/site-packages/%%(name)s-%%(version)s-py%(pv)s-linux-x86_64.egg' % {'pv': local_pyshortver}],
+    'dirs': ['lib/python%(pyshortver)s/site-packages/%(name)s-%(version)s-py%(pyshortver)s-linux-x86_64.egg'],
 }
 
 moduleclass = 'lang'

--- a/easybuild/easyconfigs/p/pycuda/pycuda-2018.1.1-CrayGNU-19.10-python3-cuda-10.1.eb
+++ b/easybuild/easyconfigs/p/pycuda/pycuda-2018.1.1-CrayGNU-19.10-python3-cuda-10.1.eb
@@ -4,16 +4,7 @@ easyblock = 'PythonPackage'
 name = 'pycuda'
 version = '2018.1.1'
 
-local_cudaversion = '10.1'
-
-local_py_maj_ver = '3'
-local_py_min_ver = '6'
-local_py_rev_ver = '5.7'
-
-local_pyver = '%s.%s.%s' % (local_py_maj_ver, local_py_min_ver, local_py_rev_ver)
-local_pyshortver = '%s.%s' % (local_py_maj_ver, local_py_min_ver)
-
-versionsuffix = '-python%s-cuda-%s' % (local_py_maj_ver, local_cudaversion)
+versionsuffix = '-python%(pymajver)s-cuda-%(cudashortver)s'
 
 homepage = 'https://pypi.python.org/pypi/pycuda'
 description = """Python wrapper for Nvidia CUDA. PyCUDA lets you access Nvidia
@@ -26,7 +17,7 @@ source_urls = [PYPI_SOURCE]
 sources = [SOURCE_TAR_GZ]
 
 dependencies = [
-    ('cray-python/%s' % local_pyver, EXTERNAL_MODULE),
+    ('cray-python/3.6.5.7', EXTERNAL_MODULE),
     ('cudatoolkit/10.1.105_3.27-7.0.1.1_4.1__ga311ce7', EXTERNAL_MODULE),
 ]
 
@@ -34,7 +25,7 @@ prebuildopts = "python ./configure.py --cuda-root=$EBROOTCUDA"
 
 sanity_check_paths = {
     'files': [],
-    'dirs': ['lib/python%(pv)s/site-packages/%%(name)s-%%(version)s-py%(pv)s-linux-x86_64.egg' % {'pv': local_pyshortver}],
+    'dirs': ['lib/python%(pyshortver)s/site-packages/%(name)s-%(version)s-py%(pyshortver)s-linux-x86_64.egg'],
 }
 
 moduleclass = 'lang'

--- a/easybuild/easyconfigs/q/QuantumESPRESSO/QuantumESPRESSO-6.4.1-CrayIntel-19.10-cuda-10.1.eb
+++ b/easybuild/easyconfigs/q/QuantumESPRESSO/QuantumESPRESSO-6.4.1-CrayIntel-19.10-cuda-10.1.eb
@@ -3,8 +3,7 @@ easyblock = "ConfigureMake"
 
 name = 'QuantumESPRESSO'
 version = '6.4.1'
-local_cudaversion = '10.1'
-versionsuffix = '-cuda-%s' % local_cudaversion
+versionsuffix = '-cuda-%(cudashortver)s'
 
 homepage = 'http://www.quantum-espresso.org/'
 description = """Quantum ESPRESSO is an integrated suite of computer codes
@@ -17,7 +16,7 @@ toolchainopts = {'usempi': True, 'openmp': True, 'pic': True, 'verbose': False, 
 
 sources = ['https://github.com/QEF/q-e/archive/' + 'qe-%s.tar.gz' % version ]
 
-builddependencies = [
+dependencies = [
     ('cudatoolkit/10.1.105_3.27-7.0.1.1_4.1__ga311ce7', EXTERNAL_MODULE),
 ]
 

--- a/easybuild/easyconfigs/q/QuantumESPRESSO/QuantumESPRESSO-6.5a1-CrayPGI-19.10-cuda-10.1.eb
+++ b/easybuild/easyconfigs/q/QuantumESPRESSO/QuantumESPRESSO-6.5a1-CrayPGI-19.10-cuda-10.1.eb
@@ -3,16 +3,15 @@ easyblock = "ConfigureMake"
 
 name = 'QuantumESPRESSO'
 version = '6.5a1'
-local_cudaversion = '10.1'
-versionsuffix = '-cuda-%s' % local_cudaversion
+versionsuffix = '-cuda-%(cudashortver)s'
 
 homepage = 'http://www.quantum-espresso.org/'
 description = """Quantum ESPRESSO is an integrated suite of computer codes for
 electronic-structure calculations and materials modeling at the nanoscale. It
 is based on density-functional theory, plane waves, and pseudopotentials (both
-norm-conserving and ultrasoft). 
+norm-conserving and ultrasoft).
 
-Note: PGI Fortran gives the warning "ieee_inexact FORTRAN STOP" with QE GPU.  
+Note: PGI Fortran gives the warning "ieee_inexact FORTRAN STOP" with QE GPU.
 Set NO_STOP_MESSAGES=1 in your batch script to avoid the warning.
 More details on the PGI User Forum at https://www.pgroup.com/userforum
 """
@@ -23,22 +22,19 @@ toolchainopts = {'usempi': True, 'openmp': True, 'verbose': False}
 source_urls = ['https://gitlab.com/QEF/q-e-gpu/-/archive/qe-gpu-%s/' % version]
 sources = ['q-e-gpu-qe-gpu-%s.tar.bz2' % version]
 
-builddependencies = [
-    ('cudatoolkit/10.1.105_3.27-7.0.1.1_4.1__ga311ce7', EXTERNAL_MODULE),
-]
-
 dependencies = [
+    ('cudatoolkit/10.1.105_3.27-7.0.1.1_4.1__ga311ce7', EXTERNAL_MODULE),
     ('intel/19.0.1.144', EXTERNAL_MODULE)
 ]
 
-# Scalapack disabled: the GPU eigensolver can outperform the parallel CPU one 
+# Scalapack disabled: the GPU eigensolver can outperform the parallel CPU one
 configopts = ' CC=cc F77=pgf90 MPIF90=ftn '
 configopts += ' LAPACK_LIBS="$MKLROOT/lib/intel64/libmkl_lapack95_lp64.a" '
 configopts += ' BLAS_LIBS="$MKLROOT/lib/intel64/libmkl_blas95_lp64.a" '
 configopts += ' FFT_LIBS="-L$MKLROOT/lib/intel64 -lmkl_intel_lp64 -lmkl_intel_thread -lmkl_core" '
 configopts += ' --enable-openmp --enable-parallel --with-scalapack=no '
 configopts += ' --with-cuda=$CUDATOOLKIT_HOME --with-cuda-cc=60 '
-configopts += ' --with-cuda-runtime=10.1 '
+configopts += ' --with-cuda-runtime=%(cudashortver)s '
 
 # the experimental CUDA-Aware MPI (-D__GPU_MPI) does not work!
 prebuildopts = """
@@ -48,7 +44,7 @@ prebuildopts = """
     -e 's/^CFLAGS .*/CFLAGS         = -O3 $(DFLAGS) $(IFLAGS)/' \
     -e 's/^F90FLAGS .*/F90FLAGS       = -fast -Mcache_align -Mpreprocess -Mlarge_arrays -mp $(FDFLAGS) $(CUDA_F90FLAGS) $(IFLAGS) $(MODFLAGS)/' \
     -e 's/^FFLAGS .*/FFLAGS         = -fast -mp/' \
-    -e 's/^LDFLAGS .*/LDFLAGS        = -pgf90libs -mp -Mcuda=cc60,cuda10.1/' \
+    -e 's/^LDFLAGS .*/LDFLAGS        = -pgf90libs -mp -Mcuda=cc60,cuda%(cudashortver)s/' \
     make.inc &&
 """
 prebuildopts += " cat make.inc && "

--- a/easybuild/easyconfigs/s/SWIG/SWIG-3.0.12-CrayGNU-19.10-python3.eb
+++ b/easybuild/easyconfigs/s/SWIG/SWIG-3.0.12-CrayGNU-19.10-python3.eb
@@ -3,11 +3,7 @@
 name = 'SWIG'
 version = '3.0.12'
 
-local_py_maj_ver = '3'
-local_py_min_ver = '6'
-local_py_rev_ver = '5.7'
-
-versionsuffix = '-python%s' % (local_py_maj_ver)
+versionsuffix = '-python%(pymajver)s'
 
 homepage = 'http://www.swig.org/'
 description = """SWIG is a software development tool that connects programs written in C and C++ with
@@ -20,13 +16,13 @@ source_urls = [SOURCEFORGE_SOURCE]
 sources = [SOURCELOWER_TAR_GZ]
 
 dependencies = [
-    ('cray-python/%s.%s.%s' % (local_py_maj_ver, local_py_min_ver, local_py_rev_ver), EXTERNAL_MODULE),
+    ('cray-python/3.6.5.7', EXTERNAL_MODULE),
     ('PCRE', '8.42'),
 ]
 
 configopts = 'LDFLAGS="$LDFLAGS -Wl,--rpath=$EBROOTPCRE/lib"'
-configopts += ' --with-python=/opt/python/%s.%s.%s/bin/python' % (local_py_maj_ver, local_py_min_ver, local_py_rev_ver)
-configopts += ' --with-python-version=%s.%s' % (local_py_maj_ver, local_py_min_ver)
-configopts += ' --with-python-root=/opt/python/%s.%s.%s/lib/python%s.%s' % (local_py_maj_ver, local_py_min_ver, local_py_rev_ver, local_py_maj_ver, local_py_min_ver)
+configopts += ' --with-python=/opt/python/%(pyver)s/bin/python'
+configopts += ' --with-python-version=%(pyshortver)s'
+configopts += ' --with-python-root=/opt/python/%(pyver)s/lib/python%(pyshortver)s'
 
 moduleclass = 'devel'

--- a/easybuild/easyconfigs/s/scorep_binding_python/scorep_binding_python-1.1-CrayGNU-19.10-python3.eb
+++ b/easybuild/easyconfigs/s/scorep_binding_python/scorep_binding_python-1.1-CrayGNU-19.10-python3.eb
@@ -3,12 +3,7 @@ easyblock = 'PythonPackage'
 
 name = 'scorep_binding_python'
 version = '1.1'
-local_py_maj_ver = '3'
-local_py_min_ver = '6'
-local_py_rev_ver = '5.7'
-local_pyver = '%s.%s.%s' % (local_py_maj_ver, local_py_min_ver, local_py_rev_ver)
-local_pyshortver = '%s.%s' % (local_py_maj_ver, local_py_min_ver)
-versionsuffix = '-python%s' % local_py_maj_ver
+versionsuffix = '-python%(pymajver)s'
 
 homepage = 'https://github.com/score-p/scorep_binding_python'
 description = """Allows tracing of python code using Score-P"""
@@ -18,22 +13,22 @@ source_urls = ['https://github.com/score-p/%(name)s/archive']
 sources = ['v%(version)s.tar.gz']
 
 dependencies = [
-    ('cray-python/%s' % local_pyver, EXTERNAL_MODULE),
+    ('cray-python/3.6.5.7', EXTERNAL_MODULE),
     ('Score-P','6.0','-cuda-10.1'),
 ]
 
 builddependencies = [
     ('CMake', '3.14.5', '', True),
-    ('PyExtensions', '%s' % local_pyver),
+    ('PyExtensions', '%(pyver)s'),
 ]
 
 options = {'modulename': 'scorep'}
 
 sanity_check_paths = {
-    'files': ['lib/python%(pv)s/site-packages/scorep/scorep_bindings.cpython-36m-x86_64-linux-gnu.so' % {'pv': local_pyshortver}],
+    'files': ['lib/python%(pyshortver)s/site-packages/scorep/scorep_bindings.cpython-36m-x86_64-linux-gnu.so'],
     'dirs': [''],
 }
 
-modextrapaths = {'PYTHONPATH': 'lib/python%s/site-packages' % local_pyshortver}
+modextrapaths = {'PYTHONPATH': 'lib/python%(pyshortver)s/site-packages'}
 
 moduleclass = 'lib'

--- a/easybuild/easyconfigs/t/TensorFlow/TensorFlow-1.14.0-CrayGNU-19.10-cuda-10.1.168-python3.eb
+++ b/easybuild/easyconfigs/t/TensorFlow/TensorFlow-1.14.0-CrayGNU-19.10-cuda-10.1.168-python3.eb
@@ -5,20 +5,8 @@ easyblock = "CmdCp"
 name = 'TensorFlow'
 version = '1.14.0'
 
-py_maj_ver = '3'
-py_min_ver = '6'
-py_rev_ver = '5.7'
-pyver = '%s.%s.%s' % (py_maj_ver, py_min_ver, py_rev_ver)
-pyshortver = '%s.%s' % (py_maj_ver, py_min_ver)
-
-cudaversion = '10.1.168'
-
-ver_suffix_cuda = '-cuda-%s' % (cudaversion)
-ver_suffix_py = '-python%s' % (py_maj_ver)
-versionsuffix = '%s%s' % (ver_suffix_cuda, ver_suffix_py)
-
-installdir = '%(installdir)s'
-builddir = '%(builddir)s'
+versionsuffix = '-cuda-%(cudaver)s-python%(pymajver)s'
+_pyminver = '6'
 
 homepage = 'https://www.tensorflow.org/'
 description = """An open-source software library for Machine Intelligence."""
@@ -26,40 +14,41 @@ description = """An open-source software library for Machine Intelligence."""
 toolchain = {'name': 'CrayGNU', 'version': '19.10'}
 
 builddependencies = [
-    ('Bazel', '0.24.1', ver_suffix_py),
+    ('Bazel', '0.24.1'),
 ]
 
 dependencies = [
-    ('cuDNN', '7.6.1', '-cuda-%s' % cudaversion, True),
-    ('SWIG', '3.0.12', ver_suffix_py),
-    ('NCCL', '2.4.7', '-cuda-%s' % cudaversion, True),
-    ('protobuf', '3.6.0', ver_suffix_py),
-    ('dask', '1.0.0', '-python%s' % py_maj_ver),
-    ('PyExtensionsDS', pyver),
-    ('CUDA', cudaversion, '', True),
+    ('cray-python/3.6.5.7', EXTERNAL_MODULE),
+    ('cuDNN', '7.6.1', '-cuda-%(cudaver)s', True),
+    ('SWIG', '3.0.12', '-python%(pymajver)s'),
+    ('NCCL', '2.4.7', '-cuda-%(cudaver)s', True),
+    ('protobuf', '3.6.0', '-python%(pymajver)s'),
+    ('dask', '1.0.0', '-python%(pymajver)s'),
+    ('PyExtensionsDS', '%(pyver)s'),
+    ('CUDA', '10.1.168', '', True),
 ]
 
 sources = ['v%(version)s.tar.gz']
 source_urls = ['https://github.com/tensorflow/tensorflow/archive/']
 
-patches = [('tensorflow-v%s-python%s-cscs.patch' % (version, py_maj_ver)),
-           ('configure-cscs-v%s.sh' % version, '%s/tensorflow-%s/' % (builddir, version))]
+patches = [('tensorflow-v%(version)s-python%(pymajver)s-cscs.patch'),
+           ('configure-cscs-v%(version)s.sh', '%(builddir)s/tensorflow-%(version)s/')]
 
 with_configure = False
 
-whl_file = 'tensorflow-%s-cp%s%s-cp%s%sm-linux_x86_64.whl' % (version, py_maj_ver, py_min_ver, py_maj_ver, py_min_ver)
+_whl_file = 'tensorflow-%%(version)s-cp%%(pymajver)s%s-cp%%(pymajver)s%sm-linux_x86_64.whl' % (_pyminver, _pyminver)
 
-build_str  = "export TEST_TMPDIR=%s/../../../bazelout/" % builddir
+build_str  = "export TEST_TMPDIR=%(builddir)s/../../../bazelout/"
 build_str += " && rm -rf $TEST_TMPDIR"
-build_str += r" && sed -i s\@'$GCC_PATH'@$GCC_PATH@g third_party/gpus/crosstool/clang/bin/crosstool_wrapper_driver_is_not_gcc.tpl" # this line in required for the patch to work
-build_str += r" && sed -i s\@'$EBROOTCUDA'@$EBROOTCUDA@g third_party/gpus/crosstool/clang/bin/crosstool_wrapper_driver_is_not_gcc.tpl" # this line in required for the patch to work
-build_str += " && export PYMAJVER=%s && export PYMINVER=%s && export PYREVVER=%s" % (py_maj_ver, py_min_ver, py_rev_ver)   # required for configure-cscs scripts
-build_str += " && bash configure-cscs-v%s.sh" % version
+build_str += " && sed -i s\@'$GCC_PATH'@$GCC_PATH@g third_party/gpus/crosstool/clang/bin/crosstool_wrapper_driver_is_not_gcc.tpl" # this line in required for the patch to work
+build_str += " && sed -i s\@'$EBROOTCUDA'@$EBROOTCUDA@g third_party/gpus/crosstool/clang/bin/crosstool_wrapper_driver_is_not_gcc.tpl" # this line in required for the patch to work
+build_str += " && export PYVER=%(pyver)s && export PYSHORTVER=%(pyshortver)s" # required for configure-cscs scripts
+build_str += " && bash configure-cscs-v%(version)s.sh"
 build_str += " && bazel build --verbose_failures --distinct_host_configuration=false --action_env=PYTHONPATH=$PYTHONPATH"
 build_str += "    --config=cuda --copt=-mavx --copt=-mavx2 --copt=-mfma --copt=-msse4.2 --copt=-msse4.1 --cxxopt='-D_GLIBCXX_USE_CXX11_ABI=0'"
 build_str += "    -c opt //tensorflow/tools/pip_package:build_pip_package"
 build_str += " && bazel-bin/tensorflow/tools/pip_package/build_pip_package %(builddir)s"
-build_str += " && pip%s install --no-deps --prefix  %s %s/" % (py_maj_ver, builddir, builddir) + whl_file
+build_str += " && pip%(pymajver)s install --no-deps --prefix  %(builddir)s %(builddir)s/" + _whl_file
 build_str += " && rm -rf $TEST_TMPDIR"
 
 cmds_map = [
@@ -67,33 +56,30 @@ cmds_map = [
 ]
 
 files_to_copy = [
-    (['%(builddir)s/' + whl_file], '%(installdir)s'),
+    (['%(builddir)s/' + _whl_file], '%(installdir)s'),
     (['%(builddir)s/bin'], '%(installdir)s'),
     (['%(builddir)s/lib'], '%(installdir)s'),
 ]
 
 exts_defaultclass = 'PythonPackage'
 
+exts_default_options = {
+    'req_py_majver': '%(pymajver)s',
+    'req_py_minver': '%s' % _pyminver,
+    'source_urls': [PYPI_SOURCE]
+}
+
 exts_list = [
     ('tensorflow-estimator', version, {
-        'req_py_majver': '3',
-        'req_py_minver': '6',
-        'source_urls': ['https://pypi.python.org/packages/source/t/tensorflow_estimator'],
         'source_tmpl': 'tensorflow_estimator-%(version)s-py2.py3-none-any.whl',
         'modulename': 'tensorflow_estimator',
         'unpack_sources': False,
         'use_pip' : True,
     }),
     ('grpcio', '1.22.0', {
-        'req_py_majver': '3',
-        'req_py_minver': '6',
-        'source_urls': ['https://pypi.python.org/packages/source/g/grpcio'],
         'modulename': 'grpc',
     }),
     ('tensorboard', '1.14.0', {
-        'req_py_majver': '3',
-        'req_py_minver': '6',
-        'source_urls': ['https://pypi.python.org/packages/source/t/tensorboard'],
         'source_tmpl': 'tensorboard-1.14.0-py3-none-any.whl',
         'unpack_sources': False,
         'use_pip' : True,
@@ -101,12 +87,12 @@ exts_list = [
 ]
 
 sanity_check_paths = {
-    'files': [whl_file],
-    'dirs': ['%s/lib/python%s.%s/site-packages' % (installdir, py_maj_ver, py_min_ver)],
+    'files': [_whl_file],
+    'dirs': ['lib/python%(pyshortver)s/site-packages'],
 }
 
 modextrapaths = {
-    'PYTHONPATH': 'lib/python%s.%s/site-packages' % (py_maj_ver, py_min_ver),
+    'PYTHONPATH': 'lib/python%(pyshortver)s/site-packages'
 }
 
 moduleclass = 'devel'

--- a/easybuild/easyconfigs/t/TensorFlow/TensorFlow-1.14.0-CrayGNU-19.10-cuda-10.1.168-python3.eb
+++ b/easybuild/easyconfigs/t/TensorFlow/TensorFlow-1.14.0-CrayGNU-19.10-cuda-10.1.168-python3.eb
@@ -40,15 +40,15 @@ _whl_file = 'tensorflow-%%(version)s-cp%%(pymajver)s%s-cp%%(pymajver)s%sm-linux_
 
 build_str  = "export TEST_TMPDIR=%(builddir)s/../../../bazelout/"
 build_str += " && rm -rf $TEST_TMPDIR"
-build_str += " && sed -i s\@'$GCC_PATH'@$GCC_PATH@g third_party/gpus/crosstool/clang/bin/crosstool_wrapper_driver_is_not_gcc.tpl" # this line in required for the patch to work
-build_str += " && sed -i s\@'$EBROOTCUDA'@$EBROOTCUDA@g third_party/gpus/crosstool/clang/bin/crosstool_wrapper_driver_is_not_gcc.tpl" # this line in required for the patch to work
+build_str += r" && sed -i s\@'$GCC_PATH'@$GCC_PATH@g third_party/gpus/crosstool/clang/bin/crosstool_wrapper_driver_is_not_gcc.tpl" # this line in required for the patch to work
+build_str += r" && sed -i s\@'$EBROOTCUDA'@$EBROOTCUDA@g third_party/gpus/crosstool/clang/bin/crosstool_wrapper_driver_is_not_gcc.tpl" # this line in required for the patch to work
 build_str += " && export PYVER=%(pyver)s && export PYSHORTVER=%(pyshortver)s" # required for configure-cscs scripts
 build_str += " && bash configure-cscs-v%(version)s.sh"
 build_str += " && bazel build --verbose_failures --distinct_host_configuration=false --action_env=PYTHONPATH=$PYTHONPATH"
 build_str += "    --config=cuda --copt=-mavx --copt=-mavx2 --copt=-mfma --copt=-msse4.2 --copt=-msse4.1 --cxxopt='-D_GLIBCXX_USE_CXX11_ABI=0'"
 build_str += "    -c opt //tensorflow/tools/pip_package:build_pip_package"
 build_str += " && bazel-bin/tensorflow/tools/pip_package/build_pip_package %(builddir)s"
-build_str += " && pip%(pymajver)s install --no-deps --prefix  %(builddir)s %(builddir)s/" + _whl_file
+build_str += " && pip%(pymajver)s install --no-deps --prefix %(builddir)s %(builddir)s/" + _whl_file
 build_str += " && rm -rf $TEST_TMPDIR"
 
 cmds_map = [

--- a/easybuild/easyconfigs/t/TensorFlow/TensorFlow-2.0.0-CrayGNU-19.10-cuda-10.1.168.eb
+++ b/easybuild/easyconfigs/t/TensorFlow/TensorFlow-2.0.0-CrayGNU-19.10-cuda-10.1.168.eb
@@ -5,19 +5,8 @@ easyblock = "CmdCp"
 name = 'TensorFlow'
 version = '2.0.0'
 
-py_maj_ver = '3'
-py_min_ver = '6'
-py_rev_ver = '5.7'
-pyver = '%s.%s.%s' % (py_maj_ver, py_min_ver, py_rev_ver)
-pyshortver = '%s.%s' % (py_maj_ver, py_min_ver)
-
-cudaversion = '10.1.168'
-
-versionsuffix = '-cuda-%s' % (cudaversion)
-ver_suffix_py = '-python%s' % (py_maj_ver)
-
-installdir = '%(installdir)s'
-builddir = '%(builddir)s'
+versionsuffix = '-cuda-%(cudaver)s'
+_pyminver = '6'
 
 homepage = 'https://www.tensorflow.org/'
 description = """An open-source software library for Machine Intelligence."""
@@ -25,40 +14,41 @@ description = """An open-source software library for Machine Intelligence."""
 toolchain = {'name': 'CrayGNU', 'version': '19.10'}
 
 builddependencies = [
-    ('Bazel', '0.24.1', ver_suffix_py),
+    ('Bazel', '0.24.1'),
 ]
 
 dependencies = [
-    ('cuDNN', '7.6.4', '-cuda-%s' % cudaversion, True),
-    ('SWIG', '3.0.12', ver_suffix_py),
-    ('NCCL', '2.4.8', '-cuda-%s' % cudaversion, True),
-    ('protobuf', '3.6.0', ver_suffix_py),
-    ('dask', '1.0.0', '-python%s' % py_maj_ver),
+    ('cray-python/3.6.5.7', EXTERNAL_MODULE),
+    ('cuDNN', '7.6.4', '-cuda-%(cudaver)s', True),
+    ('SWIG', '3.0.12', '-python%(pymajver)s'),
+    ('NCCL', '2.4.8', '-cuda-%(cudaver)s', True),
+    ('protobuf', '3.6.0', '-python%(pymajver)s'),
+    ('dask', '1.0.0', '-python%(pymajver)s'),
     ('prereq', 'tf-2.0'),
-    ('CUDA', cudaversion, '', True),
+    ('CUDA', '10.1.168', '', True),
 ]
 
 sources = ['v%(version)s.tar.gz']
 source_urls = ['https://github.com/tensorflow/tensorflow/archive/']
 
-patches = [('tensorflow-v%s-cuda%s-cscs.patch' % (version, cudaversion)),
-           ('configure-cscs-v%s.sh' % version, '%s/tensorflow-%s/' % (builddir, version))]
+patches = [('tensorflow-v%(version)s-cuda%(cudaver)s-cscs.patch'),
+           ('configure-cscs-v%(version)s.sh', '%(builddir)s/tensorflow-%(version)s/')]
 
 with_configure = False
 
-whl_file = 'tensorflow-%s-cp%s%s-cp%s%sm-linux_x86_64.whl' % (version, py_maj_ver, py_min_ver, py_maj_ver, py_min_ver)
+_whl_file = 'tensorflow-%%(version)s-cp%%(pymajver)s%s-cp%%(pymajver)s%sm-linux_x86_64.whl' % (_pyminver, _pyminver)
 
-build_str  = "export TEST_TMPDIR=%s/../../../bazelout/" % builddir
+build_str  = "export TEST_TMPDIR=%(builddir)s/../../../bazelout/"
 build_str += " && rm -rf $TEST_TMPDIR"
-build_str += " && sed -i s\@'$GCC_PATH'@$GCC_PATH@g third_party/gpus/crosstool/clang/bin/crosstool_wrapper_driver_is_not_gcc.tpl" # this line in required for the patch to work
-build_str += " && sed -i s\@'$EBROOTCUDA'@$EBROOTCUDA@g third_party/gpus/crosstool/clang/bin/crosstool_wrapper_driver_is_not_gcc.tpl" # this line in required for the patch to work
-build_str += " && export PYMAJVER=%s && export PYMINVER=%s && export PYREVVER=%s" % (py_maj_ver, py_min_ver, py_rev_ver)   # required for configure-cscs scripts
-build_str += " && bash configure-cscs-v%s.sh" % version
+build_str += " && sed -i s\@'$GCC_PATH'@$GCC_PATH@g third_party/gpus/crosstool/clang/bin/crosstool_wrapper_driver_is_not_gcc.tpl"
+build_str += " && sed -i s\@'$EBROOTCUDA'@$EBROOTCUDA@g third_party/gpus/crosstool/clang/bin/crosstool_wrapper_driver_is_not_gcc.tpl"
+build_str += " && export PYVER=%(pyver)s && export PYSHORTVER=%(pyshortver)s"
+build_str += " && bash configure-cscs-v%(version)s.sh"
 build_str += " && bazel build --verbose_failures --distinct_host_configuration=false --action_env=PYTHONPATH=$PYTHONPATH"
 build_str += "    --config=v2 --config=cuda --copt=-mavx --copt=-mavx2 --copt=-mfma --copt=-msse4.2 --copt=-msse4.1 --cxxopt='-D_GLIBCXX_USE_CXX11_ABI=0'"
 build_str += "    -c opt //tensorflow/tools/pip_package:build_pip_package"
 build_str += " && bazel-bin/tensorflow/tools/pip_package/build_pip_package %(builddir)s"
-build_str += " && pip%s install --no-deps --prefix  %s %s/" % (py_maj_ver, builddir, builddir) + whl_file
+build_str += " && pip%(pymajver)s install --no-deps --prefix  %(builddir)s %(builddir)s/" + _whl_file
 build_str += " && rm -rf $TEST_TMPDIR"
 
 cmds_map = [
@@ -66,67 +56,42 @@ cmds_map = [
 ]
 
 files_to_copy = [
-    (['%(builddir)s/' + whl_file], '%(installdir)s'),
+    (['%(builddir)s/' + _whl_file], '%(installdir)s'),
     (['%(builddir)s/bin'], '%(installdir)s'),
     (['%(builddir)s/lib'], '%(installdir)s'),
 ]
 
 exts_defaultclass = 'PythonPackage'
+exts_default_options = {
+    'req_py_majver': '%(pymajver)s',
+    'req_py_minver': '%s' % _pyminver,
+    'source_urls': [PYPI_SOURCE]
+}
 
 exts_list = [
-    # ('wrapt', '1.11.2', {
-    #         'req_py_majver': '3',
-    #         'req_py_minver': '6',
-    #         'source_urls': ['https://pypi.python.org/packages/source/w/wrapt/'],
-    # }),
-    # ('setuptools', '41.0.1', {
-    #     'req_py_majver': '3',
-    #     'req_py_minver': '6',
-    #     'source_urls': ['https://pypi.python.org/packages/source/s/setuptools'],
-    #     'source_tmpl': 'setuptools-41.0.1.zip',
-    # }),
-    # ('Markdown', '3.1.1', {
-    #     'req_py_majver': '3',
-    #     'req_py_minver': '6',
-    #     'source_urls': ['https://pypi.python.org/packages/source/m/markdown'],
-    # }),
-    # ('wheel', '0.33.4', {
-    #     'req_py_majver': '3',
-    #     'req_py_minver': '6',
-    #     'source_urls': ['https://pypi.python.org/packages/source/w/wheel'],
-    # }),
     ('tensorflow-estimator', '2.0.0', {
-        'req_py_majver': '3',
-        'req_py_minver': '6',
-        'source_urls': ['https://pypi.python.org/packages/source/t/tensorflow_estimator'],
         'source_tmpl': 'tensorflow_estimator-%(version)s-py2.py3-none-any.whl',
         'modulename': 'tensorflow_estimator',
         'unpack_sources': False,
         'use_pip' : True,
     }),
     ('grpcio', '1.24.0', {
-        'req_py_majver': '3',
-        'req_py_minver': '6',
-        'source_urls': ['https://pypi.python.org/packages/source/g/grpcio'],
         'modulename': 'grpc',
     }),
     ('tensorboard', '2.0.0', {
-        'req_py_majver': '3',
-        'req_py_minver': '6',
-        'source_urls': ['https://pypi.python.org/packages/source/t/tensorboard'],
-        'source_tmpl': 'tensorboard-1.14.0-py3-none-any.whl',
+        'source_tmpl': 'tensorboard-2.0.0-py3-none-any.whl',
         'unpack_sources': False,
         'use_pip' : True,
     }),
 ]
 
 sanity_check_paths = {
-    'files': [whl_file],
-    'dirs': ['%s/lib/python%s.%s/site-packages' % (installdir, py_maj_ver, py_min_ver)],
+    'files': [_whl_file],
+    'dirs': ['lib/python%(pyshortver)s/site-packages'],
 }
 
 modextrapaths = {
-    'PYTHONPATH': 'lib/python%s.%s/site-packages' % (py_maj_ver, py_min_ver),
+    'PYTHONPATH': 'lib/python%(pyshortver)s/site-packages',
 }
 
 moduleclass = 'devel'

--- a/easybuild/easyconfigs/t/TensorFlow/configure-cscs-v1.14.0.sh
+++ b/easybuild/easyconfigs/t/TensorFlow/configure-cscs-v1.14.0.sh
@@ -2,8 +2,8 @@
 
 CONF_IN="configure.in"
 
-echo "/opt/python/$PYMAJVER.$PYMINVER.$PYREVVER/bin/python"$PYMAJVER > $CONF_IN
-echo "/opt/python/$PYMAJVER.$PYMINVER.$PYREVVER/lib/python"$PYMAJVER"."$PYMINVER"/site-packages" >> $CONF_IN
+echo "/opt/python/$PYVER/bin/python" > $CONF_IN
+echo "/opt/python/$PYVER/lib/python"$PYSHORTVER"/site-packages" >> $CONF_IN
 echo "n" >> $CONF_IN # Do you wish to build TensorFlow with XLA JIT support? [Y/n]:
 echo "n" >> $CONF_IN # Do you wish to build TensorFlow with OpenCL SYCL support? [y/N]:
 echo "n" >> $CONF_IN # Do you wish to build TensorFlow with ROCm support? [y/N]:
@@ -15,7 +15,7 @@ echo "2.4.7" >> $CONF_IN # Please specify the NCCL version you want to use.
 echo "$EBROOTCUDA,$EBROOTCUDNN,$EBROOTNCCL" >> $CONF_IN # Please specify the comma-separated list of base paths to look for CUDA libraries and headers.
 echo "6.0" >> $CONF_IN # Please specify a list of comma-separated Cuda compute capabilities you want to build with.
 echo "n" >> $CONF_IN # Do you want to use clang as CUDA compiler? [y/N] n
-echo $GCC_PATH"/bin/gcc" >> $CONF_IN # Please specify which gcc should be used by nvcc as the host compiler 
+echo $GCC_PATH"/bin/gcc" >> $CONF_IN # Please specify which gcc should be used by nvcc as the host compiler
 echo "n" >> $CONF_IN # MPI support?
 echo "-march=native" >> $CONF_IN # Please specify optimization flags "--config=opt" :
 echo "n" >> $CONF_IN # Android builds?

--- a/easybuild/easyconfigs/t/TensorFlow/configure-cscs-v2.0.0.sh
+++ b/easybuild/easyconfigs/t/TensorFlow/configure-cscs-v2.0.0.sh
@@ -2,8 +2,8 @@
 
 CONF_IN="configure.in"
 
-echo "/opt/python/$PYMAJVER.$PYMINVER.$PYREVVER/bin/python"$PYMAJVER > $CONF_IN
-echo "/opt/python/$PYMAJVER.$PYMINVER.$PYREVVER/lib/python"$PYMAJVER"."$PYMINVER"/site-packages" >> $CONF_IN
+echo "/opt/python/$PYVER/bin/python" > $CONF_IN
+echo "/opt/python/$PYVER/lib/python"$PYSHORTVER"/site-packages" >> $CONF_IN
 echo "n" >> $CONF_IN # Do you wish to build TensorFlow with XLA JIT support? [Y/n]:
 echo "n" >> $CONF_IN # Do you wish to build TensorFlow with OpenCL SYCL support? [y/N]:
 echo "n" >> $CONF_IN # Do you wish to build TensorFlow with ROCm support? [y/N]:

--- a/easybuild/easyconfigs/v/VASP/VASP-5.4.4-CrayIntel-19.10-cuda-10.1.eb
+++ b/easybuild/easyconfigs/v/VASP/VASP-5.4.4-CrayIntel-19.10-cuda-10.1.eb
@@ -3,8 +3,7 @@ easyblock = 'MakeCp'
 
 name = 'VASP'
 version = '5.4.4'
-local_cudaversion = '10.1'
-versionsuffix = '-cuda-%s' % local_cudaversion
+versionsuffix = '-cuda-%(cudashortver)s'
 
 homepage = 'http://www.vasp.at'
 description = """The Vienna Ab initio Simulation Package (VASP) is a computer program for atomic scale materials modelling, e.g. electronic structure calculations and quantum-mechanical molecular dynamics, from first principles. """
@@ -17,8 +16,11 @@ patches = [('%(name)s-%(version)s-%(toolchain_name)s-%(toolchain_version)s%(vers
 sources = ['/apps/common/UES/easybuild/sources/%(nameletterlower)s/%(name)s/' + SOURCELOWER_TAR_BZ2]
 
 builddependencies = [
-    (('cudatoolkit/10.1.105_3.27-7.0.1.1_4.1__ga311ce7', EXTERNAL_MODULE)),
     ('cray-fftw', EXTERNAL_MODULE),
+]
+
+dependencies = [
+    ('cudatoolkit/10.1.105_3.27-7.0.1.1_4.1__ga311ce7', EXTERNAL_MODULE),
 ]
 
 prebuildopts = ' mv %(name)s-%(version)s-%(toolchain_name)s-%(toolchain_version)s%(versionsuffix)s.makefile.include makefile.include && '


### PR DESCRIPTION
The purpose of this PR is to homogenize the recipes that have python and cuda dependencies, so that automatic updates are easier.

Main changes:
1. Whenever possible we user the python and cuda template variables (`pyver`, `pyshortver`, `pymajver`, `cudaver`, `cudashortver`, `cudamajver`)
2. For this reason cudatoolkit and cray-python are now dependencies, and not builddependencies. Files affected: `VASP`, `Amber`, `CP2K`, `GROMACS`, `Julia`, `LAMMPS`, `NAMD`, `nvtop`, `QuantumESPRESSO`
3. Use `PythonBundle` instead of `Bundle` when appropriate (no need to set ext_default_class  and modextspaths )
4. For PythonBundle easybuild will fail if some extension tries to download more extension. We have to add all of them explicitly, but this is good for reproducibility (see for example `PyExtensions-2.7.15.6-CrayGNU-19.10.eb` recipe, that was downloading python-dateutil, pytz, kiwisolver, cycler because of matplotlib, but it wasn't failing as a `Bundle`
5. Use `exts_default_options` to make the new recipes a bit shorter
6. Bazel doesn't depend on python, so it shouldn't have it on the suffix. It is used only in the tensorflow recipe so we have to change this as well
7. Add `cray-python/2.7.15.6` and `cray-python/3.6.5.6` entry in the 19.10 metadata since they are used in their respective PyExtensions recipes

Issues:
1. Still missing recipes: Visit-3.1.0-CrayGNU-19.10.eb, ParaView-5.7
2. WIP pycuda-python2, oq-engine, CPMD, VTK
3. Eb >=4.2 has to be the default in order for the PR to pass the jenkins tests
4. there is no `pyminver` template, so when it’s unavoidable, we use local variable `_pyminver`