### PR TITLE
[dom] CPMD 4.1

### DIFF
--- a/easybuild/easyconfigs/c/CPMD/CPMD-4.1-CrayIntel-20.08.eb
+++ b/easybuild/easyconfigs/c/CPMD/CPMD-4.1-CrayIntel-20.08.eb
@@ -1,0 +1,40 @@
+# contributed by Andreas Jocksch, Luca Marsella and Guilherme Peretti Pezzi (CSCS)
+easyblock = 'MakeCp'
+
+name = 'CPMD'
+version = '4.1'
+
+homepage = 'http://www.cpmd.org/'
+description = """
+    CPMD The CPMD code is a parallelized plane wave / pseudopotential
+    implementation of Density Functional Theory, particularly designed
+    for ab-initio molecular dynamics.
+"""
+
+toolchain = {'name': 'CrayIntel', 'version': '20.08'}
+toolchainopts = {'usempi': True}
+
+sources = [
+    '/apps/common/UES/easybuild/sources/c/CPMD/cpmd-v%s.tar.gz' %version
+]
+
+patches = [('CRAY-XE6-INTEL-MKL', 'CPMD/configure')]
+
+dependencies = [('cray-fftw', EXTERNAL_MODULE)]
+
+skipsteps = ['configure']
+
+local_common_prebuildopts = (
+    './configure.sh PREFIX=%(installdir)s CRAY-XE6-INTEL-MKL &&'
+)
+
+prebuildopts = [ local_common_prebuildopts, ]
+
+files_to_copy = [(['bin/cpmd*.x'],'bin')]
+
+sanity_check_paths = {
+    'files': ['bin/cpmd.x'],
+    'dirs': [],
+}
+
+moduleclass = 'chem'

--- a/jenkins-builds/7.0.UP02-20.08-dom-gpu
+++ b/jenkins-builds/7.0.UP02-20.08-dom-gpu
@@ -6,7 +6,8 @@
  CDO-1.9.5-CrayIntel-20.08.eb
  CMake-3.14.5.eb                                        --set-default-module
  CP2K-7.1-CrayGNU-20.08-cuda.eb                         --set-default-module
- CPMD-4.3-CrayIntel-20.08-cuda.eb                       --set-default-module
+ CPMD-4.1-CrayIntel-20.08.eb                            --set-default-module
+ CPMD-4.3-CrayIntel-20.08-cuda.eb
  GREASY-19.03-cscs-CrayGNU-20.08.eb                     --set-default-module
  GROMACS-2018.6-CrayGNU-20.08-cuda.eb                   --set-default-module
  GSL-2.5-CrayGNU-20.08.eb                               --set-default-module

--- a/jenkins-builds/7.0.UP02-20.08-dom-mc
+++ b/jenkins-builds/7.0.UP02-20.08-dom-mc
@@ -6,7 +6,8 @@
  CDO-1.9.5-CrayIntel-20.08.eb
  CMake-3.14.5.eb                                        --set-default-module
  CP2K-7.1-CrayGNU-20.08.eb                              --set-default-module
- CPMD-4.3-CrayIntel-20.08.eb                            --set-default-module
+ CPMD-4.1-CrayIntel-20.08.eb                            --set-default-module
+ CPMD-4.3-CrayIntel-20.08.eb
  dask-2.2.0-CrayGNU-20.08-python3.eb                    --set-default-module
  GREASY-19.03-cscs-CrayGNU-20.08.eb                     --set-default-module
  GROMACS-2020.1-CrayGNU-20.08.eb                        --set-default-module


### PR DESCRIPTION
we set CPMD 4.1 as default since our test case is executed faster with the old version

UES-1052