### PR TITLE
[daint-gpu] Starting point for ipcmagic and PyExtensions

### DIFF
--- a/easybuild/easyconfigs/i/ipcmagic/ipcmagic-0.1-CrayGNU-19.10.eb
+++ b/easybuild/easyconfigs/i/ipcmagic/ipcmagic-0.1-CrayGNU-19.10.eb
@@ -1,3 +1,4 @@
+# contributed by Eirini Koutsaniti and Luca Marsella (CSCS)
 easyblock = "PythonPackage"
 
 name = 'ipcmagic'
@@ -11,13 +12,13 @@ toolchain = {'name': 'CrayGNU', 'version': '19.10'}
 sources = ['/apps/common/easybuild/sources/i/ipcmagic/ipcmagic-0.1.tar.gz']
 
 dependencies = [
-    ('cray-python/3.6.5.7', EXTERNAL_MODULE),
+    ('cray-python', EXTERNAL_MODULE),
     ('jupyterlab', '1.1.1', '-batchspawner')
 ]
+exts_defaultclass = 'PythonPackage'
 
 _pyminver = '6'
 
-exts_defaultclass = 'PythonPackage'
 exts_default_options = {
     'req_py_majver': '%(pymajver)s',
     'req_py_minver': '%s' % _pyminver,
@@ -31,8 +32,7 @@ exts_list = [
     ('docopt', '0.6.2')
 ]
 
-# using this to avoid running `python -c 'import ipcmagic'`
-# it works only with ipython
+# use to avoid running `python -c 'import ipcmagic': it works only with ipython
 options = {'modulename': 'os'}
 sanity_check_commands = [("ipython -c 'import ipcmagic'")]
 

--- a/easybuild/easyconfigs/p/PyExtensions/PyExtensions-python3-CrayGNU-19.10.eb
+++ b/easybuild/easyconfigs/p/PyExtensions/PyExtensions-python3-CrayGNU-19.10.eb
@@ -11,23 +11,24 @@ toolchain = {'name': 'CrayGNU', 'version': '19.10'}
 toolchainopts = {'pic': True, 'verbose': False}
 
 dependencies = [
-    ('cray-python/3.6.5.7', EXTERNAL_MODULE),
-    #('libffi', '3.2.1')
+    ('cray-python', EXTERNAL_MODULE),
 ]
 
-use_pip = True
-
 exts_default_options = {
-    'source_urls': [PYPI_SOURCE]
+    'source_urls': [PYPI_SOURCE],
+    'req_py_majver': '%(pymajver)s',
+    'req_py_minver': '%(pyminver)s',
 }
 
 exts_list = [
+    ('zipp', '0.5.0'),
     ('Cython', '0.28.4'),
     ('six', '1.11.0'),
     ('pyparsing', '2.4.7'),
     ('kiwisolver', '1.2.0'),
     ('pytz', '2020.1'),
     ('cycler', '0.10.0'),
+    ('wheel', '0.34.2'),
     ('python-dateutil', '2.8.1', {
         'modulename': 'dateutil',
     }),


### PR DESCRIPTION
The recipe of `ipcmagic` was failing in a previous pull request #1741 and this pull request should fix it. 
I also include an updated recipe of `PyExtensions` provided by @ekouts in the branch `experimental`. 

I have removed the version of `cray-python` from the recipes, since the default is loaded: however, this might be wrong, so please feel free to suggest to re-insert the version.