### PR TITLE
[dom-gpu] Fix integer overflow on xalt data

### DIFF
--- a/easybuild/easyconfigs/x/xalt/xalt-xalt-2.8.10.bindata.patch
+++ b/easybuild/easyconfigs/x/xalt/xalt-xalt-2.8.10.bindata.patch
@@ -1,11 +1,11 @@
 diff -Nru xalt-xalt-2.8.10-orig/src/extractXALTRecord.C xalt-xalt-2.8.10/src/extractXALTRecord.C
 --- xalt-xalt-2.8.10-orig/src/extractXALTRecord.C	2020-07-25 19:32:11.000000000 +0200
-+++ xalt-xalt-2.8.10/src/extractXALTRecord.C	2020-08-20 10:32:37.481731000 +0200
++++ xalt-xalt-2.8.10/src/extractXALTRecord.C	2020-09-02 19:37:52.660611000 +0200
 @@ -2,12 +2,13 @@
  #include "capture.h"
  #include "xalt_config.h"
  
-+
++#include <algorithm>
  bool extractXALTRecordString(std::string& exec, std::string& watermark)
  {
  
@@ -52,10 +52,16 @@ diff -Nru xalt-xalt-2.8.10-orig/src/extractXALTRecord.C xalt-xalt-2.8.10/src/ext
        v = watermark.substr(s2+3,s3 - (s2+3));
  
        s4 = 0;
-@@ -117,3 +118,124 @@
+@@ -117,3 +118,160 @@
        recordT[n] = v;
      }
  }
++
++inline void rtrim(std::string &s) {
++    s.erase(std::find_if(s.rbegin(), s.rend(), [](int ch) {
++        return !std::isspace(ch);
++    }).base(), s.end());
++}
 +
 +bool extractBinaryData(std::string& exec, std::string& dataString)
 +{
@@ -144,7 +150,7 @@ diff -Nru xalt-xalt-2.8.10-orig/src/extractXALTRecord.C xalt-xalt-2.8.10/src/ext
 +
 +  // Take the output above and convert the string portion into a single line
 +  std::string            xaltRecord;
-+  std::string::size_type idx, len;
++  std::string::size_type idx, len, start, end;
 +  int count = 0;
 +  // for (i = i + 1; i < nlines; i++)
 +  //   {
@@ -160,18 +166,48 @@ diff -Nru xalt-xalt-2.8.10-orig/src/extractXALTRecord.C xalt-xalt-2.8.10/src/ext
 +  //   }
 +
 +  i = i + 1;
++  // const int max_characters = 10000;
++  // while(i < nlines and count < max_characters) {
++  //   std::string& line = result[i];
++  //   idx               = line.find_last_of("  ");
++  //   len               = line.size();
++  //   if (idx+2 < len) {
++  //     if (line[idx+1] != '.' and line[idx+1] != '_' and line[idx+2] != '_') {
++  //       xaltRecord       += line.substr(idx, len-idx-1);
++  //       count += len - idx;
++  //     }
++  //   }
++  //   i++;
++  // }
 +  const int max_characters = 10000;
 +  while(i < nlines and count < max_characters) {
-+      std::string& line = result[i];
-+      idx               = line.find_last_of("  ");
-+      len               = line.size();
-+      if (idx+2 < len) {
-+        if (line[idx+1] != '.' and line[idx+1] != '_' and line[idx+2] != '_') {
-+          xaltRecord       += line.substr(idx, len-idx-1);
-+          count += len - idx;
-+        }
++    rtrim(result[i]);
++    std::string& line = result[i];
++    idx               = line.rfind("  ");
++    len               = line.size();
++    // removing [clone .*] references from the function name
++    // these are compiler dependent
++    end               = line.rfind(" [clone .");
++    if (idx == std::string::npos) {
++      idx = 0;
++      start = 0;
++    } else {
++      start = idx + 2;
++    }
++
++    if (end == std::string::npos) {
++      end = len;
++    }
++
++    if (idx+3 < end) {
++      if (line[idx+2] == '.' or (line[idx+2] == '_' and line[idx+3] == '_')) {
 +      }
-+      i++;
++      else {
++        xaltRecord       += "?###?" + line.substr(start, end-idx-2);
++        count += end - idx - 1;
++      }
++    }
++    i++;
 +  }
 +
 +  dataString = xaltRecord;


### PR DESCRIPTION
This fixes an integer overflow on XALT
Introduces the '?###?' separator for the symboles
Removes symbols that start with '.' or '__'
Strips the ' [code .*]' entries at the end of the function names