### PR TITLE
[daint] Julia 1.4.2 with CUDA 1.2.0

### DIFF
--- a/easybuild/easyblocks/juliapackage.py
+++ b/easybuild/easyblocks/juliapackage.py
@@ -120,6 +120,9 @@ class JuliaPackage(ExtensionEasyBlock):
         if self.cfg['mpiexec_args']:
             pre_cmd += ' && export JULIA_MPIEXEC_ARGS="%s"' % self.cfg['mpiexec_args']
 
+        if self.cfg['arch_name'] == 'gpu':
+            pre_cmd += ' && export JULIA_CUDA_USE_BINARYBUILDER=false'
+
         if remove:
             cmd = ' && '.join([pre_cmd, "julia --eval 'using Pkg; Pkg.rm(PackageSpec(%s))'" % install_opts])
         else:

--- a/easybuild/easyconfigs/j/Julia/Julia-1.4.2-CrayGNU-19.10-cuda-10.1.eb
+++ b/easybuild/easyconfigs/j/Julia/Julia-1.4.2-CrayGNU-19.10-cuda-10.1.eb
@@ -1,0 +1,44 @@
+# Recipe for linux, x86_64 created by Samuel Omlin (CSCS), Victor Holanda Rusu (CSCS)
+name = 'Julia'
+version = '1.4.2'
+_cudaversion = '10.1'
+versionsuffix = '-cuda-%s' % _cudaversion
+
+arch_name = 'gpu'
+
+homepage = 'https://julialang.org'
+description = 'Julia is a high-level general-purpose dynamic programming language that was originally designed to address the needs of high-performance numerical analysis and computational science, without the typical need of separate compilation to be fast, also usable for client and server web use, low-level systems programming or as a specification language (wikipedia.org). Julia provides ease and expressiveness for high-level numerical computing, in the same way as languages such as R, MATLAB, and Python, but also supports general programming. To achieve this, Julia builds upon the lineage of mathematical programming languages, but also borrows much from popular dynamic languages, including Lisp, Perl, Python, Lua, and Ruby (julialang.org).'
+
+toolchain = { 'name' : 'CrayGNU', 'version' : '19.10' }
+toolchainopts = {'pic': True, 'verbose': True, 'usempi': True}
+
+source_urls = ['https://julialang-s3.julialang.org/bin/linux/x64/%(version_major_minor)s/']
+sources = ['%(namelower)s-%(version)s-linux-x86_64.tar.gz']
+
+builddependencies = [
+    ('cudatoolkit/10.1.105_3.27-7.0.1.1_4.1__ga311ce7', EXTERNAL_MODULE),
+]
+dependencies = [
+    ('craype-accel-nvidia60', EXTERNAL_MODULE)
+]
+
+exts_defaultclass = 'JuliaPackage'
+
+exts_list = [
+    ('MPI.jl', '0.15.0', {
+        'mpiexec': 'srun',
+        'mpiexec_args': "-C %s" % arch_name,
+        'source_tmpl': 'v0.15.0.tar.gz',
+        'source_urls': ['https://github.com/JuliaParallel/MPI.jl/archive/'],
+    }),
+    ('CUDA.jl', '1.2.0', {
+        'source_tmpl': 'v1.2.0.tar.gz',
+        'source_urls': ['https://github.com/JuliaGPU/CUDA.jl/archive/'],
+    }),
+]
+
+modextravars = {
+    'JULIA_CUDA_USE_BINARYBUILDER': 'false',
+}
+
+moduleclass = 'lang'

--- a/easybuild/easyconfigs/j/Julia/Julia-1.4.2-CrayGNU-19.10.eb
+++ b/easybuild/easyconfigs/j/Julia/Julia-1.4.2-CrayGNU-19.10.eb
@@ -1,0 +1,27 @@
+# Recipe for linux, x86_64 created by Samuel Omlin (CSCS), Victor Holanda Rusu (CSCS)
+name = 'Julia'
+version = '1.4.2'
+
+arch_name = 'mc'
+
+homepage = 'https://julialang.org'
+description = 'Julia is a high-level general-purpose dynamic programming language that was originally designed to address the needs of high-performance numerical analysis and computational science, without the typical need of separate compilation to be fast, also usable for client and server web use, low-level systems programming or as a specification language (wikipedia.org). Julia provides ease and expressiveness for high-level numerical computing, in the same way as languages such as R, MATLAB, and Python, but also supports general programming. To achieve this, Julia builds upon the lineage of mathematical programming languages, but also borrows much from popular dynamic languages, including Lisp, Perl, Python, Lua, and Ruby (julialang.org).'
+
+toolchain = { 'name' : 'CrayGNU', 'version' : '19.10' }
+toolchainopts = {'pic': True, 'verbose': True, 'usempi': True}
+
+source_urls = ['https://julialang-s3.julialang.org/bin/linux/x64/%(version_major_minor)s/']
+sources = ['%(namelower)s-%(version)s-linux-x86_64.tar.gz']
+
+exts_defaultclass = 'JuliaPackage'
+
+exts_list = [
+    ('MPI.jl', '0.15.0', {
+        'mpiexec': 'srun',
+        'mpiexec_args': "-C %s" % arch_name,
+        'source_tmpl': 'v0.15.0.tar.gz',
+        'source_urls': ['https://github.com/JuliaParallel/MPI.jl/archive/'],
+    }),
+]
+
+moduleclass = 'lang'

--- a/easybuild/easyconfigs/j/JuliaExtensions/JuliaExtensions-1.4.2-CrayGNU-19.10-cuda-10.1.eb
+++ b/easybuild/easyconfigs/j/JuliaExtensions/JuliaExtensions-1.4.2-CrayGNU-19.10-cuda-10.1.eb
@@ -1,0 +1,37 @@
+# Recipe for linux, x86_64 created by Samuel Omlin (CSCS), Victor Holanda Rusu (CSCS)
+easyblock = 'JuliaBundle'
+
+name = 'JuliaExtensions'
+version = '1.4.2'
+_cudaversion = '10.1'
+versionsuffix = '-cuda-%s' % _cudaversion
+
+arch_name = 'gpu'
+
+homepage = 'https://julialang.org'
+description = 'Extensions for julia'
+
+toolchain = { 'name' : 'CrayGNU', 'version' : '19.10' }
+toolchainopts = {'pic': True, 'verbose': True}
+
+dependencies = [
+    ('Julia', version, versionsuffix),
+]
+
+exts_list = [
+    ('Plots.jl', '1.5.5', {
+        'source_tmpl': 'v1.5.5.tar.gz',
+        'source_urls': ['https://github.com/JuliaPlots/Plots.jl/archive/'],
+    }),
+    ('PyCall.jl', '1.91.4', {
+        'source_tmpl': 'v1.91.4.tar.gz',
+        'source_urls': ['https://github.com/JuliaPy/PyCall.jl/archive/'],
+    }),
+    ('HDF5.jl', '0.13.2', {
+        'source_tmpl': 'v0.13.2.tar.gz',
+        'source_urls': ['https://github.com/JuliaIO/HDF5.jl/archive/'],
+    }),
+]
+
+
+moduleclass = 'tools'

--- a/easybuild/easyconfigs/j/JuliaExtensions/JuliaExtensions-1.4.2-CrayGNU-19.10.eb
+++ b/easybuild/easyconfigs/j/JuliaExtensions/JuliaExtensions-1.4.2-CrayGNU-19.10.eb
@@ -1,0 +1,35 @@
+# Recipe for linux, x86_64 created by Samuel Omlin (CSCS), Victor Holanda Rusu (CSCS)
+easyblock = 'JuliaBundle'
+
+name = 'JuliaExtensions'
+version = '1.4.2'
+
+arch_name = 'mc'
+
+homepage = 'https://julialang.org'
+description = 'Extensions for julia'
+
+toolchain = { 'name' : 'CrayGNU', 'version' : '19.10' }
+toolchainopts = {'pic': True, 'verbose': True}
+
+dependencies = [
+    ('Julia', version),
+]
+
+exts_list = [
+    ('Plots.jl', '1.5.5', {
+        'source_tmpl': 'v1.5.5.tar.gz',
+        'source_urls': ['https://github.com/JuliaPlots/Plots.jl/archive/'],
+    }),
+    ('PyCall.jl', '1.91.4', {
+        'source_tmpl': 'v1.91.4.tar.gz',
+        'source_urls': ['https://github.com/JuliaPy/PyCall.jl/archive/'],
+    }),
+    ('HDF5.jl', '0.13.2', {
+        'source_tmpl': 'v0.13.2.tar.gz',
+        'source_urls': ['https://github.com/JuliaIO/HDF5.jl/archive/'],
+    }),
+]
+
+
+moduleclass = 'tools'


### PR DESCRIPTION
The Julia CUDA packages CUDAdrv, CUDAnative and CuArrays were merged into one single package CUDA.jl. This PR includes the latest CUDA.jl package as well as the latest versions of all other included packages.