### PR TITLE
[daint-mc] Changing SCOTCH dependency of OF7

### DIFF
--- a/easybuild/easyconfigs/o/OpenFOAM/OpenFOAM-7.0-CrayGNU-19.10.eb
+++ b/easybuild/easyconfigs/o/OpenFOAM/OpenFOAM-7.0-CrayGNU-19.10.eb
@@ -1,4 +1,4 @@
-# mkra (CSCS), 2018
+# mkra (CSCS), 2020
 easyblock='Binary'
 name = 'OpenFOAM'
 version = "7.0"
@@ -31,7 +31,7 @@ builddependencies = [
      ('CMake/3.14.5', EXTERNAL_MODULE),
 ]
 dependencies = [
-     ('SCOTCH', '6.0.9'),
+     ('cray-tpsl', EXTERNAL_MODULE),
 ]
 
 extract_sources = 'True'

--- a/easybuild/easyconfigs/o/OpenFOAM/patch.OpenFOAM-7.0-20200508
+++ b/easybuild/easyconfigs/o/OpenFOAM/patch.OpenFOAM-7.0-20200508
@@ -1,6 +1,6 @@
-diff -Nru OpenFOAM-7.ref/etc/bashrc OpenFOAM-7/etc/bashrc
---- OpenFOAM-7.ref/etc/bashrc	2020-06-22 12:39:01.000000000 +0200
-+++ OpenFOAM-7/etc/bashrc	2020-06-22 13:31:20.000000000 +0200
+diff -rNu OpenFOAM-7.ref/etc/bashrc OpenFOAM-7/etc/bashrc
+--- OpenFOAM-7.ref/etc/bashrc	2020-05-08 12:49:05.000000000 +0200
++++ OpenFOAM-7/etc/bashrc	2020-08-25 21:54:50.000000000 +0200
 @@ -32,7 +32,7 @@
  #------------------------------------------------------------------------------
  
@@ -10,12 +10,11 @@ diff -Nru OpenFOAM-7.ref/etc/bashrc OpenFOAM-7/etc/bashrc
  
  ################################################################################
  # USER EDITABLE PART: Changes made here may be lost with the next upgrade
-@@ -86,7 +86,12 @@
+@@ -86,7 +86,11 @@
  #- MPI implementation:
  #    WM_MPLIB = SYSTEMOPENMPI | OPENMPI | SYSTEMMPI | MPICH | MPICH-GM | HPMPI
  #               | MPI | FJMPI | QSMPI | SGIMPI | INTELMPI
 -export WM_MPLIB=SYSTEMOPENMPI
-+export WM_MPLIB=SYSTEMMPI
 +export WM_MPLIB=SYSTEMMPI
 +export MPI_ROOT=${MPICH_DIR}
 +export MPI_ARCH_FLAGS=" "
@@ -24,22 +23,22 @@ diff -Nru OpenFOAM-7.ref/etc/bashrc OpenFOAM-7/etc/bashrc
  
  #- Operating System:
  #    WM_OSTYPE = POSIX | ???
-diff -Nru OpenFOAM-7.ref/etc/config.sh/scotch OpenFOAM-7/etc/config.sh/scotch
---- OpenFOAM-7.ref/etc/config.sh/scotch	2020-06-22 12:39:02.000000000 +0200
-+++ OpenFOAM-7/etc/config.sh/scotch	2020-06-22 13:32:07.000000000 +0200
+diff -rNu OpenFOAM-7.ref/etc/config.sh/scotch OpenFOAM-7/etc/config.sh/scotch
+--- OpenFOAM-7.ref/etc/config.sh/scotch	2020-05-08 12:49:05.000000000 +0200
++++ OpenFOAM-7/etc/config.sh/scotch	2020-08-25 21:55:30.000000000 +0200
 @@ -37,7 +37,7 @@
  #
  #------------------------------------------------------------------------------
  
 -export SCOTCH_VERSION=scotch_6.0.6
 -export SCOTCH_ARCH_PATH=$WM_THIRD_PARTY_DIR/platforms/$WM_ARCH$WM_COMPILER$WM_PRECISION_OPTION$WM_LABEL_OPTION/$SCOTCH_VERSION
-+export SCOTCH_VERSION=${EBVERSIONSCOTCH}
-+export SCOTCH_ARCH_PATH=${EBROOTSCOTCH}
++#export SCOTCH_VERSION=scotch_6.0.6
++export SCOTCH_ARCH_PATH=${CRAY_TPSL_DIR}
  
  #------------------------------------------------------------------------------
-diff -Nru OpenFOAM-7.ref/etc/config.sh/settings OpenFOAM-7/etc/config.sh/settings
---- OpenFOAM-7.ref/etc/config.sh/settings	2020-06-22 12:39:02.000000000 +0200
-+++ OpenFOAM-7/etc/config.sh/settings	2020-06-22 13:32:37.000000000 +0200
+diff -rNu OpenFOAM-7.ref/etc/config.sh/settings OpenFOAM-7/etc/config.sh/settings
+--- OpenFOAM-7.ref/etc/config.sh/settings	2020-05-08 12:49:05.000000000 +0200
++++ OpenFOAM-7/etc/config.sh/settings	2020-08-25 21:56:37.000000000 +0200
 @@ -61,8 +61,8 @@
          64)
              WM_ARCH=linux64
@@ -51,9 +50,9 @@ diff -Nru OpenFOAM-7.ref/etc/config.sh/settings OpenFOAM-7/etc/config.sh/setting
              export WM_CFLAGS='-m64 -fPIC'
              export WM_CXXFLAGS='-m64 -fPIC -std=c++0x'
              export WM_LDFLAGS='-m64'
-diff -Nru OpenFOAM-7.ref/src/parallel/decompose/Allwmake OpenFOAM-7/src/parallel/decompose/Allwmake
---- OpenFOAM-7.ref/src/parallel/decompose/Allwmake	2020-06-22 12:39:08.000000000 +0200
-+++ OpenFOAM-7/src/parallel/decompose/Allwmake	2020-06-22 13:32:51.000000000 +0200
+diff -rNu OpenFOAM-7.ref/src/parallel/decompose/Allwmake OpenFOAM-7/src/parallel/decompose/Allwmake
+--- OpenFOAM-7.ref/src/parallel/decompose/Allwmake	2020-05-08 12:49:05.000000000 +0200
++++ OpenFOAM-7/src/parallel/decompose/Allwmake	2020-08-25 21:57:17.000000000 +0200
 @@ -31,7 +31,7 @@
          [ -e "$whichmpi" -a -e "$whichscotch" ] || wclean $libName
          echo "wmake $targetType $libName"
@@ -63,9 +62,9 @@ diff -Nru OpenFOAM-7.ref/src/parallel/decompose/Allwmake OpenFOAM-7/src/parallel
      )
      done
  }
-diff -Nru OpenFOAM-7.ref/src/parallel/decompose/ptscotchDecomp/ptscotchDecomp.C OpenFOAM-7/src/parallel/decompose/ptscotchDecomp/ptscotchDecomp.C
---- OpenFOAM-7.ref/src/parallel/decompose/ptscotchDecomp/ptscotchDecomp.C	2020-06-22 12:39:08.000000000 +0200
-+++ OpenFOAM-7/src/parallel/decompose/ptscotchDecomp/ptscotchDecomp.C	2020-06-22 13:33:39.000000000 +0200
+diff -rNu OpenFOAM-7.ref/src/parallel/decompose/ptscotchDecomp/ptscotchDecomp.C OpenFOAM-7/src/parallel/decompose/ptscotchDecomp/ptscotchDecomp.C
+--- OpenFOAM-7.ref/src/parallel/decompose/ptscotchDecomp/ptscotchDecomp.C	2020-05-08 12:49:05.000000000 +0200
++++ OpenFOAM-7/src/parallel/decompose/ptscotchDecomp/ptscotchDecomp.C	2020-08-25 21:57:59.000000000 +0200
 @@ -30,11 +30,11 @@
  #include "globalIndex.H"
  #include "SubField.H"
@@ -79,9 +78,9 @@ diff -Nru OpenFOAM-7.ref/src/parallel/decompose/ptscotchDecomp/ptscotchDecomp.C 
      #include "ptscotch.h"
  }
  
-diff -Nru OpenFOAM-7.ref/src/Pstream/Allwmake OpenFOAM-7/src/Pstream/Allwmake
---- OpenFOAM-7.ref/src/Pstream/Allwmake	2020-06-22 12:39:04.000000000 +0200
-+++ OpenFOAM-7/src/Pstream/Allwmake	2020-06-22 13:34:03.000000000 +0200
+diff -rNu OpenFOAM-7.ref/src/Pstream/Allwmake OpenFOAM-7/src/Pstream/Allwmake
+--- OpenFOAM-7.ref/src/Pstream/Allwmake	2020-05-08 12:49:05.000000000 +0200
++++ OpenFOAM-7/src/Pstream/Allwmake	2020-08-25 21:58:13.000000000 +0200
 @@ -17,7 +17,7 @@
          whichmpi="$WM_PROJECT_DIR/platforms/$WM_OPTIONS/src/Pstream/$libName/using:$FOAM_MPI"
          [ -e "$whichmpi" ] || wclean $libName
@@ -91,9 +90,9 @@ diff -Nru OpenFOAM-7.ref/src/Pstream/Allwmake OpenFOAM-7/src/Pstream/Allwmake
      )
      done
  }
-diff -Nru OpenFOAM-7.ref/wmake/rules/linux64Gcc/c OpenFOAM-7/wmake/rules/linux64Gcc/c
---- OpenFOAM-7.ref/wmake/rules/linux64Gcc/c	2020-06-22 12:39:15.000000000 +0200
-+++ OpenFOAM-7/wmake/rules/linux64Gcc/c	2020-06-22 13:34:27.000000000 +0200
+diff -rNu OpenFOAM-7.ref/wmake/rules/linux64Gcc/c OpenFOAM-7/wmake/rules/linux64Gcc/c
+--- OpenFOAM-7.ref/wmake/rules/linux64Gcc/c	2020-05-08 12:49:05.000000000 +0200
++++ OpenFOAM-7/wmake/rules/linux64Gcc/c	2020-08-25 21:58:33.000000000 +0200
 @@ -2,7 +2,7 @@
  
  cWARN        = -Wall
@@ -103,9 +102,9 @@ diff -Nru OpenFOAM-7.ref/wmake/rules/linux64Gcc/c OpenFOAM-7/wmake/rules/linux64
  
  include $(DEFAULT_RULES)/c$(WM_COMPILE_OPTION)
  
-diff -Nru OpenFOAM-7.ref/wmake/rules/linux64Gcc/c++ OpenFOAM-7/wmake/rules/linux64Gcc/c++
---- OpenFOAM-7.ref/wmake/rules/linux64Gcc/c++	2020-06-22 12:39:15.000000000 +0200
-+++ OpenFOAM-7/wmake/rules/linux64Gcc/c++	2020-06-22 13:34:45.000000000 +0200
+diff -rNu OpenFOAM-7.ref/wmake/rules/linux64Gcc/c++ OpenFOAM-7/wmake/rules/linux64Gcc/c++
+--- OpenFOAM-7.ref/wmake/rules/linux64Gcc/c++	2020-05-08 12:49:05.000000000 +0200
++++ OpenFOAM-7/wmake/rules/linux64Gcc/c++	2020-08-25 21:58:47.000000000 +0200
 @@ -6,7 +6,7 @@
  # Suppress some warnings for flex++ and CGAL
  c++LESSWARN = -Wno-old-style-cast -Wno-unused-local-typedefs -Wno-array-bounds


### PR DESCRIPTION
Changing the dependencies to use the SCOTCH library from the `cray-tpsl` module, instead of building SCOTCH apart.