### PR TITLE
[dom-gpu] Julia 1.5.0 without cray-libsci_acc module

### DIFF
--- a/easybuild/easyconfigs/j/Julia/Julia-1.5.0-CrayGNU-20.08-cuda.eb
+++ b/easybuild/easyconfigs/j/Julia/Julia-1.5.0-CrayGNU-20.08-cuda.eb
@@ -36,4 +36,6 @@ modextravars = {
     'JULIA_MPI_PATH': '$::env(CRAY_MPICH_DIR)',
 }
 
+modtclfooter = "module unload cray-libsci_acc"
+
 moduleclass = 'lang'


### PR DESCRIPTION
This PR removes the cray-libsci_acc module from the Julia 1.5.0 module as it causes issues with numpy and Dask at runtime in JupyterLab.