### PR TITLE
[dom-gpu] Update production lists on Dom

### DIFF
--- a/jenkins-builds/7.0.UP02-20.06-gpu-dom
+++ b/jenkins-builds/7.0.UP02-20.06-gpu-dom
@@ -35,9 +35,11 @@
  netcdf-python-1.4.1-CrayGNU-20.06-python3.eb        --set-default-module
  numpy-1.17.2-CrayGNU-20.06.eb                       --set-default-module
  PLUMED-2.5.1-CrayGNU-20.06.eb                       --set-default-module
+ PLUMED-2.5.1-CrayIntel-20.06.eb
  pycuda-2018.1.1-CrayGNU-20.06-python3-cuda-10.2.eb  --set-default-module
  PyExtensions-python3-CrayGNU-20.06.eb
  Python-bare-3.7.3.eb                                --hidden
+ QuantumESPRESSO-6.5a1-CrayPGI-20.06-cuda.eb         --set-default-module
  Spark-2.3.1-CrayGNU-20.06-Hadoop-2.7.eb             --set-default-module
  VASP-6.1.0-CrayIntel-20.06-cuda.eb                  --set-default-module
  VMD-1.9.3-egl.eb

--- a/jenkins-builds/7.0.UP02-20.06-gpu-dom
+++ b/jenkins-builds/7.0.UP02-20.06-gpu-dom
@@ -40,6 +40,7 @@
  PyExtensions-python3-CrayGNU-20.06.eb
  Python-bare-3.7.3.eb                                --hidden
  QuantumESPRESSO-6.5a1-CrayPGI-20.06-cuda.eb         --set-default-module
+ QuantumESPRESSO-SIRIUS-6.5-rc4-CrayIntel-20.06-cuda.eb --set-default-module
  Spark-2.3.1-CrayGNU-20.06-Hadoop-2.7.eb             --set-default-module
  VASP-6.1.0-CrayIntel-20.06-cuda.eb                  --set-default-module
  VMD-1.9.3-egl.eb

--- a/jenkins-builds/7.0.UP02-20.06-mc-dom
+++ b/jenkins-builds/7.0.UP02-20.06-mc-dom
@@ -32,6 +32,8 @@
  netcdf-python-1.4.1-CrayGNU-20.06-python3.eb       --set-default-module
  numpy-1.17.2-CrayGNU-20.06.eb                      --set-default-module
  ParaView-5.8.0-CrayGNU-20.06-OSMesa.eb
+ PLUMED-2.5.1-CrayGNU-20.06.eb                       --set-default-module
+ PLUMED-2.5.1-CrayIntel-20.06.eb
  PyExtensions-python3-CrayGNU-20.06.eb
  Python-bare-3.7.3.eb                               --hidden
  QuantumESPRESSO-6.5-CrayIntel-20.06.eb             --set-default-module


### PR DESCRIPTION
I have updated the production lists of Dom: I have noticed that on Piz Daint we have defined both `PLUMED` modules as default, but I think that we should have only one default, even if they belong to a different toolchain.
Therefore I propose to have `PLUMED` with `CrayGNU` as default.