### PR TITLE
[tsa] Remove PrgEnv-pgi-20.4 from production list

### DIFF
--- a/jenkins-builds/MCH-PE20.08-dev0
+++ b/jenkins-builds/MCH-PE20.08-dev0
@@ -55,5 +55,3 @@ netCDF-Fortran-4.4.5-PGI-20.4-GCC-8.3.0.eb             --installpath=/apps/aroll
 OpenMPI-4.0.2-PGI-20.4-GCC-8.3.0-cuda-10.1.eb          --installpath=/apps/arolla/UES/jenkins/RH7.7/MCH-PE20.08-dev0/pgi/20.4/easybuild
 PrgEnv-gnu-tsa-19.2-nocuda.eb                          --module-naming-scheme=EasyBuildMNS
 PrgEnv-gnu-tsa-19.2.eb                                 --module-naming-scheme=EasyBuildMNS --set-default-module
-PrgEnv-pgi-tsa-20.4-nocuda.eb                          --module-naming-scheme=EasyBuildMNS
-PrgEnv-pgi-tsa-20.4.eb                                 --module-naming-scheme=EasyBuildMNS --set-default-module


### PR DESCRIPTION
Recipes for PGI 20.4 meta modules will be added later and, therefore, they are removed from the production list.