### PR TITLE
[dom-gpu, daint-gpu] Eb template values in nvtop and line_profiler

### DIFF
--- a/easybuild/easyconfigs/l/line_profiler/line_profiler-2.1-CrayGNU-19.10-python3.eb
+++ b/easybuild/easyconfigs/l/line_profiler/line_profiler-2.1-CrayGNU-19.10-python3.eb
@@ -4,15 +4,7 @@ easyblock = 'PythonPackage'
 name = 'line_profiler'
 version = '2.1'
 
-local_py_maj_ver = '3'
-local_py_min_ver = '6'
-local_py_rev_ver = '5.7'
-req_py_majver = local_py_maj_ver
-req_py_minver = local_py_min_ver
-local_pyver = '%s.%s.%s' % (local_py_maj_ver, local_py_min_ver, local_py_rev_ver)
-local_pyshortver = '%s.%s' % (local_py_maj_ver, local_py_min_ver)
-
-versionsuffix = '-python%s' % (local_py_maj_ver)
+versionsuffix = '-python%(pymajver)s'
 
 homepage = 'https://github.com/rkern/line_profiler'
 description = """Line-by-line profiler for Python"""
@@ -23,13 +15,16 @@ toolchainopts = {'verbose': False}
 source_urls = ['https://github.com/rkern/%(name)s/archive']
 sources = ['%(version)s.tar.gz']
 
-dependencies = [ ('PyExtensions', local_pyver) ] # Cython
+dependencies = [
+    ('cray-python/3.6.5.7', EXTERNAL_MODULE),
+    ('PyExtensions', '%(pyver)s')
+] # Cython
 
 sanity_check_paths = {
     'files': [],
     'dirs': [(
-        'lib/python%(pv)s/site-packages/%%(name)s-%%(version)s-py%(pv)s'
-        '-linux-x86_64.egg' % {'pv': local_pyshortver}
+        'lib/python%(pyshortver)s/site-packages/%(name)s-%(version)s-py%(pyshortver)s'
+        '-linux-x86_64.egg'
     )],
 }
 

--- a/easybuild/easyconfigs/n/nvtop/nvtop-1.0.0-CrayGNU-19.10-cuda-10.1.eb
+++ b/easybuild/easyconfigs/n/nvtop/nvtop-1.0.0-CrayGNU-19.10-cuda-10.1.eb
@@ -3,7 +3,7 @@ easyblock = 'CMakeMake'
 
 name = 'nvtop'
 version = '1.0.0'
-versionsuffix = '-cuda-10.1'
+versionsuffix = '-cuda-%(cudashortver)s'
 
 homepage = 'https://github.com/Syllo/nvtop'
 description = 'htop-like GPU usage monitor'
@@ -14,6 +14,8 @@ sources = ['%(version)s.tar.gz']
 osdependencies = [('ncurses-devel')]
 builddependencies = [
     ('CMake', '3.14.5', '', True),
+]
+dependencies = [
     ('cudatoolkit/10.1.105_3.27-7.0.1.1_4.1__ga311ce7', EXTERNAL_MODULE),
 ]
 separate_build_dir = True


### PR DESCRIPTION
Since #1616 is getting too big, I am splitting the PR into smaller ones.

When `cray-python` and `cudatoolkit` are direct dependencies, we can use the easybuild template variables (pyver, pyshortver, pymajver, cudaver, cudashortver, cudamajver), in order to update the recipes more easily in the future.