### PR TITLE
[dom-gpu] Update ELPA dependency of SIRIUS

### DIFF
--- a/easybuild/easyconfigs/e/ELPA/ELPA-2019.11.001-CrayIntel-20.08-cuda.eb
+++ b/easybuild/easyconfigs/e/ELPA/ELPA-2019.11.001-CrayIntel-20.08-cuda.eb
@@ -14,6 +14,10 @@ toolchainopts = {'usempi': True, 'openmp': True}
 source_urls = ['http://%(namelower)s.mpcdf.mpg.de/html/Releases/%(version)s/']
 sources = [SOURCELOWER_TAR_GZ]
 
+builddependencies = [
+    ("cudatoolkit", EXTERNAL_MODULE)
+]
+
 preconfigopts = ' module unload cray-libsci && module list && CC=cc FC=ftn CPP=cpp FCPP=cpp  LIBS="-L$MKLROOT/lib/intel64 -lmkl_scalapack_lp64 -lmkl_intel_lp64 -lmkl_intel_thread -lmkl_core -lmkl_blacs_intelmpi_lp64 -lpthread -lstdc++ -ldl"  FCFLAGS="-qopenmp -O3 -xAVX2" CFLAGS="-qopenmp -O3 -xAVX2" '
 configopts = " --enable-openmp --enable-static "
 configopts += " --enable-gpu --with-GPU-compute-capability=sm_60 "

--- a/easybuild/easyconfigs/e/ELPA/ELPA-2019.11.001-CrayIntel-20.08-cuda.eb
+++ b/easybuild/easyconfigs/e/ELPA/ELPA-2019.11.001-CrayIntel-20.08-cuda.eb
@@ -1,0 +1,32 @@
+# Contributed by Luca Marsella (CSCS)
+easyblock = 'ConfigureMake'
+
+name = 'ELPA'
+version = '2019.11.001'
+versionsuffix = '-cuda' 
+
+homepage = 'http://elpa.rzg.mpg.de'
+description = "Eigenvalue SoLvers for Petaflop-Applications ."
+
+toolchain = {'name': 'CrayIntel', 'version': '20.08'}
+toolchainopts = {'usempi': True, 'openmp': True}
+
+source_urls = ['http://%(namelower)s.mpcdf.mpg.de/html/Releases/%(version)s/']
+sources = [SOURCELOWER_TAR_GZ]
+
+preconfigopts = ' module unload cray-libsci && module list && CC=cc FC=ftn CPP=cpp FCPP=cpp  LIBS="-L$MKLROOT/lib/intel64 -lmkl_scalapack_lp64 -lmkl_intel_lp64 -lmkl_intel_thread -lmkl_core -lmkl_blacs_intelmpi_lp64 -lpthread -lstdc++ -ldl"  FCFLAGS="-qopenmp -O3 -xAVX2" CFLAGS="-qopenmp -O3 -xAVX2" '
+configopts = " --enable-openmp --enable-static "
+configopts += " --enable-gpu --with-GPU-compute-capability=sm_60 "
+
+prebuildopts = " module unload cray-libsci && make clean && "
+
+sanity_check_paths = {
+    'files': ['lib/libelpa_openmp.a', 'lib/libelpa_openmp.so'],
+    'dirs': ['bin', 'include/elpa_openmp-%(version)s/%(namelower)s', 'include/elpa_openmp-%(version)s/modules', 'lib/pkgconfig'],
+}
+
+modextrapaths = {'CPATH': ['include/elpa_openmp-%(version)s']}
+
+modextravars = {'ELPA_INCLUDE_DIR': '%(installdir)s/include/elpa_openmp-%(version)s'}
+
+moduleclass = 'math'

--- a/easybuild/easyconfigs/s/SIRIUS/SIRIUS-6.5.3-CrayIntel-20.08-cuda.eb
+++ b/easybuild/easyconfigs/s/SIRIUS/SIRIUS-6.5.3-CrayIntel-20.08-cuda.eb
@@ -20,7 +20,7 @@ builddependencies = [
 ]
 dependencies = [
     ('cray-hdf5', EXTERNAL_MODULE),
-    ('ELPA', '2019.11.001'),
+    ('ELPA', '2019.11.001', '-cuda'),
     ('GSL', '2.5'),
     ('libxc', '4.3.4'),
     ('magma', '2.5.3', '-cuda'),


### PR DESCRIPTION
Linking `ELPA` with GPU support as already done for `CP2K`: linking the new library will not change the behaviour of the code, as described in the `ELPA` Wiki:
> If ELPA is build with GPU support, users can choose at RUNTIME, whether to use the GPU version or not.

Only if the configure option `--with-gpu-support-only` is used when building `ELPA`, then the use of the GPU version of the library will be enforced at runtime:
```
--with-gpu-support-only | Compile and always use the GPU version
```
See https://gitlab.mpcdf.mpg.de/elpa/elpa/-/wikis/INSTALL for more information.