### PR TITLE
Add Julia 1.4.2 to production

### DIFF
--- a/jenkins-builds/7.0.UP01-19.10-gpu
+++ b/jenkins-builds/7.0.UP01-19.10-gpu
@@ -36,7 +36,9 @@
  ipcmagic-0.1-CrayGNU-19.10.eb                      --set-default-module
  ipyparallel-6.2.4-CrayGNU-19.10-python3.eb
  Julia-1.2.0-CrayGNU-19.10-cuda-10.1.eb             --set-default-module
+ Julia-1.4.2-CrayGNU-19.10-cuda-10.1.eb             --umask=022
  JuliaExtensions-1.2.0-CrayGNU-19.10-cuda-10.1.eb   --set-default-module
+ JuliaExtensions-1.4.2-CrayGNU-19.10-cuda-10.1.eb   --umask=022
  jupyterlab-1.1.1-CrayGNU-19.10.eb                  --set-default-module
  jupyterlab-1.1.1-CrayGNU-19.10-batchspawner.eb
  jupyterlab-1.2.16-CrayGNU-19.10-cuda-10.1-batchspawner.eb

--- a/jenkins-builds/7.0.UP01-19.10-mc
+++ b/jenkins-builds/7.0.UP01-19.10-mc
@@ -36,7 +36,9 @@
  ipcmagic-0.1-CrayGNU-19.10.eb                      --set-default-module
  ipyparallel-6.2.4-CrayGNU-19.10-python3.eb
  Julia-1.2.0-CrayGNU-19.10.eb                       --set-default-module
+ Julia-1.4.2-CrayGNU-19.10.eb                       --umask=022
  JuliaExtensions-1.2.0-CrayGNU-19.10.eb             --set-default-module
+ JuliaExtensions-1.4.2-CrayGNU-19.10.eb             --umask=022
  jupyterhub-1.0.0-CrayGNU-19.10.eb                  --set-default-module
  jupyterlab-1.1.1-CrayGNU-19.10.eb                  --set-default-module
  jupyterlab-1.1.1-CrayGNU-19.10-batchspawner.eb


### PR DESCRIPTION
This is the version required by the jupyterlab that is going in production.