### PR TITLE
[daint-gpu] VASP 6.1.0 gpu

### DIFF
--- a/easybuild/easyconfigs/m/magma/magma-2.5.3-CrayPGI-19.10-cuda-10.1.eb
+++ b/easybuild/easyconfigs/m/magma/magma-2.5.3-CrayPGI-19.10-cuda-10.1.eb
@@ -1,0 +1,40 @@
+# created by Anton Kozhevnikov and Luca Marsella (CSCS)
+easyblock = 'CMakeMake'
+
+name = 'magma'
+version = '2.5.3'
+versionsuffix = '-cuda-10.1'
+
+homepage = 'http://icl.cs.utk.edu/magma/'
+description = """The MAGMA project aims to develop a dense linear algebra
+library similar to LAPACK but for heterogeneous/hybrid architectures, starting
+with current Multicore+GPU systems."""
+
+toolchain = {'name': 'CrayPGI', 'version': '19.10'}
+toolchainopts = {'pic': True, 'openmp': True, 'verbose': False}
+
+sources = [SOURCE_TAR_GZ]
+source_urls = ['http://icl.cs.utk.edu/projectsfiles/magma/downloads/']
+
+builddependencies = [
+  ('CMake', '3.14.5', '', True),
+  ('cudatoolkit/10.1.105_3.27-7.0.1.1_4.1__ga311ce7', EXTERNAL_MODULE)
+]
+
+dependencies = [
+  ('gcc/8.3.0', EXTERNAL_MODULE),
+  ('intel/19.0.1.144', EXTERNAL_MODULE)
+]
+
+separate_build_dir = True
+
+configopts = ' -DCUDA_NVCC_FLAGS="-DHAVE_CUBLAS -gencode=arch=compute_60,code=compute_60" -DCMAKE_C_COMPILER="gcc" -DCMAKE_CXX_COMPILER="g++" -DCMAKE_C_FLAGS="" -DCMAKE_CXX_FLAGS="" -DCMAKE_Fortran_FLAGS="" ' 
+
+buildopts = " VERBOSE=1 " 
+
+sanity_check_paths={
+    'files': ['lib/libmagma.so'],
+    'dirs': ['lib', 'include'],
+}
+
+moduleclass = 'math'

--- a/easybuild/easyconfigs/m/magma/magma-2.5.3-CrayPGI-19.10-cuda-10.1.eb
+++ b/easybuild/easyconfigs/m/magma/magma-2.5.3-CrayPGI-19.10-cuda-10.1.eb
@@ -30,8 +30,6 @@ separate_build_dir = True
 
 configopts = ' -DCUDA_NVCC_FLAGS="-DHAVE_CUBLAS -gencode=arch=compute_60,code=compute_60" -DCMAKE_C_COMPILER="gcc" -DCMAKE_CXX_COMPILER="g++" -DCMAKE_C_FLAGS="" -DCMAKE_CXX_FLAGS="" -DCMAKE_Fortran_FLAGS="" ' 
 
-buildopts = " VERBOSE=1 " 
-
 sanity_check_paths={
     'files': ['lib/libmagma.so'],
     'dirs': ['lib', 'include'],

--- a/easybuild/easyconfigs/q/QD/QD-2.3.22-CrayPgi-19.10.eb
+++ b/easybuild/easyconfigs/q/QD/QD-2.3.22-CrayPgi-19.10.eb
@@ -1,0 +1,24 @@
+# contributed by Luca Marsella (CSCS)
+easyblock = 'ConfigureMake'
+
+name = 'QD'
+version = "2.3.22"
+
+homepage = 'http://www.tddft.org/programs/octopus/wiki/index.php/Libxc'
+description = """QD is a library for real double-double and quad-double arithmetic."""
+
+toolchain = {'name': 'CrayPGI', 'version': '19.10'}
+toolchainopts = {'opt': True, 'pic': True}
+
+sources = [SOURCELOWER_TAR_GZ]
+source_urls = ['https://www.davidhbailey.com/dhbsoftware/']
+
+configopts = ' CXX=CC FC=ftn FCFLAGS="-fPIC -m64" --enable-shared --with-pic '
+
+sanity_check_paths = {
+    'files': ['lib/libqd.a', 'lib/libqd_f_main.a', 'lib/libqdmod.a',
+              'lib/libqd.so', 'lib/libqd_f_main.so', 'lib/libqdmod.so'],
+    'dirs': ['include', 'lib']
+}
+
+moduleclass = 'chem'

--- a/easybuild/easyconfigs/q/QD/QD-2.3.22-CrayPgi-19.10.eb
+++ b/easybuild/easyconfigs/q/QD/QD-2.3.22-CrayPgi-19.10.eb
@@ -4,7 +4,7 @@ easyblock = 'ConfigureMake'
 name = 'QD'
 version = "2.3.22"
 
-homepage = 'http://www.tddft.org/programs/octopus/wiki/index.php/Libxc'
+homepage = 'https://www.davidhbailey.com/dhbsoftware'
 description = """QD is a library for real double-double and quad-double arithmetic."""
 
 toolchain = {'name': 'CrayPGI', 'version': '19.10'}

--- a/easybuild/easyconfigs/v/VASP/VASP-6.1.0-CrayPGI-19.10-cuda-10.1.eb
+++ b/easybuild/easyconfigs/v/VASP/VASP-6.1.0-CrayPGI-19.10-cuda-10.1.eb
@@ -18,9 +18,9 @@ sources = ['/apps/common/UES/easybuild/sources/%(nameletterlower)s/%(name)s/' + 
 
 builddependencies = [
     ('cudatoolkit/10.1.105_3.27-7.0.1.1_4.1__ga311ce7', EXTERNAL_MODULE),
-    ('cray-fftw', EXTERNAL_MODULE),
-    ('QD', 3.2.22),
-    ('Wannier90', 3.1.0)
+    ('cray-fftw/3.3.8.3', EXTERNAL_MODULE),
+    ('QD', '2.3.22'),
+#    ('Wannier90', '3.1.0')
 ]
 
 prebuildopts = ' mv %(name)s-%(version)s-%(toolchain_name)s-%(toolchain_version)s%(versionsuffix)s.makefile.include makefile.include && '

--- a/easybuild/easyconfigs/v/VASP/VASP-6.1.0-CrayPGI-19.10-cuda-10.1.eb
+++ b/easybuild/easyconfigs/v/VASP/VASP-6.1.0-CrayPGI-19.10-cuda-10.1.eb
@@ -19,6 +19,7 @@ sources = ['/apps/common/UES/easybuild/sources/%(nameletterlower)s/%(name)s/' + 
 builddependencies = [
     ('cudatoolkit/10.1.105_3.27-7.0.1.1_4.1__ga311ce7', EXTERNAL_MODULE),
     ('cray-fftw/3.3.8.3', EXTERNAL_MODULE),
+    ('magma', '2.5.3', '-cuda-%s' % local_cudaversion),
     ('QD', '2.3.22'),
 #    ('Wannier90', '3.1.0')
 ]

--- a/easybuild/easyconfigs/v/VASP/VASP-6.1.0-CrayPGI-19.10-cuda-10.1.eb
+++ b/easybuild/easyconfigs/v/VASP/VASP-6.1.0-CrayPGI-19.10-cuda-10.1.eb
@@ -1,0 +1,41 @@
+# contributed by Luca Marsella (CSCS)
+easyblock = 'MakeCp'
+
+name = 'VASP'
+version = '6.1.0'
+local_cudaversion = '10.1'
+versionsuffix = '-cuda-%s' % local_cudaversion
+
+homepage = 'http://www.vasp.at'
+description = """The Vienna Ab initio Simulation Package (VASP) is a computer program for atomic scale materials modelling, e.g. electronic structure calculations and quantum-mechanical molecular dynamics, from first principles. """
+
+toolchain = {'name': 'CrayPGI', 'version': '19.10'}
+toolchainopts = { 'usempi': True }
+
+patches = [('%(name)s-%(version)s-%(toolchain_name)s-%(toolchain_version)s%(versionsuffix)s.makefile.include', '%(builddir)s/%(namelower)s-%(version)s')]
+
+sources = ['/apps/common/UES/easybuild/sources/%(nameletterlower)s/%(name)s/' + SOURCELOWER_TAR_BZ2]
+
+builddependencies = [
+    ('cudatoolkit/10.1.105_3.27-7.0.1.1_4.1__ga311ce7', EXTERNAL_MODULE),
+    ('cray-fftw', EXTERNAL_MODULE),
+    ('QD', 3.2.22),
+    ('Wannier90', 3.1.0)
+]
+
+prebuildopts = ' mv %(name)s-%(version)s-%(toolchain_name)s-%(toolchain_version)s%(versionsuffix)s.makefile.include makefile.include && '
+
+# don't use parallel make, results in compilation failure
+parallel = 1
+
+# build type
+buildopts = ' gpu gpu_ncl '
+
+files_to_copy = [(['./bin/vasp_*'],'bin')]
+
+sanity_check_paths = {
+    'files': ['bin/vasp_gpu','bin/vasp_gpu_ncl'],
+    'dirs': [],
+}
+
+moduleclass = 'phys'

--- a/easybuild/easyconfigs/v/VASP/VASP-6.1.0-CrayPGI-19.10-cuda-10.1.eb
+++ b/easybuild/easyconfigs/v/VASP/VASP-6.1.0-CrayPGI-19.10-cuda-10.1.eb
@@ -19,9 +19,12 @@ sources = ['/apps/common/UES/easybuild/sources/%(nameletterlower)s/%(name)s/' + 
 builddependencies = [
     ('cudatoolkit/10.1.105_3.27-7.0.1.1_4.1__ga311ce7', EXTERNAL_MODULE),
     ('cray-fftw/3.3.8.3', EXTERNAL_MODULE),
+    ('Wannier90', '3.1.0')
+]
+
+dependencies = [
     ('magma', '2.5.3', '-cuda-%s' % local_cudaversion),
     ('QD', '2.3.22'),
-#    ('Wannier90', '3.1.0')
 ]
 
 prebuildopts = ' mv %(name)s-%(version)s-%(toolchain_name)s-%(toolchain_version)s%(versionsuffix)s.makefile.include makefile.include && '

--- a/easybuild/easyconfigs/v/VASP/VASP-6.1.0-CrayPGI-19.10-cuda-10.1.makefile.include
+++ b/easybuild/easyconfigs/v/VASP/VASP-6.1.0-CrayPGI-19.10-cuda-10.1.makefile.include
@@ -11,8 +11,8 @@ CPP_OPTIONS= -DHOST=\"LinuxPGI\"\
              -Dfock_dblbuf \
              -Duse_shmem \
              -D_OPENACC \
-             -DUSENCCL \
-             -DVASP2WANNIER90v2
+#             -DUSENCCL \
+#             -DVASP2WANNIER90v2
 
 CPP        = ftn -Mpreprocess -Mfree -Mextend -E $(CPP_OPTIONS) $*$(FUFFIX)  > $*$(SUFFIX)
 

--- a/easybuild/easyconfigs/v/VASP/VASP-6.1.0-CrayPGI-19.10-cuda-10.1.makefile.include
+++ b/easybuild/easyconfigs/v/VASP/VASP-6.1.0-CrayPGI-19.10-cuda-10.1.makefile.include
@@ -1,6 +1,6 @@
 # Precompiler options
-CPP_OPTIONS= -DHOST=\"LinuxPGI\"\
-             -DMPI -DMPI_BLOCK=8000 -DMPI_INPLACE -Duse_collective\
+CPP_OPTIONS= -DHOST=\"LinuxPGI\" \
+             -DMPI -DMPI_BLOCK=8000 -DMPI_INPLACE -Duse_collective \
              -DscaLAPACK \
              -DCACHE_SIZE=4000 \
              -Davoidalloc \
@@ -8,45 +8,35 @@ CPP_OPTIONS= -DHOST=\"LinuxPGI\"\
              -Duse_bse_te \
              -Dtbdyn \
              -Dqd_emulate \
-             -Dfock_dblbuf \
-             -Duse_shmem \
-             -D_OPENACC \
-#             -DUSENCCL \
-#             -DVASP2WANNIER90v2
+             -Dfock_dblbuf
 
 CPP        = ftn -Mpreprocess -Mfree -Mextend -E $(CPP_OPTIONS) $*$(FUFFIX)  > $*$(SUFFIX)
 
-FC         = ftn -acc -ta=tesla:cc60,cuda10.1
-FCL        = ftn -acc -ta=tesla:cc60,cuda10.1 -pgc++libs
+FC         = ftn
+FCL        = ftn -pgc++libs
 
-FREE       = -Mfree -names lowercase
-
+FREE       = -Mfree
 FFLAGS     = -Mnoupcase -Mbackslash -Mlarge_arrays
 OFLAG      = -fast
-DEBUG      = -Mfree -O0 -traceback
+DEBUG      = -O0 -traceback
 
-#BLAS       = $(MKLROOT)/lib/intel64/libmkl_blas95_lp64.a
-#LAPACK     = $(MKLROOT)/lib/intel64/libmkl_lapack95_lp64.a
-#BLACS      = -lmkl_blacs_intelmpi_lp64
-#SCALAPACK  = -L$(MKLROOT)/lib/intel64 -lmkl_scalapack_lp64 -lmkl_intel_lp64 -lmkl_sequential -lmkl_core -lmkl_blacs_intelmpi_lp64
+# Use Intel MKL libraries
+BLAS       = $(MKLROOT)/lib/intel64/libmkl_blas95_lp64.a
+LAPACK     = $(MKLROOT)/lib/intel64/libmkl_lapack95_lp64.a
+BLACS      = -lmkl_blacs_intelmpi_lp64
+SCALAPACK  = -L$(MKLROOT)/lib/intel64 -lmkl_scalapack_lp64 -lmkl_intel_lp64 -lmkl_sequential -lmkl_core -lmkl_blacs_intelmpi_lp64
 
-# Use PGI provided BLAS and LAPACK libraries
-BLAS       = -lblas
-LAPACK     = -llapack
-BLACS      =
-SCALAPACK  = -Mscalapack
-
-CUDA       = -Mcudalib=cublas -Mcudalib=cufft -Mcudalib=cusolver -Mcuda
-LLIBS      = $(SCALAPACK) $(LAPACK) $(BLAS) $(CUDA)
+LLIBS      = $(SCALAPACK) $(LAPACK) $(BLAS)
 
 # Software emulation of quadruple precsion
+QD         ?= $(EBROOTQD)
 LLIBS      += -L$(EBROOTQD)/lib -lqdmod -lqd
 INCS       += -I$(EBROOTQD)/include/qd
 
 # Use the FFTs from fftw
-OBJECTS    = fftmpiw.o fftmpi_map.o fftw3d.o fft3dlib.o
 LLIBS      += -L$(FFTW_DIR) -lfftw3
 INCS       += -I$(FFTW_INC)
+OBJECTS    = fftmpiw.o fftmpi_map.o fftw3d.o fft3dlib.o
 
 # Redefine the standard list of O1 and O2 objects
 SOURCE_O1  := pade_fit.o
@@ -63,8 +53,28 @@ FREE_LIB   = $(FREE)
 OBJECTS_LIB= linpack_double.o getshmem.o
 
 # For the parser library
-CXX_PARS   = CC --no_warnings
+CXX_PARS   = pgc++ --no_warnings
 
 # Normally no need to change this
 SRCDIR     = ../../src
 BINDIR     = ../../bin
+
+#================================================
+# GPU Stuff
+
+CPP_GPU    = -DCUDA_GPU -DRPROMU_CPROJ_OVERLAP -DCUFFT_MIN=28 -UscaLAPACK -Ufock_dblbuf # -DUSE_PINNED_MEMORY 
+
+OBJECTS_GPU= fftmpiw.o fftmpi_map.o fft3dlib.o fftw3d_gpu.o fftmpiw_gpu.o
+
+CC         = cc
+CXX        = CC
+CFLAGS     = -fPIC -DADD_ -mp -DMAGMA_WITH_MKL -DMAGMA_SETAFFINITY -DGPUSHMEM=300 -DHAVE_CUBLAS
+
+CUDA_ROOT  ?= $(CUDATOOLKIT_HOME)
+NVCC       := $(CUDA_ROOT)/bin/nvcc
+CUDA_LIB   := -L$(CUDA_ROOT)/lib64 -lnvToolsExt -lcudart -lcuda -lcufft -lcublas
+
+GENCODE_ARCH    := -gencode=arch=compute_60,code=\"sm_60,compute_60\" 
+
+MAGMA_ROOT = $(EBROOTMAGMA)
+MPI_INC    = $(MPICH_DIR)/include

--- a/easybuild/easyconfigs/v/VASP/VASP-6.1.0-CrayPGI-19.10-cuda-10.1.makefile.include
+++ b/easybuild/easyconfigs/v/VASP/VASP-6.1.0-CrayPGI-19.10-cuda-10.1.makefile.include
@@ -8,7 +8,8 @@ CPP_OPTIONS= -DHOST=\"LinuxPGI\" \
              -Duse_bse_te \
              -Dtbdyn \
              -Dqd_emulate \
-             -Dfock_dblbuf
+             -Dfock_dblbuf \
+             -DVASP2WANNIER90v2
 
 CPP        = ftn -Mpreprocess -Mfree -Mextend -E $(CPP_OPTIONS) $*$(FUFFIX)  > $*$(SUFFIX)
 
@@ -25,8 +26,9 @@ BLAS       = $(MKLROOT)/lib/intel64/libmkl_blas95_lp64.a
 LAPACK     = $(MKLROOT)/lib/intel64/libmkl_lapack95_lp64.a
 BLACS      = -lmkl_blacs_intelmpi_lp64
 SCALAPACK  = -L$(MKLROOT)/lib/intel64 -lmkl_scalapack_lp64 -lmkl_intel_lp64 -lmkl_sequential -lmkl_core -lmkl_blacs_intelmpi_lp64
+WANNIER90  = $(EBROOTWANNIER90)/lib/libwannier.a
 
-LLIBS      = $(SCALAPACK) $(LAPACK) $(BLAS)
+LLIBS      = $(WANNIER90) $(SCALAPACK) $(LAPACK) $(BLAS)
 
 # Software emulation of quadruple precsion
 QD         ?= $(EBROOTQD)

--- a/easybuild/easyconfigs/v/VASP/VASP-6.1.0-CrayPGI-19.10-cuda-10.1.makefile.include
+++ b/easybuild/easyconfigs/v/VASP/VASP-6.1.0-CrayPGI-19.10-cuda-10.1.makefile.include
@@ -1,0 +1,70 @@
+# Precompiler options
+CPP_OPTIONS= -DHOST=\"LinuxPGI\"\
+             -DMPI -DMPI_BLOCK=8000 -DMPI_INPLACE -Duse_collective\
+             -DscaLAPACK \
+             -DCACHE_SIZE=4000 \
+             -Davoidalloc \
+             -Dvasp6 \
+             -Duse_bse_te \
+             -Dtbdyn \
+             -Dqd_emulate \
+             -Dfock_dblbuf \
+             -Duse_shmem \
+             -D_OPENACC \
+             -DUSENCCL \
+             -DVASP2WANNIER90v2
+
+CPP        = ftn -Mpreprocess -Mfree -Mextend -E $(CPP_OPTIONS) $*$(FUFFIX)  > $*$(SUFFIX)
+
+FC         = ftn -acc -ta=tesla:cc60,cuda10.1
+FCL        = ftn -acc -ta=tesla:cc60,cuda10.1 -pgc++libs
+
+FREE       = -Mfree -names lowercase
+
+FFLAGS     = -Mnoupcase -Mbackslash -Mlarge_arrays
+OFLAG      = -fast
+DEBUG      = -Mfree -O0 -traceback
+
+#BLAS       = $(MKLROOT)/lib/intel64/libmkl_blas95_lp64.a
+#LAPACK     = $(MKLROOT)/lib/intel64/libmkl_lapack95_lp64.a
+#BLACS      = -lmkl_blacs_intelmpi_lp64
+#SCALAPACK  = -L$(MKLROOT)/lib/intel64 -lmkl_scalapack_lp64 -lmkl_intel_lp64 -lmkl_sequential -lmkl_core -lmkl_blacs_intelmpi_lp64
+
+# Use PGI provided BLAS and LAPACK libraries
+BLAS       = -lblas
+LAPACK     = -llapack
+BLACS      =
+SCALAPACK  = -Mscalapack
+
+CUDA       = -Mcudalib=cublas -Mcudalib=cufft -Mcudalib=cusolver -Mcuda
+LLIBS      = $(SCALAPACK) $(LAPACK) $(BLAS) $(CUDA)
+
+# Software emulation of quadruple precsion
+LLIBS      += -L$(EBROOTQD)/lib -lqdmod -lqd
+INCS       += -I$(EBROOTQD)/include/qd
+
+# Use the FFTs from fftw
+OBJECTS    = fftmpiw.o fftmpi_map.o fftw3d.o fft3dlib.o
+LLIBS      += -L$(FFTW_DIR) -lfftw3
+INCS       += -I$(FFTW_INC)
+
+# Redefine the standard list of O1 and O2 objects
+SOURCE_O1  := pade_fit.o
+SOURCE_O2  := pead.o
+
+# For what used to be vasp.5.lib
+CPP_LIB    = $(CPP)
+FC_LIB     = ftn
+CC_LIB     = cc
+CFLAGS_LIB = -O
+FFLAGS_LIB = -O1 -Mfixed
+FREE_LIB   = $(FREE)
+
+OBJECTS_LIB= linpack_double.o getshmem.o
+
+# For the parser library
+CXX_PARS   = CC --no_warnings
+
+# Normally no need to change this
+SRCDIR     = ../../src
+BINDIR     = ../../bin

--- a/easybuild/easyconfigs/w/Wannier90/Wannier90-3.1.0-CrayPGI-19.10.eb
+++ b/easybuild/easyconfigs/w/Wannier90/Wannier90-3.1.0-CrayPGI-19.10.eb
@@ -1,0 +1,37 @@
+# contributed by Luca Marsella (CSCS)
+easyblock = 'MakeCp'
+
+name = 'Wannier90'
+version = '3.1.0'
+
+homepage = 'http://www.wannier.org'
+description = """A tool for obtaining maximally-localised Wannier functions"""
+
+toolchain = {'name': 'CrayPGI', 'version': '19.10'}
+
+sources = ['v3.1.0.tar.gz']
+source_urls = ['https://github.com/wannier-developers/wannier90/archive/']
+
+builddependencies = [
+  ('intel/19.0.1.144', EXTERNAL_MODULE)
+]
+
+# create make.inc with definition of compilers
+prebuildopts = ' echo -e "F90 = ftn \nCOMMS = mpi \nMPIF90 = ftn " > make.inc && '
+# append MKL library link line to make.inc
+prebuildopts += ' echo "LIBS = -L\$(MKLROOT)/lib/intel64 -lmkl_core -lmkl_intel_lp64 -lmkl_sequential" >> make.inc && cat make.inc && '
+
+# build program and library
+buildopts = 'all'
+
+files_to_copy = [
+    (['postw90.x','wannier90.x'], 'bin'), 
+    (['libwannier.a'], 'lib')
+]
+
+sanity_check_paths = {
+    'files': ['bin/postw90.x', 'bin/wannier90.x', 'lib/libwannier.a'],
+    'dirs': []
+}
+
+moduleclass = 'chem'


### PR DESCRIPTION
The pull request addresses the new build of `VASP 6.1.0` using `CrayPGI`: few more libraries are now needed as dependency, see https://www.vasp.at/wiki/index.php/Installing_VASP.6.X.X