### PR TITLE
[daint-gpu] Enforce group vasp6

### DIFF
--- a/jenkins-builds/production.sh
+++ b/jenkins-builds/production.sh
@@ -233,8 +233,8 @@ for((i=0; i<${#eb_files[@]}; i++)); do
             if [[ "$version" =~ "5.4" ]]; then
                 group="${name,,}"
             else
-                # After June 30th 2020: group="${name,,}6"
-                group="${name,,}"
+                # group vasp6 enforced after June 30th 2020"
+                group="${name,,}6"
             fi
         else
             group=${name,,}


### PR DESCRIPTION
After June 30th 2020, VASP.6 modules will be accessible only to users belonging to the unix group `vasp6`.