### PR TITLE
[daint-gpu] CP2K 7.1 with SIRIUS 6.5.3 and CrayIntel

### DIFF
--- a/easybuild/easyconfigs/c/CP2K/CP2K-7.1-CrayIntel-19.10-SIRIUS-6.5.3-cuda-10.1.eb
+++ b/easybuild/easyconfigs/c/CP2K/CP2K-7.1-CrayIntel-19.10-SIRIUS-6.5.3-cuda-10.1.eb
@@ -1,0 +1,68 @@
+# contributed by Luca Marsella (CSCS)
+easyblock = 'MakeCp'
+
+name = 'CP2K'
+version = '7.1'
+local_release = '%s.0' % version
+local_siriusversion = '6.5.3'
+local_cudaversion = '10.1'
+versionsuffix = '-SIRIUS-%s-cuda-%s' % (local_siriusversion, local_cudaversion)
+
+homepage = 'http://www.cp2k.org/'
+description = """
+    CP2K is a freely available (GPL) program, written in Fortran 95, to
+    perform atomistic and molecular simulations of solid state, liquid,
+    molecular and biological systems. It provides a general framework for
+    different methods such as e.g. density functional theory (DFT) using a
+    mixed Gaussian and plane waves approach (GPW), and classical pair and
+    many-body potentials.
+"""
+
+toolchain = {'name': 'CrayIntel', 'version': '19.10'}
+toolchainopts = { 'usempi': True, 'openmp': True }
+
+patches = [(
+    '%(name)s-%(version)s-%(toolchain_name)s%(versionsuffix)s.psmp',
+    '%(builddir)s/%(namelower)s-%(version)s/arch'
+)]
+
+sources = [SOURCELOWER_TAR_BZ2]
+source_urls = [
+    'https://github.com/%(namelower)s/%(namelower)s/releases/download/v{0}'.format(local_release)
+]
+
+builddependencies = [
+    ('cudatoolkit/10.1.105_3.27-7.0.1.1_4.1__ga311ce7', EXTERNAL_MODULE),
+    ('Bison', '3.3.2'),
+    ('flex', '2.6.4')
+]
+
+dependencies = [
+    ('ELPA', '2019.11.001'),
+    ('Libint-CP2K', '2.6.0'),
+    ('libxc', '4.3.4'),
+    ('SIRIUS', '%s' % local_siriusversion, '-cuda-%s' % local_cudaversion)
+]
+
+# unload cray-libsci to link Intel MKL
+prebuildopts = 'module unload cray-libsci && '
+# build type
+buildopts = 'ARCH=%(name)s-%(version)s-%(toolchain_name)s%(versionsuffix)s VERSION=psmp'
+
+files_to_copy = [
+    (['./arch/%(name)s-%(version)s-%(toolchain_name)s%(versionsuffix)s.psmp'],'arch'),
+    (['./exe/%(name)s-%(version)s-%(toolchain_name)s%(versionsuffix)s/*'],'bin'),
+    (['./data'],'.'),
+    (['./tests'],'.')
+]
+
+sanity_check_paths = {
+    'files': ['arch/%(name)s-%(version)s-%(toolchain_name)s%(versionsuffix)s.psmp',
+              'bin/cp2k.psmp'],
+    'dirs': ['data','tests'],
+}
+
+# set custom CP2K_DATA_DIR
+modextravars = {'CP2K_DATA_DIR': '%(installdir)s/data'}
+
+moduleclass = 'chem'

--- a/easybuild/easyconfigs/c/CP2K/CP2K-7.1-CrayIntel-SIRIUS-6.5.3-cuda-10.1.psmp
+++ b/easybuild/easyconfigs/c/CP2K/CP2K-7.1-CrayIntel-SIRIUS-6.5.3-cuda-10.1.psmp
@@ -1,0 +1,43 @@
+# contributed by Luca Marsella (CSCS)
+# modules: Bison cray-hdf5 CrayIntel cudatoolkit ELPA 
+#          flex GSL Libint libxc SIRIUS SpFFT spglib
+GPUVER    = P100
+NVCC      = nvcc
+CC        = cc
+FC        = ftn
+LD        = ftn
+AR        = ar -r
+# LIBXSMM (-D__LIBXSMM) is slower than LIBSMM (-D__HAS_smm_dnn)
+DFLAGS    = -D__ACC -D__DBCSR_ACC -D__MKL -D__PW_CUDA -D__FFTW3 -D__ELPA=201911 -D__GSL -D__HDF5 -D__LIBINT -D__LIBXC -D__MAX_CONTR=4 -D__SIRIUS -D__SPFFT -D__SPGLIB -D__parallel -D__SCALAPACK -D__HAS_smm_dnn
+CFLAGS    = $(DFLAGS) -g -O3
+# The compiler flag "-fp-model precise" slows down execution by ~25% 
+# See https://software.intel.com/en-us/cpp-compiler-developer-guide-and-reference-fp-model-fp 
+FCFLAGS   = $(DFLAGS) -g -O3 -qopenmp -funroll-loops -fpp -free
+# MKL FFT is faster than FFTW3
+FCFLAGS   += -I$(MKLROOT)/include -I$(MKLROOT)/include/fftw
+FCFLAGS   += -I$(ELPA_INCLUDE_DIR)/elpa -I$(ELPA_INCLUDE_DIR)/modules 
+FCFLAGS   += -I$(EBROOTGSL)/include/gsl
+FCFLAGS   += -I$(HDF5_ROOT)/include
+FCFLAGS   += -I$(EBROOTLIBINTMINCP2K)/include 
+FCFLAGS   += -I$(EBROOTLIBXC)/include 
+FCFLAGS   += -I$(EBROOTSIRIUS)/include/sirius
+FCFLAGS   += -I$(EBROOTSPFFT)/include/spfft
+FCFLAGS   += -I$(EBROOTSPGLIB)/include
+LDFLAGS   = $(FCFLAGS)
+LDFLAGS_C = $(FCFLAGS) -nofor_main
+NVFLAGS   = $(DFLAGS) -O3 -arch sm_60
+LIBS   	  = -lcudart -lcublas -lcufft -lcusolver -lrt -lnvrtc
+LIBS      += -L$(MKLROOT)/lib/intel64 -lmkl_scalapack_lp64 -lmkl_intel_lp64 -lmkl_intel_thread -lmkl_core -lmkl_blacs_intelmpi_lp64 -lpthread -lstdc++ -ldl
+LIBS      += -L$(EBROOTELPA)/lib -lelpa_openmp
+LIBS      += -L$(EBROOTGSL)/lib -lgsl -lgslcblas
+LIBS      += -L$(HDF5_ROOT)/lib -lhdf5 -lhdf5_hl
+LIBS      += -L$(EBROOTLIBINTMINCP2K)/lib -lint2 -lstdc++
+LIBS      += -L$(EBROOTLIBXC)/lib -lxcf03 -lxc
+LIBS      += -L$(EBROOTSIRIUS)/lib64 -lsirius
+LIBS      += -L$(EBROOTSPFFT)/lib64 -lspfft
+LIBS      += -L$(EBROOTSPGLIB)/lib -lsymspg
+LIBS      += /apps/common/UES/easybuild/sources/c/CP2K/libsmm_dnn_cray.intel.mkl.a
+
+# Required due to memory leak that occurs if high optimisations are used
+mp2_optimize_ri_basis.o: mp2_optimize_ri_basis.F
+			 $(FC) -c $(subst O2,O0,$(FCFLAGS)) $<


### PR DESCRIPTION
I provide the EasyBuild scripts to link CP2K with SIRIUS, using Intel MKL on the Cray XC50.