### PR TITLE
[tsa] Change buildPath to prevent EB locks during concurrent builds

### DIFF
--- a/jenkins/Machines.groovy
+++ b/jenkins/Machines.groovy
@@ -24,7 +24,7 @@ def kesch = [name: 'kesch',
 
 def tsa = [name: 'tsa',
            archs: [],
-           buildPath: '/tmp/$USER/easybuild/build',
+           buildPath: '/tmp/$USER/easybuild/tsa',
            unusePath: '/apps/arolla/UES/modulefiles',
            modulesProduction: '',
            modulesUnuseProduction: '',


### PR DESCRIPTION
When different Jenkins projects run at the same time, EB might abort the build of a particular module in case it detects build folders/files for the same module from the other project present in the buildPath. Therefore, a separate buildPath is suggested.