### PR TITLE
[dom] Updated ipcmagic recipe and production lists

### DIFF
--- a/easybuild/easyconfigs/i/ipcmagic/ipcmagic-0.1-CrayGNU-20.06.eb
+++ b/easybuild/easyconfigs/i/ipcmagic/ipcmagic-0.1-CrayGNU-20.06.eb
@@ -1,0 +1,43 @@
+# modified by Luca Marsella (CSCS)
+easyblock = "PythonPackage"
+
+name = 'ipcmagic'
+version = '0.1'
+
+homepage = 'https://github.com/eth-cscs/jupyter-utils'
+description = "Utilities for working with Jupyter at CSCS"
+
+toolchain = {'name': 'CrayGNU', 'version': '20.06'}
+
+sources = ['/apps/common/easybuild/sources/i/ipcmagic/ipcmagic-0.1.tar.gz']
+
+dependencies = [
+    ('cray-python', EXTERNAL_MODULE),
+    ('jupyterlab', '1.1.1', '-batchspawner')
+]
+
+exts_defaultclass = 'PythonPackage'
+exts_default_options = {
+    'req_py_majver': '%(pymajver)s',
+    'req_py_minver': '%(pyminver)s',
+    'source_urls': [PYPI_SOURCE],
+    'use_pip': True
+}
+
+exts_list = [
+    ('pexpect', '4.8.0'),
+    ('ipyparallel', '6.3.0'),
+    ('docopt', '0.6.2')
+]
+
+# using this to avoid running `python -c 'import ipcmagic'`
+# it works only with ipython
+options = {'modulename': 'os'}
+sanity_check_commands = [("ipython -c 'import ipcmagic'")]
+
+sanity_check_paths = {
+    'files': ['lib/python%(pyshortver)s/site-packages/ipcmagic/__init__.py'],
+    'dirs': ['lib/python%(pyshortver)s/site-packages'],
+}
+
+moduleclass = 'tools'

--- a/jenkins-builds/7.0.UP02-20.06-gpu-dom
+++ b/jenkins-builds/7.0.UP02-20.06-gpu-dom
@@ -22,6 +22,7 @@
  h5py-2.8.0-CrayGNU-20.06-python3-serial.eb
  IDL-8.5.1.eb                                        --set-default-module
  IDL-8.7.2-CSCS.eb
+ ipcmagic-0.1-CrayGNU-20.06.eb                       --set-default-module
  ipyparallel-6.2.4-CrayGNU-20.06-python3.eb
  Julia-1.2.0-CrayGNU-20.06-cuda.eb                   --set-default-module
  JuliaExtensions-1.2.0-CrayGNU-20.06-cuda.eb         --set-default-module

--- a/jenkins-builds/7.0.UP02-20.06-mc-dom
+++ b/jenkins-builds/7.0.UP02-20.06-mc-dom
@@ -21,6 +21,7 @@
  h5py-2.8.0-CrayGNU-20.06-python3-serial.eb
  IDL-8.5.1.eb                                       --set-default-module
  IDL-8.7.2-CSCS.eb
+ ipcmagic-0.1-CrayGNU-20.06.eb                      --set-default-module
  ipyparallel-6.2.4-CrayGNU-20.06-python3.eb
  Julia-1.2.0-CrayGNU-20.06.eb                       --set-default-module
  JuliaExtensions-1.2.0-CrayGNU-20.06.eb             --set-default-module


### PR DESCRIPTION
The new recipe uses the current metadata file and loads external dependencies without versions. 

I don't understand why `ipcmagic` builds the extension `ipyparallel 6.3.0`, while we have a stand-alone modulefile ` ipyparallel/6.2.4-CrayGNU-20.06-python3` in the production list. Any idea?