### PR TITLE
[dom-mc] Visit 3.1.2 for cdt/20.06

### DIFF
--- a/easybuild/easyconfigs/v/Visit/Visit-3.1.0-CrayGNU-20.06-python3.eb
+++ b/easybuild/easyconfigs/v/Visit/Visit-3.1.0-CrayGNU-20.06-python3.eb
@@ -1,0 +1,94 @@
+# contributed by Jean Favre (CSCS)
+easyblock = 'CMakeMake'
+
+name = 'Visit'
+version = "3.1.2"
+versionsuffix = '-python%(pymajver)s'
+
+homepage = 'https://wci.llnl.gov/codes/visit/'
+description = """VisIt is an Open Source, interactive, scalable, visualization,
+animation and analysis tool."""
+
+toolchain = {'name': 'CrayGNU', 'version': '20.06'}
+toolchainopts = {'usempi': True, 'verbose': False}
+
+#
+# Visit downloads all its dependencies by itself during the configuration.
+# The downloads may fail due to different reasons. So, we have pre-packaged
+# visit with the downloaded dependencies.
+#
+# Below you will find the steps to create the SOURCELOWER_TAR_GZ file used in
+# this recipe.
+#
+# wget http://portal.nersc.gov/project/visit/releases/3.1.2/visit3.1.2.tar.gz
+# tar xfz visit3.1.2.tar.gz
+# cd visit3.1.2
+# ./src/tools/dev/scripts/build_visit --console --no-visit --parallel \
+#                            --system-cmake --hdf5 --icet --llvm --mesagl \
+#                            --qt --qwt --silo --netcdf --vtk --system-python \
+#                            --openssl --download-only 
+# cd ..
+
+# tar cfz  visit-3.1.2.tar.gz visit3.1.2
+# mkdir -p $EASYBUILD_SOURCEPATH/v/Visit
+# cp visit-3.1.2.tar.gz $EASYBUILD_SOURCEPATH/v/Visit/
+#
+# NOTES:
+# * The new visit package is named visit-3.1.2.tar.gz, not visit3.1.2.tar.gz
+#   as the original file.
+# * The download-only option must not be included in the actual build.
+# * The configuration options are the same as the ones below.
+# * In the preconfigopts commands below, there is an additional <<< "yes".
+#   This is used to accept the Qt License. This is not needed when using
+#   --download-only
+# * The original intent was to compile only the server-side components, disabling the
+#   use of the GUI client for login nodes. Yet, this also removes the cli, preventing
+#   us to run python-based batch-mode scripts. Thus, we build all components [default]
+
+# In order to use the pre-downloaded version use the source below
+sources = ['/apps/common/UES/easybuild/sources/%(nameletterlower)s/%(name)s/' + SOURCELOWER_TAR_GZ]
+
+srcdir='../src'
+#preconfigopts  = ' export PAR_COMPILER=$CC; '
+#preconfigopts += ' export PAR_INCLUDE="-I$MPICH_DIR/include"; '
+preconfigopts = ' mkdir third_party; '
+preconfigopts += ' ./src/tools/dev/scripts/build_visit --console --no-visit --parallel '
+preconfigopts += ' --system-cmake --hdf5 --icet --llvm --mesagl --silo --netcdf --vtk '
+preconfigopts += ' --makeflags -j24 --system-python --alt-python-dir ${EBROOTPYTHON} '
+preconfigopts += ' --openssl --alt-boost-dir $EBROOTBOOST '
+#preconfigopts += ' --xdmf '
+preconfigopts += ' --qwt --qt <<< "yes" && '
+preconfigopts += ' sed -i /VISIT_MPI_COMPILER/d `hostname`.cmake; '
+preconfigopts += ' sed -i "s/rca TYPE/mpichcxx_gnu_71 rt mpich_gnu_71 rt rca pthread TYPE/g" `hostname`.cmake; '
+preconfigopts += ' cp `hostname`.cmake ../visit%(version)s/src/config-site; '
+preconfigopts += ' mkdir build; cd build; '
+
+configopts  = ' -DCMAKE_BUILD_TYPE=RelWithDebInfo '
+configopts += ' -DVISIT_DATA_MANUAL_EXAMPLES:BOOL=ON '
+configopts += ' -DVISIT_INSTALL_THIRD_PARTY:BOOL=ON '
+configopts += ' -DVISIT_SLIVR:BOOL=OFF -DVISIT_ENABLE_XDB:BOOL=OFF '
+
+prebuildopts  = ' cd build; '
+buildopts = 'install'
+
+dependencies = [
+    ('Boost', '1.70.0', '-python%(pymajver)s'),
+    ('cray-python', EXTERNAL_MODULE)
+]
+
+builddependencies = [
+    #('CMake', '3.9.3', '', True)
+    ('CMake', '3.14.5', '', True)
+]
+
+parallel = 24
+skipsteps = ['install']
+
+runtest = False
+
+sanity_check_paths = {
+    'files': [],
+    'dirs': ['current', 'bin', 'data', '%(version)s' ],
+}
+
+moduleclass = 'vis'

--- a/easybuild/easyconfigs/v/Visit/Visit-3.1.2-CrayGNU-20.06-python3.eb
+++ b/easybuild/easyconfigs/v/Visit/Visit-3.1.2-CrayGNU-20.06-python3.eb
@@ -20,7 +20,7 @@ toolchainopts = {'usempi': True, 'verbose': False}
 # Below you will find the steps to create the SOURCELOWER_TAR_GZ file used in
 # this recipe.
 #
-# wget http://portal.nersc.gov/project/visit/releases/3.1.2/visit3.1.2.tar.gz
+# wget https://github.com/visit-dav/visit/releases/download/v3.1.2/visit3.1.2.tar.gz
 # tar xfz visit3.1.2.tar.gz
 # cd visit3.1.2
 # ./src/tools/dev/scripts/build_visit --console --no-visit --parallel \


### PR DESCRIPTION
The pull request provides a draft recipe for `Visit` 3.1.2, with a tentative dependency `CMake 3.14.5` and trying to use the default `gcc 8.3.0` instead of `gcc 7.3.0` as in the previous version `Visit 3.1.0` on Piz Daint. 
If needed, we can use the system `/usr/bin/gcc 7.5.0` on Dom and build an older `CMake` modulefile.