### PR TITLE
[dom] New versions of Julia and Jupyterlab in production on Dom

### DIFF
--- a/jenkins-builds/7.0.UP02-20.06-gpu-dom
+++ b/jenkins-builds/7.0.UP02-20.06-gpu-dom
@@ -26,7 +26,7 @@
  ipcmagic-0.1-CrayGNU-20.06.eb                       --set-default-module
  Julia-1.5.0-CrayGNU-20.06-cuda.eb                   --set-default-module
  JuliaExtensions-1.5.0-CrayGNU-20.06-cuda.eb         --set-default-module
- jupyterhub-1.0.0-CrayGNU-20.06.eb                   --set-default-module
+ jupyterlab-1.1.1-CrayGNU-20.06-batchspawner         --set-default-module
  jupyterlab-1.2.16-CrayGNU-20.06-batchspawner-cuda.eb
  jupyter-utils-0.1.eb                                --set-default-module
  LAMMPS-03Mar20-CrayGNU-20.06-cuda.eb                --set-default-module

--- a/jenkins-builds/7.0.UP02-20.06-gpu-dom
+++ b/jenkins-builds/7.0.UP02-20.06-gpu-dom
@@ -24,10 +24,10 @@
  IDL-8.5.1.eb                                        --set-default-module
  IDL-8.7.2-CSCS.eb
  ipcmagic-0.1-CrayGNU-20.06.eb                       --set-default-module
- ipyparallel-6.2.4-CrayGNU-20.06-python3.eb
- Julia-1.2.0-CrayGNU-20.06-cuda.eb                   --set-default-module
- JuliaExtensions-1.2.0-CrayGNU-20.06-cuda.eb         --set-default-module
+ Julia-1.5.0-CrayGNU-20.06-cuda.eb                   --set-default-module
+ JuliaExtensions-1.5.0-CrayGNU-20.06-cuda.eb         --set-default-module
  jupyterhub-1.0.0-CrayGNU-20.06.eb                   --set-default-module
+ jupyterlab-1.2.16-CrayGNU-20.06-batchspawner-cuda.eb
  jupyter-utils-0.1.eb                                --set-default-module
  LAMMPS-03Mar20-CrayGNU-20.06-cuda.eb                --set-default-module
  Lmod-7.8.2.eb                                       --set-default-module --hidden

--- a/jenkins-builds/7.0.UP02-20.06-mc-dom
+++ b/jenkins-builds/7.0.UP02-20.06-mc-dom
@@ -25,7 +25,8 @@
  ipcmagic-0.1-CrayGNU-20.06.eb                      --set-default-module
  Julia-1.5.0-CrayGNU-20.06.eb                       --set-default-module
  JuliaExtensions-1.5.0-CrayGNU-20.06.eb             --set-default-module
- jupyterlab-1.2.16-CrayGNU-20.06-batchspawner.eb    --set-default-module
+ jupyterlab-1.1.1-CrayGNU-20.06-batchspawner        --set-default-module
+ jupyterlab-1.2.16-CrayGNU-20.06-batchspawner.eb    
  jupyter-utils-0.1.eb                               --set-default-module
  LAMMPS-03Mar20-CrayGNU-20.06.eb                    --set-default-module
  Lmod-7.8.2.eb                                      --set-default-module --hidden

--- a/jenkins-builds/7.0.UP02-20.06-mc-dom
+++ b/jenkins-builds/7.0.UP02-20.06-mc-dom
@@ -23,9 +23,9 @@
  IDL-8.5.1.eb                                       --set-default-module
  IDL-8.7.2-CSCS.eb
  ipcmagic-0.1-CrayGNU-20.06.eb                      --set-default-module
- ipyparallel-6.2.4-CrayGNU-20.06-python3.eb
- Julia-1.2.0-CrayGNU-20.06.eb                       --set-default-module
- JuliaExtensions-1.2.0-CrayGNU-20.06.eb             --set-default-module
+ Julia-1.5.0-CrayGNU-20.06.eb                       --set-default-module
+ JuliaExtensions-1.5.0-CrayGNU-20.06.eb             --set-default-module
+ jupyterlab-1.2.16-CrayGNU-20.06-batchspawner.eb    --set-default-module
  jupyter-utils-0.1.eb                               --set-default-module
  LAMMPS-03Mar20-CrayGNU-20.06.eb                    --set-default-module
  Lmod-7.8.2.eb                                      --set-default-module --hidden


### PR DESCRIPTION
I'm removing the old releases of Julia and Jupyterlab from the production list of Dom. 
I have also removed `ipyparallel`, since this Python package is installed as an extension of `ipcmagic`.

Are there other items related to Jupyter in the production lists to remove or update on Dom with the PE 20.06?