### PR TITLE
[dom-gpu] Cray PE 20.08 metadata file

### DIFF
--- a/easybuild/cray_external_modules_metadata-20.08.cfg
+++ b/easybuild/cray_external_modules_metadata-20.08.cfg
@@ -1,0 +1,75 @@
+# metadata useful to EasyBuild (hpcugent.github.io/easybuild) for modules provided by Cray on Cray systems
+# authors: Guilherme Peretti-Pezzi (CSCS), Petar Forai (IMP/IMBA), Kenneth Hoste (HPC-UGent), Eirini Koutsaniti (CSCS)
+
+[cray-fftw]
+name = FFTW
+
+[cray-hdf5]
+name = HDF5
+version = 1.12.0.0
+prefix = HDF5_DIR
+
+[cray-hdf5-parallel]
+name = HDF5
+version = 1.12.0.0
+prefix = HDF5_DIR
+
+[cray-libsci]
+name = LibSci
+version = 20.06.1
+prefix = CRAY_LIBSCI_PREFIX
+
+[cray-netcdf]
+name = netCDF, netCDF-Fortran
+version = 4.7.4.0, 4.7.4.0
+prefix = NETCDF_DIR
+
+[cray-netcdf-hdf5parallel]
+name = netCDF, netCDF-Fortran
+version = 4.7.4.0, 4.7.4.0
+prefix = NETCDF_DIR
+
+[cray-petsc]
+name = PETSc
+
+[cray-petsc-64]
+name = PETSc
+
+[cray-petsc-complex]
+name = PETSc
+
+[cray-petsc-complex-64]
+name = PETSc
+
+[cray-python]
+name = Python
+
+[cray-R]
+name = R
+
+[cray-tpsl]
+name = TPSL
+
+[cray-tpsl-64]
+name = TPSL
+
+[cudatoolkit]
+name = CUDA
+version = 10.2.89_3.28-7.0.2.1_2.17__g52c0314
+prefix = CRAY_CUDATOOLKIT_DIR
+
+[gcc]
+name = GCC
+version = 8.3.0
+prefix = GCC_PATH
+
+[papi]
+name = PAPI
+
+[pmi]
+name = pmi
+
+[slurm/.default]
+name = slurm
+version = .default
+prefix = SLURMDIR


### PR DESCRIPTION
The metadata file is needed by the Jenkins project `UpdateEB` to update the software stack. 