### PR TITLE
[daint-gpu] Add HWLOC_ROOT to hwloc modules

### DIFF
--- a/easybuild/easyconfigs/h/hwloc/hwloc-1.11.7.eb
+++ b/easybuild/easyconfigs/h/hwloc/hwloc-1.11.7.eb
@@ -28,4 +28,6 @@ sources = [SOURCE_TAR_GZ]
 #configopts = "--enable-libnuma=$EBROOTNUMACTL --with-x"
 configopts = "--enable-libnuma --with-x"
 
+modextravars = {'HWLOC_ROOT': '%(installdir)s'}
+
 moduleclass = 'system'

--- a/easybuild/easyconfigs/h/hwloc/hwloc-2.0.4.eb
+++ b/easybuild/easyconfigs/h/hwloc/hwloc-2.0.4.eb
@@ -13,7 +13,7 @@ description = """
     various system attributes such as cache and memory information as well as
     the locality of I/O devices such as network interfaces, InfiniBand HCAs or
     GPUs. It primarily aims at helping applications with gathering information
-    about modern computing hardware so as to exploit it accordingly and 
+    about modern computing hardware so as to exploit it accordingly and
     efficiently.
 """
 
@@ -27,5 +27,7 @@ sources = [SOURCE_TAR_GZ]
 dependencies = [('numactl', '2.0.12')]
 # configopts = "--enable-libnuma=$EBROOTNUMACTL --with-x"
 #configopts = "--with-x"
+
+modextravars = {'HWLOC_ROOT': '%(installdir)s'}
 
 moduleclass = 'system'


### PR DESCRIPTION
The export of the `HWLOC_ROOT` environment allows CMake 3.17.3 cannot find hwloc, while CMake 3.17.1 can find it without this environment variable.

This issue was observed in the past with Boost, so we have added this environment variable (https://github.com/eth-cscs/production/blob/1c9786abae372c86efdcb68a5ac10a4a8a22fb58/easybuild/easyconfigs/b/Boost/Boost-1.70.0-CrayGNU-20.08.eb#L25).

