### PR TITLE
Update 7.0.UP01-19.10-gpu

### DIFF
--- a/jenkins-builds/7.0.UP01-19.10-gpu
+++ b/jenkins-builds/7.0.UP01-19.10-gpu
@@ -39,6 +39,7 @@
  JuliaExtensions-1.2.0-CrayGNU-19.10-cuda-10.1.eb   --set-default-module
  jupyterlab-1.1.1-CrayGNU-19.10.eb                  --set-default-module
  jupyterlab-1.1.1-CrayGNU-19.10-batchspawner.eb
+ jupyterlab-1.2.16-CrayGNU-19.10-cuda-10.1-batchspawner.eb
  jupyterhub-1.0.0-CrayGNU-19.10.eb                  --set-default-module
  jupyter-utils-0.1.eb                               --set-default-module
  LAMMPS-22Aug2018-CrayGNU-19.10-cuda-10.1.eb        --set-default-module

--- a/jenkins-builds/7.0.UP01-19.10-mc
+++ b/jenkins-builds/7.0.UP01-19.10-mc
@@ -40,6 +40,7 @@
  jupyterhub-1.0.0-CrayGNU-19.10.eb                  --set-default-module
  jupyterlab-1.1.1-CrayGNU-19.10.eb                  --set-default-module
  jupyterlab-1.1.1-CrayGNU-19.10-batchspawner.eb
+ jupyterlab-1.2.16-CrayGNU-19.10-batchspawner.eb
  jupyter-utils-0.1.eb                               --set-default-module
  LAMMPS-22Aug2018-CrayGNU-19.10.eb                  --set-default-module
  LAMMPS-03Mar2020-CrayGNU-19.10.eb


### PR DESCRIPTION
This PR adds the jupyterlab 1.2.16 (IJulia support) from PR #1763 ~PR #1738~  into the production lists. 