### PR TITLE
[daint-gpu] Recipes of older VASP 5.4.4 on cdt 20.08

### DIFF
--- a/easybuild/easyconfigs/v/VASP/VASP-5.4.4-CrayIntel-20.08-cuda.eb
+++ b/easybuild/easyconfigs/v/VASP/VASP-5.4.4-CrayIntel-20.08-cuda.eb
@@ -1,0 +1,39 @@
+# contributed by Luca Marsella (CSCS)
+easyblock = 'MakeCp'
+
+name = 'VASP'
+version = '5.4.4'
+versionsuffix = '-cuda'
+
+homepage = 'http://www.vasp.at'
+description = """The Vienna Ab initio Simulation Package (VASP) is a computer program for atomic scale materials modelling, e.g. electronic structure calculations and quantum-mechanical molecular dynamics, from first principles. """
+
+toolchain = {'name': 'CrayIntel', 'version': '20.08'}
+toolchainopts = { 'usempi': True }
+
+patches = [('%(name)s-%(version)s-%(toolchain_name)s%(versionsuffix)s.makefile.include', '%(builddir)s/%(namelower)s-%(version)s')]
+
+sources = ['/apps/common/UES/easybuild/sources/%(nameletterlower)s/%(name)s/' + SOURCELOWER_TAR_BZ2]
+
+builddependencies = [
+    ('cudatoolkit', EXTERNAL_MODULE),
+    ('cray-fftw', EXTERNAL_MODULE),
+    ('Wannier90', '3.1.0')
+]
+
+prebuildopts = ' mv %(name)s-%(version)s-%(toolchain_name)s%(versionsuffix)s.makefile.include makefile.include && '
+
+# don't use parallel make, results in compilation failure
+parallel = 1
+
+# build type
+buildopts = ' gpu gpu_ncl '
+
+files_to_copy = [(['./bin/vasp_*'],'bin')]
+
+sanity_check_paths = {
+    'files': ['bin/vasp_gpu','bin/vasp_gpu_ncl'],
+    'dirs': [],
+}
+
+moduleclass = 'phys'

--- a/easybuild/easyconfigs/v/VASP/VASP-5.4.4-CrayIntel-20.08.eb
+++ b/easybuild/easyconfigs/v/VASP/VASP-5.4.4-CrayIntel-20.08.eb
@@ -1,0 +1,35 @@
+# contributed by Luca Marsella (CSCS)
+easyblock = 'MakeCp'
+
+name = 'VASP'
+version = '5.4.4'
+
+homepage = 'http://www.vasp.at'
+description = """The Vienna Ab initio Simulation Package (VASP) is a computer program for atomic scale materials modelling, e.g. electronic structure calculations and quantum-mechanical molecular dynamics, from first principles. """
+
+toolchain = {'name': 'CrayIntel', 'version': '20.08'}
+toolchainopts = { 'usempi': True }
+
+patches = [('%(name)s-%(version)s-%(toolchain_name)s.makefile.include', '%(builddir)s/%(namelower)s-%(version)s')]
+sources = ['/apps/common/UES/easybuild/sources/%(nameletterlower)s/%(name)s/' + SOURCELOWER_TAR_BZ2]
+
+builddependencies = [
+    ('cray-fftw', EXTERNAL_MODULE),
+    ('Wannier90', '3.1.0')
+]
+
+prebuildopts = ' mv %(name)s-%(version)s-%(toolchain_name)s.makefile.include makefile.include && '
+# don't use parallel make, results in compilation failure
+parallel = 1
+
+# build type
+buildopts = ' all '
+ 
+files_to_copy = [(['./bin/vasp_*'],'bin')]
+
+sanity_check_paths = {
+    'files': ['bin/vasp_gam','bin/vasp_ncl','bin/vasp_std'],
+    'dirs': [],
+}
+
+moduleclass = 'phys'

--- a/easybuild/easyconfigs/v/VASP/VASP-5.4.4-CrayIntel-cuda.makefile.include
+++ b/easybuild/easyconfigs/v/VASP/VASP-5.4.4-CrayIntel-cuda.makefile.include
@@ -1,0 +1,1 @@
+VASP-5.4.4-CrayIntel-cuda-10.1-w90-3.1.0.makefile.include

--- a/easybuild/easyconfigs/v/VASP/VASP-5.4.4-CrayIntel.makefile.include
+++ b/easybuild/easyconfigs/v/VASP/VASP-5.4.4-CrayIntel.makefile.include
@@ -1,1 +1,1 @@
-VASP-5.4.4-CrayIntel-17.08.makefile.include
+VASP-5.4.4-CrayIntel-w90-3.1.0.makefile.include


### PR DESCRIPTION
I provide the EasyBuild recipes of the older `VASP 5.4.4` release for users that have not yet purchased a license for the latest release `VASP 6`, as explained on the User Portal at https://user.cscs.ch/computing/applications/vasp.