### PR TITLE
[dom-mc] oq-engine-3.2.0 with CrayGNU-20.06

### DIFF
--- a/easybuild/easyconfigs/o/oq-engine/oq-engine-3.2.0-CrayGNU-20.06.eb
+++ b/easybuild/easyconfigs/o/oq-engine/oq-engine-3.2.0-CrayGNU-20.06.eb
@@ -49,7 +49,9 @@ exts_list = [
         'modulename': 'dateutil'
     }),
     ('Cython', '0.29.21'),
-    ('pyproj', '1.9.5.1'),
+    ('pyproj', '1.9.5.1', {
+        'setup_requires': ['cython=0.29.21'],
+    }),
     ('basemap', '1.1.0', {
         'source_urls': ['https://github.com/matplotlib/basemap/archive'],
         'source_tmpl': 'v1.1.0.tar.gz',

--- a/easybuild/easyconfigs/o/oq-engine/oq-engine-3.2.0-CrayGNU-20.06.eb
+++ b/easybuild/easyconfigs/o/oq-engine/oq-engine-3.2.0-CrayGNU-20.06.eb
@@ -48,6 +48,7 @@ exts_list = [
     ('python-dateutil', '2.7.2', {
         'modulename': 'dateutil'
     }),
+    ('Cython', '0.29.21'),
     ('pyproj', '1.9.5.1'),
     ('basemap', '1.1.0', {
         'source_urls': ['https://github.com/matplotlib/basemap/archive'],

--- a/easybuild/easyconfigs/o/oq-engine/oq-engine-3.2.0-CrayGNU-20.06.eb
+++ b/easybuild/easyconfigs/o/oq-engine/oq-engine-3.2.0-CrayGNU-20.06.eb
@@ -1,0 +1,85 @@
+# @author: sarafael, gppezzi
+easyblock = 'Bundle'
+
+name = 'oq-engine'
+version = '3.2.0'
+
+homepage = 'https://pypi.python.org/pypi'
+description = """This module is a bundle of Python packages on Cray systems based on the module cray-python"""
+
+toolchain = {'name': 'CrayGNU', 'version': '20.06'}
+toolchainopts = {'pic': True, 'verbose': False}
+
+dependencies = [
+    ('cray-python', EXTERNAL_MODULE),
+    ('GEOS', '3.6.2'),
+    ('libspatialindex', '1.8.5'),
+    ('h5py', '2.8.0', '-python%(pymajver)s-parallel')
+]
+
+exts_defaultclass = 'PythonPackage'
+exts_default_options = {
+    'req_py_majver': '%(pymajver)s',
+    'req_py_minver': '%(pyminver)s',
+    'source_urls': [PYPI_SOURCE],
+}
+
+exts_list = [
+    ('pytz', '2018.3'),
+    ('mock', '2.0.0'),
+    ('psutil', '5.4.3'),
+    ('Shapely', '1.6.4.post1'),
+    ('pbr', '4.0.0'),
+    ('Django', '2.0.4'),
+    ('certifi', '2018.1.18'),
+    ('pyshp', '1.2.3', {
+        'modulename': 'shapefile'
+    }),
+    ('setproctitle', '1.1.10'),
+    ('python-prctl', '1.6.1', {
+        'modulename': 'prctl'
+    }),
+    ('Rtree', '0.8.3'),
+    ('vine', '1.1.4'),
+    ('amqp', '2.2.2'),
+    ('kombu', '4.1.0'),
+    ('billiard', '3.5.0.3'),
+    ('celery', '4.1.0'),
+    ('python-dateutil', '2.7.2', {
+        'modulename': 'dateutil'
+    }),
+    ('pyproj', '1.9.5.1'),
+    ('basemap', '1.1.0', {
+        'source_urls': ['https://github.com/matplotlib/basemap/archive'],
+        'source_tmpl': 'v1.1.0.tar.gz',
+        'prebuildopts': 'export GEOS_DIR=$EBROOTGEOS; ',
+        'preinstallopts': 'export GEOS_DIR=$EBROOTGEOS; ',
+        'modulename': 'os',
+    }),
+    ('flake8', '3.5.0'),
+    ('pdbpp', '0.9.2', {
+        'modulename': 'pdb'
+    }),
+    ('fancycompleter', '0.8'),
+    ('wmctrl', '0.3', {
+        'modulename': 'os'
+    }),
+    (name, version, {
+        'source_urls': ['https://github.com/gem/oq-engine/archive/'],
+        'source_tmpl': 'v%(version)s.tar.gz',
+        'modulename': 'openquake'
+    }),
+]
+
+local_full_sanity_check = True
+
+modextrapaths = {'PYTHONPATH': ['lib/python%(pyshortver)s/site-packages']}
+
+modextravars = {'OQ_DATADIR': '$::env(SCRATCH)/oqdata'}
+
+sanity_check_paths = {
+    'files': [],
+    'dirs': ['lib/python%(pyshortver)s/site-packages']
+}
+
+moduleclass = 'tools'


### PR DESCRIPTION
The recipe is a draft for the module `oq-engine-3.2.0` with `CrayGNU 20.06`: `oq-engine-3.2.0` is currently available as a hidden modulefile in the production list `daint-mc`.
Unfortunately, the build fails while installing the extension `pyproj 1.9.5.1` with several errors of this kind:
```
_proj.c: In function '__Pyx_ExceptionSave':
_proj.c:7421:21: error: 'PyThreadState' {aka 'struct _ts'} has no member named 'exc_ty
pe'; did you mean 'curexc_type'?
     *type = tstate->exc_type;
                     ^~~~~~~~
                     curexc_type
```
Any advice to solve the issue is appreciated.