### PR TITLE
[daint-gpu] CP2K dependency libsmm with Intel MKL

### DIFF
--- a/easybuild/easyconfigs/c/CP2K/CP2K-7.1-CrayIntel-19.10-cuda-10.1.psmp
+++ b/easybuild/easyconfigs/c/CP2K/CP2K-7.1-CrayIntel-19.10-cuda-10.1.psmp
@@ -25,7 +25,7 @@ LIBS      += -L$(MKLROOT)/lib/intel64 -lmkl_scalapack_lp64 -lmkl_intel_lp64 -lmk
 LIBS      += -L$(EBROOTELPA)/lib -lelpa_openmp
 LIBS      += -L$(EBROOTLIBINTMINCP2K)/lib -lint2 -lstdc++
 LIBS      += -L$(EBROOTLIBXC)/lib -lxcf03 -lxc
-LIBS      += /apps/common/UES/easybuild/sources/c/CP2K/libsmm_dnn_cray.gnu.a
+LIBS      += /apps/common/UES/easybuild/sources/c/CP2K/libsmm_dnn_cray.intel.mkl.a
 
 # Required due to memory leak that occurs if high optimisations are used
 mp2_optimize_ri_basis.o: mp2_optimize_ri_basis.F

--- a/easybuild/easyconfigs/c/CP2K/CP2K-7.1-CrayIntel-19.10.psmp
+++ b/easybuild/easyconfigs/c/CP2K/CP2K-7.1-CrayIntel-19.10.psmp
@@ -21,7 +21,7 @@ LIBS      = -L$(MKLROOT)/lib/intel64 -lmkl_scalapack_lp64 -lmkl_intel_lp64 -lmkl
 LIBS      += -L$(EBROOTELPA)/lib -lelpa_openmp
 LIBS      += -L$(EBROOTLIBINT)/lib -lint2 -lstdc++ 
 LIBS      += -L$(EBROOTLIBXC)/lib -lxcf03 -lxc
-LIBS      += /apps/common/UES/easybuild/sources/c/CP2K/libsmm_dnn_cray.gnu.a
+LIBS      += /apps/common/UES/easybuild/sources/c/CP2K/libsmm_dnn_cray.intel.mkl.a
 
 # Required due to memory leak that occurs if high optimisations are used
 mp2_optimize_ri_basis.o: mp2_optimize_ri_basis.F


### PR DESCRIPTION
The new architecture files link the Intel MKL version of the `libsmm` library, which improves the performance of the executable `cp2k.psmp` and makes it always slightly faster than the GNU build. 
However, the size of the Intel executable is almost three times larger with respect to the GNU one:
- Intel MKL: 444M (`gpu`) and 437M (`mc`)
- GNU (`cray-libsci`, `fftw`): 162M (`gpu`) and 145M (`mc`)

The performance measured with the CP2K ReFrame checks in production (256 water molecules) improves by ~ 2% with the Intel multicore build and only by ~ 0.5% with the Intel GPU build. 