### PR TITLE
[dom, daint] Fix boost patch for python[m] includes

### DIFF
--- a/easybuild/easyconfigs/b/Boost/Boost-1.70.0-CrayGNU-19.10-python3.eb
+++ b/easybuild/easyconfigs/b/Boost/Boost-1.70.0-CrayGNU-19.10-python3.eb
@@ -40,7 +40,8 @@ patches = ['Boost-1.70.0-python%(pymajver)s.patch']
 
 # for python3 the corresponding lib is libboost_python36.so
 sanity_check_paths = {
-    'files': ['lib/libboost_system.so', 'lib/libboost_mpi.so',
+    'files': ['lib/libboost_system.so',
+              'lib/libboost_mpi.so',
               'lib/libboost_python%%(pymajver)s%s.so' % _pyminver],
     'dirs': ['include/boost']
 }

--- a/easybuild/easyconfigs/b/Boost/Boost-1.70.0-CrayIntel-19.10-python3.eb
+++ b/easybuild/easyconfigs/b/Boost/Boost-1.70.0-CrayIntel-19.10-python3.eb
@@ -2,11 +2,8 @@
 name = 'Boost'
 version = '1.70.0'
 
-local_py_maj_ver = '3'
-local_py_min_ver = '6'
-local_py_rev_ver = '5.7'
-
-versionsuffix = '-python%s' % local_py_maj_ver
+_pyminver = '6'
+versionsuffix = '-python%(pymajver)s'
 
 homepage = 'http://www.boost.org/'
 description = """
@@ -21,19 +18,17 @@ source_urls = ['https://dl.bintray.com/boostorg/release/%(version)s/source/']
 
 configopts  = (
     ' --with-python=$(EBROOTPYTHON)/bin/python '
-    ' --with-python-version={0}.{1}'
-    ' --with-python-root=$(EBROOTPYTHON)/lib/python{0}.{1}'
-    .format(local_py_maj_ver, local_py_min_ver)
+    ' --with-python-version=%(pyshortver)s'
+    ' --with-python-root=$(EBROOTPYTHON)/lib/python%(pyshortver)s'
 )
 
 dependencies = [
     ('bzip2', '1.0.6'),
     ('zlib', '1.2.11'),
-    ('cray-python/%s.%s.%s' % (local_py_maj_ver, local_py_min_ver, local_py_rev_ver),
-     EXTERNAL_MODULE),
+    ('cray-python/3.6.5.7', EXTERNAL_MODULE),
 ]
 
-patches = ['Boost-1.70.0-python%s.patch' % local_py_maj_ver]
+patches = ['Boost-1.70.0-python%(pymajver)s.patch']
 
 # CURRENTLY DISABLED, SINCE IT LEADS TO COMPATIBILITY ISSUES (e. g. with ParaView, HPX)
 #
@@ -45,8 +40,9 @@ patches = ['Boost-1.70.0-python%s.patch' % local_py_maj_ver]
 
 # for python3 the corresponding lib is libboost_python36.so
 sanity_check_paths = {
-    'files': ['lib/libboost_system.so', 'lib/libboost_mpi.so',
-              'lib/libboost_python%s%s.so' % (local_py_maj_ver, local_py_min_ver)],
+    'files': ['lib/libboost_system.so',
+              'lib/libboost_mpi.so',
+              'lib/libboost_python%%(pymajver)s%s.so' % _pyminver],
     'dirs': ['include/boost']
 }
 

--- a/easybuild/easyconfigs/b/Boost/Boost-1.70.0-python3.patch
+++ b/easybuild/easyconfigs/b/Boost/Boost-1.70.0-python3.patch
@@ -1,21 +1,14 @@
 diff -Nru boost_1_70_0-original/tools/build/src/tools/python.jam boost_1_70_0/tools/build/src/tools/python.jam
 --- boost_1_70_0-original/tools/build/src/tools/python.jam
 +++ boost_1_70_0/tools/build/src/tools/python.jam
-@@ -544,7 +544,16 @@
+@@ -544,7 +544,9 @@
      }
      else
      {
 -        includes ?= $(prefix)/include/python$(version) ;
-+        if  not($(prefix)/include/python$(version)m)
-+            {
-+               debug-message "Used include path: $(prefix)/include/python$(version)m" ;
-+               includes ?= $(prefix)/include/python$(version)m ;
-+            }
-+        else
-+            {
-+               debug-message "Used include path: $(prefix)/include/python$(version)" ;
-+               includes ?= $(prefix)/include/python$(version) ;
-+            }
- 
++        includes = [ GLOB $(prefix)/include : * ] ;
++        includes = $(includes[1]) ;
++        ECHO "Using include path:" $(includes) ;
+
          local lib = $(exec-prefix)/lib ;
          libraries ?= $(lib)/python$(version)/config $(lib) ;

--- a/easybuild/easyconfigs/b/Boost/Boost-1.72.0-CrayIntel-19.10-python3.eb
+++ b/easybuild/easyconfigs/b/Boost/Boost-1.72.0-CrayIntel-19.10-python3.eb
@@ -2,11 +2,8 @@
 name = 'Boost'
 version = '1.72.0'
 
-local_py_maj_ver = '3'
-local_py_min_ver = '6'
-local_py_rev_ver = '5.7'
-
-versionsuffix = '-python%s' % local_py_maj_ver
+_pyminver = '6'
+versionsuffix = '-python%(pymajver)s'
 
 homepage = 'http://www.boost.org/'
 description = """
@@ -21,19 +18,17 @@ source_urls = ['https://dl.bintray.com/boostorg/release/%(version)s/source/']
 
 configopts  = (
     ' --with-python=$(EBROOTPYTHON)/bin/python '
-    ' --with-python-version={0}.{1}'
-    ' --with-python-root=$(EBROOTPYTHON)/lib/python{0}.{1}'
-    .format(local_py_maj_ver, local_py_min_ver)
+    ' --with-python-version=%(pyshortver)s'
+    ' --with-python-root=$(EBROOTPYTHON)/lib/python%(pyshortver)s'
 )
 
 dependencies = [
     ('bzip2', '1.0.6'),
     ('zlib', '1.2.11'),
-    ('cray-python/%s.%s.%s' % (local_py_maj_ver, local_py_min_ver, local_py_rev_ver),
-     EXTERNAL_MODULE),
+    ('cray-python/3.6.5.7', EXTERNAL_MODULE),
 ]
 
-patches = ['Boost-1.70.0-python%s.patch' % local_py_maj_ver]
+patches = ['Boost-1.70.0-python%(pymajver)s.patch']
 
 # CURRENTLY DISABLED, SINCE IT LEADS TO COMPATIBILITY ISSUES (e. g. with ParaView, HPX)
 #
@@ -45,12 +40,13 @@ patches = ['Boost-1.70.0-python%s.patch' % local_py_maj_ver]
 
 # for python3 the corresponding lib is libboost_python36.so
 sanity_check_paths = {
-    'files': ['lib/libboost_system.so', 'lib/libboost_mpi.so',
-              'lib/libboost_python%s%s.so' % (local_py_maj_ver, local_py_min_ver)],
+    'files': ['lib/libboost_system.so',
+              'lib/libboost_mpi.so',
+              'lib/libboost_python%%(pymajver)s%s.so' % _pyminver],
     'dirs': ['include/boost']
 }
 
-# also build boost_mpi
+# build boost_mpi
 boost_mpi = True
 
 moduleclass = 'devel'


### PR DESCRIPTION
The former patch had a faulty condition, which always led to using `include/python{pyshortver}m` as the py include path, however, py2.7 and py3.8 should use `include/python{pyshortver}` (without the 'm')

also update eb templates for Boost-CrayIntel 