### PR TITLE
WIP [dom-gpu] ParaView for EasyBuild 4.2 and CLE7.UP01.PS09 

### DIFF
--- a/easybuild/easyconfigs/p/ParaView/ParaView-5.8.0-EGL-CrayGNU-19.10.eb
+++ b/easybuild/easyconfigs/p/ParaView/ParaView-5.8.0-EGL-CrayGNU-19.10.eb
@@ -16,20 +16,12 @@ local_download_suffix = 'download.php?submit=Download&version=v%(version_major_m
 source_urls = ['http://www.paraview.org/paraview-downloads/%s' % local_download_suffix]
 sources = ["ParaView-v%(version)s.tar.gz"]
 
-local_py_maj_ver = '3'
-local_py_min_ver = '6'
-local_py_rev_ver = '5.7'
-
-local_pyver = '%s.%s.%s' % (local_py_maj_ver, local_py_min_ver, local_py_rev_ver)
-local_pyshortver = '%s.%s' % (local_py_maj_ver, local_py_min_ver)
-local_pysuff = '-python%s' % local_py_maj_ver
-
 dependencies = [
-    ('h5py', '2.8.0', '%s-serial' % local_pysuff),
+    ('h5py', '2.8.0', '-python%(pymajver)s-serial'),
     ('ospray', '1.8.5'),
     ('oidn', '1.1.0'),
     ('VisRTX', '0.1.6'),
-    ('cray-python/%s' % local_pyver, EXTERNAL_MODULE)
+    ('cray-python/3.6.5.7', EXTERNAL_MODULE)
 ]
 
 builddependencies = [('CMake', '3.14.5','', True)]
@@ -47,12 +39,12 @@ configopts += '-DCMAKE_BUILD_TYPE=RelWithDebInfo -DPARAVIEW_BUILD_SHARED_LIBS:BO
 # use TBB for on-the-node parallelism
 configopts += '-DVTK_SMP_IMPLEMENTATION_TYPE=TBB -DTBB_INCLUDE_DIR:PATH=/opt/intel/compilers_and_libraries/linux/tbb/include '
 configopts += '-DTBB_LIBRARY_RELEASE:FILEPATH=${EBROOTOSPRAY}/lib/libtbb.so -DTBB_MALLOC_LIBRARY_RELEASE:FILEPATH=${EBROOTOSPRAY}/lib/libtbbmalloc.so '
-# for daint, February 12, 2020
-configopts += '-DOPENGL_opengl_LIBRARY=/opt/cray/nvidia/default/lib64/libOpenGL.so '
-configopts += '-DOPENGL_egl_LIBRARY=/opt/cray/nvidia/default/lib64/libEGL.so '
-# for Dom, February 12, 2020
-#configopts += '-DOPENGL_opengl_LIBRARY=/usr/lib64/libOpenGL.so '
-#configopts += '-DOPENGL_egl_LIBRARY=/usr/lib64/libEGL.so '
+# before  CLE7.UP01.PS09
+#configopts += '-DOPENGL_opengl_LIBRARY=/opt/cray/nvidia/default/lib64/libOpenGL.so '
+#configopts += '-DOPENGL_egl_LIBRARY=/opt/cray/nvidia/default/lib64/libEGL.so '
+# for  CLE7.UP01.PS09 which includes a new NVIDIA driver
+configopts += '-DOPENGL_opengl_LIBRARY=/usr/lib64/libOpenGL.so '
+configopts += '-DOPENGL_egl_LIBRARY=/usr/lib64/libEGL.so '
 #
 configopts += '-DOPENGL_INCLUDE_DIR=/opt/cray/nvidia/default/include '
 configopts += '-DPARAVIEW_ENABLE_XDMF3:BO0L=OFF '
@@ -84,15 +76,20 @@ configopts += '-DPARAVIEW_PLUGIN_ENABLE_pvNVIDIAIndeX:BOOL=ON '
 # first serial attempt would fail.
 #prebuildopts = 'make VTKData ;'
 
-modextravars = { 'LD_LIBRARY_PATH':'/apps/common/UES/easybuild/sources/p/ParaView/nvindex_default/linux-x86-64/lib:/project/g33/messmerp/cosmo/backup/vizlibs:/project/g33/messmerp/driver/NVIDIA-Linux-x86_64-418.39:/opt/python/%s/lib:$::env(LD_LIBRARY_PATH)' % local_pyver, 
+# before  CLE7.UP01.PS09
+#modextravars = { 'LD_LIBRARY_PATH':'/apps/common/UES/easybuild/sources/p/ParaView/nvindex_default/linux-x86-64/lib:/project/g33/messmerp/cosmo/backup/vizlibs:/project/g33/messmerp/driver/NVIDIA-Linux-x86_64-418.39:/opt/python/%s/lib:$::env(LD_LIBRARY_PATH)' % pyver, 
+#                 'NVINDEX_PVPLUGIN_HOME':'/apps/common/UES/easybuild/sources/p/ParaView',
+#               }
+# for  CLE7.UP01.PS09 which includes the new NVIDIA driver
+modextravars = { 'LD_LIBRARY_PATH':'/apps/common/UES/easybuild/sources/p/ParaView/nvindex_default/linux-x86-64/lib:/opt/python/%(pyver)s/lib:$::env(LD_LIBRARY_PATH)', 
                  'NVINDEX_PVPLUGIN_HOME':'/apps/common/UES/easybuild/sources/p/ParaView',
                }
 
-modextrapaths = {'PYTHONPATH': 'lib64/python%s/site-packages'% local_pyshortver}
+modextrapaths = {'PYTHONPATH': 'lib64/python%(pyshortver)s/site-packages'}
 
 sanity_check_paths = {
     'files': ['bin/pvbatch', 'bin/pvserver'],
-    'dirs': ['lib64/python%s/site-packages' % local_pyshortver,
+    'dirs': ['lib64/python%(pyshortver)s/site-packages',
              'lib64/paraview-5.8/plugins'
            ]
 }


### PR DESCRIPTION
it uses the new Python template variables and the new cmake variables for the NVIDIA driver

COMPLETED: Installation ended successfully (took 20 min 35 sec)
== Results of the build can be found in the log file(s) /scratch/snx3000tds/jfavre/daint/software/ParaView/5.8.0-CrayGNU-19.10-EGL/easybuild/easybuild-ParaView-5.8.0-20200507.112609.log