### PR TITLE
[dom-gpu] Default module for Horovod

### DIFF
--- a/jenkins-builds/7.0.UP02-20.06-gpu-dom
+++ b/jenkins-builds/7.0.UP02-20.06-gpu-dom
@@ -14,7 +14,7 @@
  GSL-2.5-CrayCCE-20.06.eb
  GSL-2.5-CrayIntel-20.06.eb
  HDFView-2.14.eb                                     --set-default-module
- Horovod-0.19.1-CrayGNU-20.06-tf-2.2.0.eb
+ Horovod-0.19.1-CrayGNU-20.06-tf-2.2.0.eb            --set-default-module
  HPX-1.4.0-CrayGNU-20.06-cuda.eb                     --set-default-module
  HPX-1.4.0-CrayGNU-20.06-APEX-cuda.eb
  HPX-1.4.0-CrayGNU-20.06-nonetworking-cuda.eb


### PR DESCRIPTION
There is no default module for Horovod.
This is in principle ok, but it is not symmetrical to the other applications that always have a default.
On daint, for instance, it shows...
```
module av Horovod
...
Horovod/0.16.4-CrayGNU-19.10-tf-1.14.0 Horovod/0.18.1-CrayGNU-19.10-tf-2.0.0  Horovod/0.19.1-CrayGNU-19.10-tf-2.2.0
```