### PR TITLE
[dom-gpu] Update version and versionsuffix in CrayCCE-classic

### DIFF
--- a/easybuild/easyconfigs/c/CrayCCE/CrayCCE-19.10-classic.eb
+++ b/easybuild/easyconfigs/c/CrayCCE/CrayCCE-19.10-classic.eb
@@ -1,11 +1,12 @@
 easyblock = 'CrayToolchain'
 
 name = 'CrayCCE'
-version = '19.10-classic'
+version = '19.10'
+versionsuffix = '-classic'
 
 homepage = 'https://pubs.cray.com/discover'
 description = """Toolchain using Cray compiler wrapper, using PrgEnv-cray
-(PE release: October 2019).\n"""
+(PE release: %s).\n""" %version
 
 toolchain = {'name': 'system', 'version': 'system'}
 
@@ -13,8 +14,8 @@ dependencies = [
     # PrgEnv version is not pinned, as Cray recommends to use the latest
     # (default) version
     ('PrgEnv-cray', EXTERNAL_MODULE),
-    ('cdt/19.10', EXTERNAL_MODULE),
-    ('cce/9.0.2-classic', EXTERNAL_MODULE),
+    ('cdt/%s' % version, EXTERNAL_MODULE),
+    ('cce/9.0.2%s' % versionsuffix, EXTERNAL_MODULE),
 ]
 
 # LD_LIBRARY_PATH is now updated by production.git/login/daint.footer

--- a/easybuild/easyconfigs/c/CrayCCE/CrayCCE-19.10-classic.eb
+++ b/easybuild/easyconfigs/c/CrayCCE/CrayCCE-19.10-classic.eb
@@ -6,7 +6,7 @@ versionsuffix = '-classic'
 
 homepage = 'https://pubs.cray.com/discover'
 description = """Toolchain using Cray compiler wrapper, using PrgEnv-cray
-(PE release: %s).\n""" %version
+(PE release: %s) and loading the Cray Classic compiler CCE%s.\n""" % (version, versionsuffix)
 
 toolchain = {'name': 'system', 'version': 'system'}
 


### PR DESCRIPTION
I have updated `CrayCCE-19.10-classic.eb` using the strings `version` and `versionsuffix` and I have checked that existing recipes are still built correctly by EasyBuild, e.g.:
```
$ eb ./c/CubeLib/CubeLib-4.4.4-CrayCCE-19.10-classic.eb --try-toolchain-version=20.05-classic -r
== temporary log file in case of crash /run/user/21827/easybuild/tmp/eb-89tOfN/easybuild-OzzJBu.log
== resolving dependencies ...
== processing EasyBuild easyconfig /users/lucamar/GitHub/lucamar/production/easybuild/easyconfigs/c/CrayCCE/CrayCCE-20.05-classic.eb
== building and installing CrayCCE/.20.05-classic...
== fetching files...
== creating build dir, resetting environment...
== unpacking...
== patching...
== preparing...
== configuring...
== building...
== testing...
== installing...
== taking care of extensions...
== restore after iterating...
== postprocessing...
== sanity checking...
== cleaning up...
== creating module...
== permissions...
== packaging...
== COMPLETED: Installation ended successfully (took 3 sec)
== Results of the build can be found in the log file(s) /apps/dom/UES/sandbox/lucamar/easybuild/software/CrayCCE/20.05-classic/easybuild/easybuild-CrayCCE-20.05-20200609.125914.log
== processing EasyBuild easyconfig /run/user/21827/easybuild/tmp/eb-89tOfN/tweaked_easyconfigs/CubeLib-4.4.4-CrayCCE-20.05-classic.eb
== building and installing CubeLib/4.4.4-CrayCCE-20.05-classic...
== fetching files...
== creating build dir, resetting environment...
== unpacking...
== patching...
== preparing...
== configuring...
== building...
== testing...
== installing...
== taking care of extensions...
== restore after iterating...
== postprocessing...
== sanity checking...
== cleaning up...
== creating module...
== permissions...
== packaging...
== COMPLETED: Installation ended successfully (took 49 sec)
== Results of the build can be found in the log file(s) /apps/dom/UES/sandbox/lucamar/easybuild/software/CubeLib/4.4.4-CrayCCE-20.05-classic/easybuild/easybuild-CubeLib-4.4.4-20200609.130003.log
== Build succeeded for 2 out of 2
== Temporary log file(s) /run/user/21827/easybuild/tmp/eb-89tOfN/easybuild-OzzJBu.log* have been removed.
== Temporary directory /run/user/21827/easybuild/tmp/eb-89tOfN has been removed.
```