### PR TITLE
[dom] Update Cray metadata in the EasyBuild custom modulefile

### DIFF
--- a/easybuild/module/EasyBuild-custom/cscs
+++ b/easybuild/module/EasyBuild-custom/cscs
@@ -73,7 +73,7 @@ if { [ string match *daint* $system ] } {
     setenv EASYBUILD_OPTARCH                    $::env(CRAY_CPU_TARGET)
     setenv EASYBUILD_RECURSIVE_MODULE_UNLOAD    0
 } elseif { [ string match *dom* $system ] } {
-    setenv EASYBUILD_EXTERNAL_MODULES_METADATA $::env(EB_CUSTOM_REPOSITORY)/cray_external_modules_metadata-20.06.cfg
+    setenv EASYBUILD_EXTERNAL_MODULES_METADATA $::env(EB_CUSTOM_REPOSITORY)/cray_external_modules_metadata-20.08.cfg
     setenv EASYBUILD_OPTARCH                    $::env(CRAY_CPU_TARGET)
     setenv EASYBUILD_RECURSIVE_MODULE_UNLOAD    0
 } elseif { [ string match *esch* $system ] } {


### PR DESCRIPTION
The reference to the Cray metadata file needs to be updated in production:
```
    setenv EASYBUILD_EXTERNAL_MODULES_METADATA $::env(EB_CUSTOM_REPOSITORY)/cray_external_modules_metadata-20.08.cfg
```