### PR TITLE
[daint-gpu] Adding make targets for QE6.5a1

### DIFF
--- a/easybuild/easyconfigs/q/QuantumESPRESSO/QuantumESPRESSO-6.5a1-CrayPGI-19.10-cuda-10.1.eb
+++ b/easybuild/easyconfigs/q/QuantumESPRESSO/QuantumESPRESSO-6.5a1-CrayPGI-19.10-cuda-10.1.eb
@@ -52,7 +52,9 @@ prebuildopts = """
     make.inc &&
 """
 prebuildopts += " cat make.inc && "
-buildopts = 'pw'
+
+# targets 'hp' and 'gwl' fail with release 6.5a1
+buildopts = ' pwall cp ld1 upf tddfpt xspectra '
 
 # single make process
 maxparallel = 1


### PR DESCRIPTION
The pull request adds make targets to the build of `QuantumESPRESSO 6.5a1` (GPU version): it should partially address the request CSCS RT #39216, but only `cp.x` and `pw.x` are GPU enabled.

As pointed out in a comment, targets 'hp' and 'gwl' are currently failing with release `6.5a1`: I'm now trying to build the latest QE GPU release `6.5.a2` with `CrayPGI` and I will open a new pull request.