### PR TITLE
[dom-gpu] Adding ELPA with GPU support

### DIFF
--- a/easybuild/easyconfigs/c/CP2K/CP2K-7.1-CrayGNU-20.08-cuda.eb
+++ b/easybuild/easyconfigs/c/CP2K/CP2K-7.1-CrayGNU-20.08-cuda.eb
@@ -32,7 +32,7 @@ builddependencies = [
     ('flex', '2.6.4'),
 ]
 dependencies = [
-    ('ELPA', '2019.11.001'),
+    ('ELPA', '2019.11.001', '-cuda'),
     ('Libint-CP2K', '2.6.0'),
     ('libxc', '4.3.4'),
 ]

--- a/easybuild/easyconfigs/e/ELPA/ELPA-2019.11.001-CrayGNU-20.08-cuda.eb
+++ b/easybuild/easyconfigs/e/ELPA/ELPA-2019.11.001-CrayGNU-20.08-cuda.eb
@@ -1,0 +1,35 @@
+# Contributed by Luca Marsella (CSCS)
+easyblock = 'ConfigureMake'
+
+name = 'ELPA'
+version = '2019.11.001'
+versionsuffix = '-cuda'
+
+homepage = 'http://elpa.rzg.mpg.de'
+description = "Eigenvalue SoLvers for Petaflop-Applications ."
+
+toolchain = {'name': 'CrayGNU', 'version': '20.08'}
+toolchainopts = {'usempi': True, 'openmp': True}
+
+source_urls = ['http://%(namelower)s.mpcdf.mpg.de/html/Releases/%(version)s/']
+sources = [SOURCELOWER_TAR_GZ]
+
+configopts = " --disable-avx512 --enable-openmp --enable-static "
+configopts += " --enable-gpu --with-GPU-compute-capability=sm_60 "
+
+prebuildopts = " make clean && "
+
+builddependencies = [
+    ("cudatoolkit", EXTERNAL_MODULE)
+]
+
+sanity_check_paths = {
+    'files': ['lib/libelpa_openmp.a', 'lib/libelpa_openmp.so'],
+    'dirs': ['bin', 'include/elpa_openmp-%(version)s/%(namelower)s', 'include/elpa_openmp-%(version)s/modules', 'lib/pkgconfig'],
+}
+
+modextrapaths = {'CPATH': ['include/elpa_openmp-%(version)s']}
+
+modextravars = {'ELPA_INCLUDE_DIR': '%(installdir)s/include/elpa_openmp-%(version)s'}
+
+moduleclass = 'math'


### PR DESCRIPTION
I'm adding the recipe for the `ELPA` library with GPU support and updating the recipe of `CP2K` where it is currently used as a dependency.
Extending the new `ELPA` recipe to build it on the current Cray PE 19.10 of Piz Daint is straightforward: the library can be compiled using the EasyBuild flag `--try-toolchain-version=19.10`.