### PR TITLE
[daint-gpu] Force remove cray-libsci_acc

### DIFF
--- a/easybuild/easyconfigs/j/Julia/Julia-1.5.0-CrayGNU-19.10-cuda-10.1.eb
+++ b/easybuild/easyconfigs/j/Julia/Julia-1.5.0-CrayGNU-19.10-cuda-10.1.eb
@@ -46,4 +46,6 @@ modextravars = {
     'JULIA_CUDA_USE_BINARYBUILDER': 'false',
 }
 
+modtclfooter = "module unload cray-libsci_acc"
+
 moduleclass = 'lang'


### PR DESCRIPTION
Force remove the `cray-libsci_acc` module as it is not needed by `CUDA.jl` or Julia in general, but it breaks the jupyterlab module (see #1862).