### PR TITLE
[dom-mc] Fix module show for ParaView/5.8.0 OSMesa

### DIFF
--- a/easybuild/easyconfigs/p/ParaView/ParaView-5.8.0-CrayGNU-20.06-OSMesa.eb
+++ b/easybuild/easyconfigs/p/ParaView/ParaView-5.8.0-CrayGNU-20.06-OSMesa.eb
@@ -50,9 +50,12 @@ sanity_check_paths = {
 # first serial attempt would fail.
 # prebuildopts = 'make VTKData ;'
 
-modextravars = {
-    'LD_LIBRARY_PATH': '/opt/python/%(pyver)s/lib:$::env(LD_LIBRARY_PATH)',
-    'PYTHONPATH': '%(installdir)s/lib64/python%(pyshortver)s/site-packages/:$::env(PYTHONPATH)',
+modextrapaths = {
+    'PYTHONPATH': 'lib64/python%(pyshortver)s/site-packages',
 }
+
+modtclfooter = """
+    prepend-path LD_LIBRARY_PATH /opt/python/%(pyver)s/lib
+"""
 
 moduleclass = 'vis'


### PR DESCRIPTION
The error can be reproduced by (on dom) running
```
module load daint-mc
module show ParaView/5.8.0-CrayGNU-20.06-OSMesa
ParaView/5.8.0-CrayGNU-20.06-OSMesa(64):ERROR:102: Tcl command execution failed: setenv	PYTHONPATH		"/apps/dom/UES/jenkins/7.0.UP02/mc/easybuild/software/ParaView/5.8.0-CrayGNU-20.06-OSMesa/lib64/python3.8/site-packages/:$::env(PYTHONPATH)"
```