### PR TITLE
[dom-gpu] toolchain upgrade script

### DIFF
--- a/tools/upgrade-tc.py
+++ b/tools/upgrade-tc.py
@@ -1,0 +1,160 @@
+#!/usr/bin/env python3
+import argparse
+import string
+import sys
+import re
+
+tc_pattern = re.compile("toolchain\s*=\s*\{\s*'name'\s*:\s*'(\S*)'\s*,\s*'version'\s*:\s*'(\S*)'\s*}")
+
+dep_regex = lambda mod: f"\(\s*'({mod})'\s*,\s*EXTERNAL_MODULE\s*\)"
+dep_pattern = re.compile(dep_regex('\S*')) # any module
+
+
+def parse_tc(file, debug):
+    ''' determine toolchain information in supplied EasyBuild config '''
+    matches = re.search(tc_pattern, file)
+
+    if matches:
+        if debug:
+            print("found matches from the config: ", matches.group())
+            print("found original toolchain in config: ", matches.group(1))
+            print("found original toolchain version in config: ", matches.group(2))
+    else:
+        raise RuntimeError(f"Couldn't determine toolchain information in supplied EasyBuild config.")
+
+    return matches.group(1), matches.group(2)
+
+
+def greater_ver(v1, v2):
+    ''' compare 2 version strings '''
+    v1 = [(int(v) if v.isnumeric() else v) for v in v1.split('.')]
+    v2 = [(int(v) if v.isnumeric() else v) for v in v2.split('.')]
+    return v1 > v2
+
+def parse_metadata(metadata):
+    ''' load a version map of every module in the given metadata '''
+    modules = {}
+    for line in metadata.readlines():
+        if line[0] == '[':
+            module = line[1:line.find(']')]
+            module = module.split('/')
+            module, version = module if len(module) > 1 else (module[0], None)
+            # keep a map of major versions to latest available version
+            if version is not None:
+                majver = version.split('.')[0]
+                if module not in modules.keys():
+                    version = {majver: version}
+                else: # update majver if needed
+                    versions = modules[module]
+                    if majver not in versions.keys() or greater_ver(version, versions[majver]):
+                        versions[majver] = version
+                    version = {k:versions[k] for k in sorted(versions.keys())}
+            modules[module] = version
+    return modules
+
+
+
+def main():
+    parser = argparse.ArgumentParser(description='Upgrade EasyBuild toolchain.')
+
+    parser.add_argument('--debug',
+                        type=bool, default=False,
+                        help="Print verbose info.")
+
+    parser.add_argument('--toolchain-prefix',
+                        required=False,
+                        help="Toolchain prefix for validation.")
+
+    parser.add_argument('--version',
+                        required=True,
+                        help="New toolchain version to use.")
+
+    parser.add_argument('--metadata',
+                        type=argparse.FileType('r'), required=False,
+                        help="Target metadata.")
+
+    parser.add_argument('--filenames',
+                        nargs='+', required=True,
+                        help="Files to process.")
+
+    args = vars(parser.parse_args())
+
+    if args['debug']:
+        print(args)
+        print(f"New toolchain is set {args['toolchain_prefix']}*-{args['version']}")
+
+    if args['metadata']:
+        modules = parse_metadata(args['metadata'])
+        if args['debug']:
+            print('Metadata:\n', modules)
+
+    successful = 0
+    for filename in args['filenames']:
+        try:
+            print(f"Processing EasyBuild config {filename} ...")
+            if args['debug']:
+                print("The new config will be placed in original directory.")
+
+            with open(filename, "r") as originalconfig:
+                ec = originalconfig.read()  # contains newlines.
+            if args['debug']:
+                print("---- The original config was:\n", ec)
+
+            toolchain, version = parse_tc(ec, args['debug'])
+
+            if args['toolchain_prefix'] and not toolchain.startswith(args['toolchain_prefix']):
+                raise RuntimeError(f"Invalid toolchain prefix in {filename}")
+
+            newecfilename = filename.replace(f"{toolchain}-{version}",
+                                            f"{toolchain}-{args['version']}")
+            if args['debug']:
+                print("New config file name will be: ", newecfilename)
+
+            newec = re.sub(tc_pattern,
+                        f"toolchain = {{'name': '{toolchain}', 'version': '{args['version']}'}}",
+                        ec)
+
+            if args['metadata']:
+                # find all external dependencies
+                deps = re.findall(dep_pattern, newec)
+                if deps is not None:
+                    if args['debug']:
+                        print("External Modules:\n", deps)
+
+                    for dep in deps:
+                        mod = dep.split('/')[0]
+                        if mod in modules.keys():
+                            ver = modules[mod]
+                            if ver is not None:
+                                assert len(dep.split('/')) > 1,  f"Error: Undefined version in external dependency '{dep}'"
+                                depver = dep.split('/')[1]
+                                majver = depver.split('.')[0]
+                                # get latest matching version
+                                ver = ver[majver] if majver in ver.keys() else ver.values()[-1]
+                                mod = f"{mod}/{ver}"
+                            if args['debug']:
+                                print(f"Replacing '{dep}' by '{mod}'")
+                                print(dep_regex(dep))
+                            newec = re.sub(dep_regex(dep), f"('{mod}', EXTERNAL_MODULE)", newec)
+
+            if args['debug']:
+                print("---- New config will be:\n", newec)
+
+            ## Check new toolchain
+            _, version = parse_tc(newec, args['debug'])
+            if version != args['version']:
+                raise RuntimeError("Error: Failed to replace toolchain version.")
+
+            with open(newecfilename, "w") as newconfig:
+                newconfig.write(newec)  # contains newlines.
+
+            print("Finished writing new config:", newecfilename)
+            successful += 1
+        except Exception as ex:
+            print(ex)
+
+    print(f"Upgrade succeeded for {successful} out of {len(args['filenames'])} files")
+    return len(args['filenames']) - successful
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
This script seems to work fine, in case someone still needs to upgrade some 19.10 recipes.
It's based on the former new-tc.py but it also updates the external module versions according to the given metadata file (which basically means that it just removes the old hardcoded versions).

```
eb easybuild/easyconfigs/h/Horovod/Horovod-0.19.1-CrayGNU-19.10-tf-2.2.0.eb -Dr | \
grep ' \* \[.\] ' | sed 's@^[^/]*/@@g' | awk '{print $1}' | xargs basename -a | \
grep '\-Cray.*-19.10' | sort | uniq | xargs -IF find . -name F | \
xargs tools/upgrade-tc.py --metadata easybuild/cray_external_modules_metadata-20.06.cfg --toolchain-prefix Cray --version 20.06 --filenames
```

```
Finished writing new config: ./easybuild/easyconfigs/b/Bazel/Bazel-2.0.0-CrayGNU-20.06.eb
Finished writing new config: ./easybuild/easyconfigs/d/dask/dask-2.2.0-CrayGNU-20.06-python3.eb
Finished writing new config: ./easybuild/easyconfigs/h/h5py/h5py-2.8.0-CrayGNU-20.06-python3-serial.eb
Finished writing new config: ./easybuild/easyconfigs/h/Horovod/Horovod-0.19.1-CrayGNU-20.06-tf-2.2.0.eb
Finished writing new config: ./easybuild/easyconfigs/n/numpy/numpy-1.17.2-CrayGNU-20.06.eb
Finished writing new config: ./easybuild/easyconfigs/p/PCRE/PCRE-8.42-CrayGNU-20.06.eb
Finished writing new config: ./easybuild/easyconfigs/p/prereq/prereq-tf-2.2-CrayGNU-20.06.eb
Finished writing new config: ./easybuild/easyconfigs/p/protobuf-core/protobuf-core-3.11.0-CrayGNU-20.06.eb
Finished writing new config: ./easybuild/easyconfigs/p/protobuf-python/protobuf-python-3.11.0-CrayGNU-20.06.eb
Finished writing new config: ./easybuild/easyconfigs/p/PyExtensions/PyExtensions-python3-CrayGNU-20.06.eb
Finished writing new config: ./easybuild/easyconfigs/s/SWIG/SWIG-3.0.12-CrayGNU-20.06-python3.eb
Finished writing new config: ./easybuild/easyconfigs/t/TensorFlow/TensorFlow-2.2.0-CrayGNU-20.06-cuda-10.1.168.eb
```