### PR TITLE
[dom-gpu] Version in Cray toolchain easyconfigs

### DIFF
--- a/easybuild/easyconfigs/c/CrayGNU/CrayGNU-19.10.eb
+++ b/easybuild/easyconfigs/c/CrayGNU/CrayGNU-19.10.eb
@@ -5,7 +5,7 @@ version = '19.10'
 
 homepage = 'https://pubs.cray.com/discover'
 description = """Toolchain using Cray compiler wrapper, using PrgEnv-gnu module
-(PE release: October 2019).\n"""
+(PE release: %s).\n""" % version
 
 toolchain = {'name': 'system', 'version': 'system'}
 
@@ -13,7 +13,7 @@ dependencies = [
     # PrgEnv version is not pinned, as Cray recommends to use the latest
     # (default) version
     ('PrgEnv-gnu', EXTERNAL_MODULE),
-    ('cdt/19.10', EXTERNAL_MODULE),
+    ('cdt/%s' % version, EXTERNAL_MODULE),
 ]
 
 # LD_LIBRARY_PATH is now updated by production.git/login/daint.footer

--- a/easybuild/easyconfigs/c/CrayIntel/CrayIntel-19.10.eb
+++ b/easybuild/easyconfigs/c/CrayIntel/CrayIntel-19.10.eb
@@ -5,7 +5,7 @@ version = '19.10'
 
 homepage = 'https://pubs.cray.com/discover'
 description = """Toolchain using Cray compiler wrapper, using PrgEnv-intel
-(PE release: October 2019).\n"""
+(PE release: %s).\n""" % version
 
 toolchain = {'name': 'system', 'version': 'system'}
 
@@ -13,7 +13,7 @@ dependencies = [
     # PrgEnv version is not pinned, as Cray recommends to use the latest
     # (default) version
     ('PrgEnv-intel', EXTERNAL_MODULE),
-    ('cdt/19.10', EXTERNAL_MODULE),
+    ('cdt/%s' % version, EXTERNAL_MODULE),
 ]
 
 # LD_LIBRARY_PATH is now updated by production.git/login/daint.footer

--- a/easybuild/easyconfigs/c/CrayPGI/CrayPGI-19.10.eb
+++ b/easybuild/easyconfigs/c/CrayPGI/CrayPGI-19.10.eb
@@ -5,7 +5,7 @@ version = '19.10'
 
 homepage = 'https://pubs.cray.com/discover'
 description = """Toolchain using Cray compiler wrapper, PrgEnv-pgi compiler
-(PE release: October 2019).\n"""
+(PE release: %s).\n""" % version
 
 toolchain = {'name': 'system', 'version': 'system'}
 
@@ -13,7 +13,7 @@ dependencies = [
     # PrgEnv version is not pinned, as Cray recommends to use the latest
     # (default) version
     ('PrgEnv-pgi', EXTERNAL_MODULE),
-    ('cdt/19.10', EXTERNAL_MODULE),
+    ('cdt/%s' % version, EXTERNAL_MODULE),
 ]
 
 # LD_LIBRARY_PATH is now updated by production.git/login/daint.footer


### PR DESCRIPTION
I have added the `version` variable to the description and to the `cdt` dependency (`EXTERNAL_MODULE`) to make it easy to automate future deployments. 
If we adopt the new easyconfig files, deploying a new Cray toolchain can be simply done using the EasyBuild option `--try-software-version`, as in the example below for `20.05` based on `19.10`:
```
eb CrayPGI-19.10.eb --hidden --try-software-version=20.05
```