### PR TITLE
[tsa] Fix Python module versions in PyExtension-2.7.16

### DIFF
--- a/easybuild/easyconfigs/p/PyExtensions/PyExtensions-2.7.16-foss-2019b.eb
+++ b/easybuild/easyconfigs/p/PyExtensions/PyExtensions-2.7.16-foss-2019b.eb
@@ -4,14 +4,14 @@ easyblock = 'PythonBundle'
 
 name = 'PyExtensions'
 version = '%(pyver)s'
-_pyminver = '6'
+_pyminver = '7'
 
 homepage = 'https://pypi.python.org/pypi'
 description = """
     This module is a bundle of Python packages based on a generic Python module
 """
 
-toolchain = {'name': 'fosscuda', 'version': '2019b'}
+toolchain = {'name': 'foss', 'version': '2019b'}
 toolchainopts = {'pic': True, 'verbose': False}
 
 dependencies = [

--- a/easybuild/easyconfigs/p/PyExtensions/PyExtensions-2.7.16-foss-2019b.eb
+++ b/easybuild/easyconfigs/p/PyExtensions/PyExtensions-2.7.16-foss-2019b.eb
@@ -22,33 +22,37 @@ dependencies = [
 
 # bundle of Python packages
 exts_defaultclass = 'PythonPackage'
+exts_default_options = {
+    'source_urls': [PYPI_SOURCE]
+}
 
 exts_list = [
     ('numpy', '1.16.4', {
-        'source_urls': ['http://pypi.python.org/packages/source/n/numpy/'],
         'source_tmpl': '%(name)s-%(version)s.zip',
     }),
-# matplotlib >= 3 requires python >= 3.5
-    ('matplotlib', '2.2.4', {
-        'source_urls': ['http://pypi.python.org/packages/source/m/matplotlib/'],
+# kiwisolver required by matplotlib
+# version 1.10 requires python >= 3.5
+    ('kiwisolver', '1.1.0'),
+    ('pyparsing', '2.4.7'),
+    ('subprocess32', '3.5.4'),
+    ('backports.functools_lru_cache', '1.6.1'),
+    ('pytz', '2020.1'),
+    ('python-dateutil', '2.8.1', {
+        'modulename': 'dateutil',
     }),
-    ('mpi4py', '3.0.2', {
-        'source_urls': ['http://pypi.python.org/packages/source/m/mpi4py/'],
-    }),
-    ('pandas', '0.24.2', {
-        'source_urls': ['http://pypi.python.org/packages/source/p/pandas/'],
-    }),
+    ('cycler', '0.10.0'),
+    ('matplotlib', '2.2.4'),
+    ('mpi4py', '3.0.2'),
+    ('pandas', '0.24.2'),
 # scipy >= 1.3.0 requires python >= 3.5
-    ('scipy', '1.2.2', {
-        'source_urls': ['http://pypi.python.org/packages/source/s/scipy/'],
-    }),
-    ('sympy', '1.4', {
-        'source_urls': ['http://pypi.python.org/packages/source/s/sympy/'],
-    }),
+    ('scipy', '1.2.2'),
+    ('mpmath', '1.1.0'),
+    ('sympy', '1.4'),
 ]
 
-# specify that Bundle easyblock should run a full sanity check, rather than just trying to load the module
-local_full_sanity_check = True
+# specify that Bundle easyblock should run a full sanity check,
+# rather than just trying to load the module
+full_sanity_check = True
 
 local_pythonpath = 'lib/python%s/site-packages' % local_pyver
 sanity_check_paths = {

--- a/easybuild/easyconfigs/p/PyExtensions/PyExtensions-2.7.16-foss-2019b.eb
+++ b/easybuild/easyconfigs/p/PyExtensions/PyExtensions-2.7.16-foss-2019b.eb
@@ -1,12 +1,8 @@
 # contributed by Luca Marsella (CSCS)
-easyblock = 'Bundle'
+easyblock = 'PythonBundle'
 
 name = 'PyExtensions'
-local_py_maj_ver = '2'
-local_py_min_ver = '7'
-local_py_rev_ver = '16'
-local_pyver = '%s.%s' % (local_py_maj_ver, local_py_min_ver)
-version = '%s.%s' % (local_pyver, local_py_rev_ver)
+version = '%(pyver)s'
 
 homepage = 'https://pypi.python.org/pypi'
 description = """
@@ -17,11 +13,9 @@ toolchain = {'name': 'foss', 'version': '2019b'}
 toolchainopts = {'pic': True, 'verbose': False}
 
 dependencies = [
-    ('Python', '%s' % version, '', True),
+    ('Python', '%(version)s', '', True),
 ]
 
-# bundle of Python packages
-exts_defaultclass = 'PythonPackage'
 exts_default_options = {
     'source_urls': [PYPI_SOURCE]
 }
@@ -30,8 +24,6 @@ exts_list = [
     ('numpy', '1.16.4', {
         'source_tmpl': '%(name)s-%(version)s.zip',
     }),
-# kiwisolver required by matplotlib
-# version 1.10 requires python >= 3.5
     ('kiwisolver', '1.1.0'),
     ('pyparsing', '2.4.7'),
     ('subprocess32', '3.5.4'),
@@ -44,17 +36,12 @@ exts_list = [
     ('matplotlib', '2.2.4'),
     ('mpi4py', '3.0.2'),
     ('pandas', '0.24.2'),
-# scipy >= 1.3.0 requires python >= 3.5
     ('scipy', '1.2.2'),
     ('mpmath', '1.1.0'),
     ('sympy', '1.4'),
 ]
 
-# specify that Bundle easyblock should run a full sanity check,
-# rather than just trying to load the module
-full_sanity_check = True
-
-local_pythonpath = 'lib/python%s/site-packages' % local_pyver
+local_pythonpath = 'lib/python%(pyshortver)s/site-packages'
 sanity_check_paths = {
     'files': [],
     'dirs': [local_pythonpath]

--- a/easybuild/easyconfigs/p/PyExtensions/PyExtensions-2.7.16-foss-2019b.eb
+++ b/easybuild/easyconfigs/p/PyExtensions/PyExtensions-2.7.16-foss-2019b.eb
@@ -13,7 +13,7 @@ toolchain = {'name': 'foss', 'version': '2019b'}
 toolchainopts = {'pic': True, 'verbose': False}
 
 dependencies = [
-    ('Python', '%(version)s', '', True),
+    ('Python', '2.7.16', '', True),
 ]
 
 exts_default_options = {

--- a/easybuild/easyconfigs/p/PyExtensions/PyExtensions-2.7.16-foss-2019b.eb
+++ b/easybuild/easyconfigs/p/PyExtensions/PyExtensions-2.7.16-foss-2019b.eb
@@ -1,15 +1,17 @@
 # contributed by Luca Marsella (CSCS)
+# modified by Matthias Kraushaar (CSCS) - 06/2020
 easyblock = 'PythonBundle'
 
 name = 'PyExtensions'
 version = '%(pyver)s'
+_pyminver = '6'
 
 homepage = 'https://pypi.python.org/pypi'
 description = """
     This module is a bundle of Python packages based on a generic Python module
 """
 
-toolchain = {'name': 'foss', 'version': '2019b'}
+toolchain = {'name': 'fosscuda', 'version': '2019b'}
 toolchainopts = {'pic': True, 'verbose': False}
 
 dependencies = [
@@ -17,17 +19,42 @@ dependencies = [
 ]
 
 exts_default_options = {
+    'req_py_majver': '%(pymajver)s',
+    'req_py_minver': '%s' % _pyminver,
     'source_urls': [PYPI_SOURCE]
 }
 
+#fixing module versions to prevent build issue due to dropping python 2 support
 exts_list = [
+    ('backports.functools_lru_cache', '1.6.1'),
+    ('funcsigs', '1.0.2'),
+    ('more-itertools', '5.0.0'),
+    ('wcwidth', '0.2.4'),
+    ('configparser', '4.0.2'),
+    ('contextlib2', '0.6.0'),
+    ('zipp', '1.2.0'),
+    ('scandir', '1.10.0'),
+    ('attrs', '19.3.0', {
+        'modulename': 'attr',
+    }),
+    ('pathlib2', '2.3.5'),
+    ('importlib-metadata', '1.1.3', {
+        'source_tmpl': 'importlib_metadata-%(version)s.tar.gz',
+    }),
+    ('pluggy', '0.13.1'),
+    ('atomicwrites', '1.4.0'),
+    ('pyparsing', '2.4.7'),
+    ('packaging', '20.4'),
+    ('py', '1.8.1'),
+    ('pytest', '4.6.0', {
+        'modulename': 'pytest',
+    }),
     ('numpy', '1.16.4', {
         'source_tmpl': '%(name)s-%(version)s.zip',
     }),
     ('kiwisolver', '1.1.0'),
     ('pyparsing', '2.4.7'),
     ('subprocess32', '3.5.4'),
-    ('backports.functools_lru_cache', '1.6.1'),
     ('pytz', '2020.1'),
     ('python-dateutil', '2.8.1', {
         'modulename': 'dateutil',
@@ -41,12 +68,9 @@ exts_list = [
     ('sympy', '1.4'),
 ]
 
-local_pythonpath = 'lib/python%(pyshortver)s/site-packages'
 sanity_check_paths = {
     'files': [],
-    'dirs': [local_pythonpath]
+    'dirs': ['lib/python%(pyshortver)s/site-packages']
 }
-
-modextrapaths = {'PYTHONPATH': local_pythonpath}
 
 moduleclass = 'tools'

--- a/easybuild/easyconfigs/p/PyExtensions/PyExtensions-2.7.16-fosscuda-2019b.eb
+++ b/easybuild/easyconfigs/p/PyExtensions/PyExtensions-2.7.16-fosscuda-2019b.eb
@@ -1,8 +1,10 @@
 # contributed by Luca Marsella (CSCS)
+# modified by Matthias Kraushaar (CSCS) - 06/2020
 easyblock = 'PythonBundle'
 
 name = 'PyExtensions'
 version = '%(pyver)s'
+_pyminver = '6'
 
 homepage = 'https://pypi.python.org/pypi'
 description = """
@@ -17,17 +19,42 @@ dependencies = [
 ]
 
 exts_default_options = {
+    'req_py_majver': '%(pymajver)s',
+    'req_py_minver': '%s' % _pyminver,
     'source_urls': [PYPI_SOURCE]
 }
 
+#fixing module versions to prevent build issue due to dropping python 2 support
 exts_list = [
+    ('backports.functools_lru_cache', '1.6.1'),
+    ('funcsigs', '1.0.2'),
+    ('more-itertools', '5.0.0'),
+    ('wcwidth', '0.2.4'),
+    ('configparser', '4.0.2'),
+    ('contextlib2', '0.6.0'),
+    ('zipp', '1.2.0'),
+    ('scandir', '1.10.0'),
+    ('attrs', '19.3.0', {
+        'modulename': 'attr',
+    }),
+    ('pathlib2', '2.3.5'),
+    ('importlib-metadata', '1.1.3', {
+        'source_tmpl': 'importlib_metadata-%(version)s.tar.gz',
+    }),
+    ('pluggy', '0.13.1'),
+    ('atomicwrites', '1.4.0'),
+    ('pyparsing', '2.4.7'),
+    ('packaging', '20.4'),
+    ('py', '1.8.1'),
+    ('pytest', '4.6.0', {
+        'modulename': 'pytest',
+    }),
     ('numpy', '1.16.4', {
         'source_tmpl': '%(name)s-%(version)s.zip',
     }),
     ('kiwisolver', '1.1.0'),
     ('pyparsing', '2.4.7'),
     ('subprocess32', '3.5.4'),
-    ('backports.functools_lru_cache', '1.6.1'),
     ('pytz', '2020.1'),
     ('python-dateutil', '2.8.1', {
         'modulename': 'dateutil',
@@ -41,12 +68,9 @@ exts_list = [
     ('sympy', '1.4'),
 ]
 
-local_pythonpath = 'lib/python%(pyshortver)s/site-packages'
 sanity_check_paths = {
     'files': [],
-    'dirs': [local_pythonpath]
+    'dirs': ['lib/python%(pyshortver)s/site-packages']
 }
-
-modextrapaths = {'PYTHONPATH': local_pythonpath}
 
 moduleclass = 'tools'

--- a/easybuild/easyconfigs/p/PyExtensions/PyExtensions-2.7.16-fosscuda-2019b.eb
+++ b/easybuild/easyconfigs/p/PyExtensions/PyExtensions-2.7.16-fosscuda-2019b.eb
@@ -4,7 +4,7 @@ easyblock = 'PythonBundle'
 
 name = 'PyExtensions'
 version = '%(pyver)s'
-_pyminver = '6'
+_pyminver = '7'
 
 homepage = 'https://pypi.python.org/pypi'
 description = """

--- a/easybuild/easyconfigs/p/PyExtensions/PyExtensions-2.7.16-fosscuda-2019b.eb
+++ b/easybuild/easyconfigs/p/PyExtensions/PyExtensions-2.7.16-fosscuda-2019b.eb
@@ -13,7 +13,7 @@ toolchain = {'name': 'fosscuda', 'version': '2019b'}
 toolchainopts = {'pic': True, 'verbose': False}
 
 dependencies = [
-    ('Python', '%(version)s', '', True),
+    ('Python', '2.7.16', '', True),
 ]
 
 exts_default_options = {

--- a/easybuild/easyconfigs/p/PyExtensions/PyExtensions-2.7.16-fosscuda-2019b.eb
+++ b/easybuild/easyconfigs/p/PyExtensions/PyExtensions-2.7.16-fosscuda-2019b.eb
@@ -9,7 +9,9 @@ local_pyver = '%s.%s' % (local_py_maj_ver, local_py_min_ver)
 version = '%s.%s' % (local_pyver, local_py_rev_ver)
 
 homepage = 'https://pypi.python.org/pypi'
-description = """This module is a bundle of Python packages based on a generic Python module"""
+description = """
+    This module is a bundle of Python packages based on a generic Python module
+"""
 
 toolchain = {'name': 'fosscuda', 'version': '2019b'}
 toolchainopts = {'pic': True, 'verbose': False}
@@ -20,33 +22,37 @@ dependencies = [
 
 # bundle of Python packages
 exts_defaultclass = 'PythonPackage'
+exts_default_options = {
+    'source_urls': [PYPI_SOURCE]
+}
 
 exts_list = [
     ('numpy', '1.16.4', {
-        'source_urls': ['http://pypi.python.org/packages/source/n/numpy/'],
         'source_tmpl': '%(name)s-%(version)s.zip',
     }),
-# matplotlib >= 3 requires python >= 3.5
-    ('matplotlib', '2.2.4', {
-        'source_urls': ['http://pypi.python.org/packages/source/m/matplotlib/'],
+# kiwisolver required by matplotlib
+# version 1.10 requires python >= 3.5
+    ('kiwisolver', '1.1.0'),
+    ('pyparsing', '2.4.7'),
+    ('subprocess32', '3.5.4'),
+    ('backports.functools_lru_cache', '1.6.1'),
+    ('pytz', '2020.1'),
+    ('python-dateutil', '2.8.1', {
+        'modulename': 'dateutil',
     }),
-    ('mpi4py', '3.0.2', {
-        'source_urls': ['http://pypi.python.org/packages/source/m/mpi4py/'],
-    }),
-    ('pandas', '0.24.2', {
-        'source_urls': ['http://pypi.python.org/packages/source/p/pandas/'],
-    }),
+    ('cycler', '0.10.0'),
+    ('matplotlib', '2.2.4'),
+    ('mpi4py', '3.0.2'),
+    ('pandas', '0.24.2'),
 # scipy >= 1.3.0 requires python >= 3.5
-    ('scipy', '1.2.2', {
-        'source_urls': ['http://pypi.python.org/packages/source/s/scipy/'],
-    }),
-    ('sympy', '1.4', {
-        'source_urls': ['http://pypi.python.org/packages/source/s/sympy/'],
-    }),
+    ('scipy', '1.2.2'),
+    ('mpmath', '1.1.0'),
+    ('sympy', '1.4'),
 ]
 
-# specify that Bundle easyblock should run a full sanity check, rather than just trying to load the module
-local_full_sanity_check = True
+# specify that Bundle easyblock should run a full sanity check,
+# rather than just trying to load the module
+full_sanity_check = True
 
 local_pythonpath = 'lib/python%s/site-packages' % local_pyver
 sanity_check_paths = {

--- a/easybuild/easyconfigs/p/PyExtensions/PyExtensions-2.7.16-fosscuda-2019b.eb
+++ b/easybuild/easyconfigs/p/PyExtensions/PyExtensions-2.7.16-fosscuda-2019b.eb
@@ -1,12 +1,8 @@
 # contributed by Luca Marsella (CSCS)
-easyblock = 'Bundle'
+easyblock = 'PythonBundle'
 
 name = 'PyExtensions'
-local_py_maj_ver = '2'
-local_py_min_ver = '7'
-local_py_rev_ver = '16'
-local_pyver = '%s.%s' % (local_py_maj_ver, local_py_min_ver)
-version = '%s.%s' % (local_pyver, local_py_rev_ver)
+version = '%(pyver)s'
 
 homepage = 'https://pypi.python.org/pypi'
 description = """
@@ -17,11 +13,9 @@ toolchain = {'name': 'fosscuda', 'version': '2019b'}
 toolchainopts = {'pic': True, 'verbose': False}
 
 dependencies = [
-    ('Python', '%s' % version, '', True),
+    ('Python', '%(version)s', '', True),
 ]
 
-# bundle of Python packages
-exts_defaultclass = 'PythonPackage'
 exts_default_options = {
     'source_urls': [PYPI_SOURCE]
 }
@@ -30,8 +24,6 @@ exts_list = [
     ('numpy', '1.16.4', {
         'source_tmpl': '%(name)s-%(version)s.zip',
     }),
-# kiwisolver required by matplotlib
-# version 1.10 requires python >= 3.5
     ('kiwisolver', '1.1.0'),
     ('pyparsing', '2.4.7'),
     ('subprocess32', '3.5.4'),
@@ -44,17 +36,12 @@ exts_list = [
     ('matplotlib', '2.2.4'),
     ('mpi4py', '3.0.2'),
     ('pandas', '0.24.2'),
-# scipy >= 1.3.0 requires python >= 3.5
     ('scipy', '1.2.2'),
     ('mpmath', '1.1.0'),
     ('sympy', '1.4'),
 ]
 
-# specify that Bundle easyblock should run a full sanity check,
-# rather than just trying to load the module
-full_sanity_check = True
-
-local_pythonpath = 'lib/python%s/site-packages' % local_pyver
+local_pythonpath = 'lib/python%(pyshortver)s/site-packages'
 sanity_check_paths = {
     'files': [],
     'dirs': [local_pythonpath]


### PR DESCRIPTION
PyExtension build failed due to new version of matplotlib dependencies available were not compatible with Python 2 anymore. 