### PR TITLE
[dom,daint] Update jupyterlab-1.1.1-CrayGNU-19.10-batchspawner.eb

### DIFF
--- a/easybuild/easyconfigs/j/jupyterlab/jupyterlab-1.1.1-CrayGNU-19.10-batchspawner.eb
+++ b/easybuild/easyconfigs/j/jupyterlab/jupyterlab-1.1.1-CrayGNU-19.10-batchspawner.eb
@@ -191,11 +191,17 @@ exts_list = [
         'source_urls': ['https://github.com/jupyterhub/batchspawner/tarball/%(version)s'],
         }),
 # ipyparaview, not yet available in pypi and npm registry, 24 April 2020
-        ('ipyparaview', 'cf1c6f4', {
+    ('ipyparaview', 'cf1c6f4', {
         'source_urls': ['https://github.com/NVIDIA/ipyparaview/tarball/%(version)s'],
         }),
     
-#code formatter
+#jupyterlab code formatter, requires a formatter e.g., black
+    ('pathspec', '0.8.0'),
+    ('typed_ast', '1.4.1'),
+    ('appdirs', '1.4.4'),
+    ('regex', '2020.6.8'),
+    ('toml', '0.10.1'),
+    ('black', '19.10b0'),
     ('jupyterlab_code_formatter', '1.1.0'),
     
     

--- a/easybuild/easyconfigs/j/jupyterlab/jupyterlab-1.1.1-CrayGNU-19.10-batchspawner.eb
+++ b/easybuild/easyconfigs/j/jupyterlab/jupyterlab-1.1.1-CrayGNU-19.10-batchspawner.eb
@@ -194,6 +194,11 @@ exts_list = [
         ('ipyparaview', 'cf1c6f4', {
         'source_urls': ['https://github.com/NVIDIA/ipyparaview/tarball/%(version)s'],
         }),
+    
+#code formatter
+    ('jupyterlab_code_formatter', '1.3.1'),
+    
+    
 # kernels
 # bash kernel, requires kernel install below, twr
     ('bash_kernel', '0.7.2'),

--- a/easybuild/easyconfigs/j/jupyterlab/jupyterlab-1.1.1-CrayGNU-19.10-batchspawner.eb
+++ b/easybuild/easyconfigs/j/jupyterlab/jupyterlab-1.1.1-CrayGNU-19.10-batchspawner.eb
@@ -196,7 +196,7 @@ exts_list = [
         }),
     
 #code formatter
-    ('jupyterlab_code_formatter', '1.3.1'),
+    ('jupyterlab_code_formatter', '1.1.0'),
     
     
 # kernels

--- a/easybuild/easyconfigs/j/jupyterlab/jupyterlab-1.1.1-CrayGNU-19.10-batchspawner.eb
+++ b/easybuild/easyconfigs/j/jupyterlab/jupyterlab-1.1.1-CrayGNU-19.10-batchspawner.eb
@@ -234,6 +234,7 @@ postinstallcmds = ["export YARN_CACHE_FOLDER=/tmp/$USER/yarn_cache && "
                    "%(installdir)s/bin/jupyter labextension install -y jupyterlab-plotly@1.0.0 --no-build && "
                    "%(installdir)s/bin/jupyter labextension install -y jupyterlab_bokeh@1.0.0 --no-build && "
                    "%(installdir)s/bin/jupyter labextension install -y bqplot@0.4.6 --no-build && "
+                   "%(installdir)s/bin/jupyter labextension install -y @ryantam626/jupyterlab_code_formatter --no-build && "                   
                    "%(installdir)s/bin/jupyter labextension install jupyterlab-topbar-extension@0.4.0 jupyterlab-system-monitor@0.4.1 --no-build && "
                    "%(installdir)s/bin/jupyter labextension install dask-labextension --no-build && "
 #                  "%(installdir)s/bin/jupyter labextension install jupyterlab-server-proxy;" #not ready for JLab 1.x


### PR DESCRIPTION
This PR adds the JupyterLab Code Formatter to JupyterLab (https://jupyterlab-code-formatter.readthedocs.io/en/latest/index.html).
It also adds one default formatter, Black, which is an industry standard for code formatting.
Dependencies of black, namely, pathspec, types_ast, appdirs, regex, toml are also included as pinned versions.
The extension also requires a serverextension to be enabled, either by the user or through the JupyterHub scripts.