### PR TITLE
[daint-gpu] slepc 3.13.4 with 20.08 + fix for PETSc metadata 

### DIFF
--- a/easybuild/cray_external_modules_metadata-20.08.cfg
+++ b/easybuild/cray_external_modules_metadata-20.08.cfg
@@ -39,7 +39,7 @@ prefix = PETSC_DIR
 
 [cray-petsc-complex]
 name = PETSc
-prefix = PETSC_DIR
+prefix = CRAY_PETSC_COMPLEX_PREFIX_DIR
 
 [cray-petsc-complex-64]
 name = PETSc

--- a/easybuild/cray_external_modules_metadata-20.08.cfg
+++ b/easybuild/cray_external_modules_metadata-20.08.cfg
@@ -31,19 +31,17 @@ prefix = NETCDF_DIR
 
 [cray-petsc]
 name = PETSc
-prefix = PETSC_DIR
 
 [cray-petsc-64]
 name = PETSc
-prefix = PETSC_DIR
 
 [cray-petsc-complex]
 name = PETSc
-prefix = CRAY_PETSC_COMPLEX_PREFIX_DIR
+prefix = CRAY_PETSC_COMPLEX_PREFIX
 
 [cray-petsc-complex-64]
 name = PETSc
-prefix = PETSC_DIR
+prefix = CRAY_PETSC_COMPLEX_64_PREFIX
 
 [cray-python]
 name = Python

--- a/easybuild/cray_external_modules_metadata-20.08.cfg
+++ b/easybuild/cray_external_modules_metadata-20.08.cfg
@@ -38,10 +38,12 @@ name = PETSc
 [cray-petsc-complex]
 name = PETSc
 prefix = CRAY_PETSC_COMPLEX_PREFIX
+version = 3.13.3.0
 
 [cray-petsc-complex-64]
 name = PETSc
 prefix = CRAY_PETSC_COMPLEX_64_PREFIX
+version = 3.13.3.0
 
 [cray-python]
 name = Python

--- a/easybuild/cray_external_modules_metadata-20.08.cfg
+++ b/easybuild/cray_external_modules_metadata-20.08.cfg
@@ -31,15 +31,19 @@ prefix = NETCDF_DIR
 
 [cray-petsc]
 name = PETSc
+prefix = PETSC_DIR
 
 [cray-petsc-64]
 name = PETSc
+prefix = PETSC_DIR
 
 [cray-petsc-complex]
 name = PETSc
+prefix = PETSC_DIR
 
 [cray-petsc-complex-64]
 name = PETSc
+prefix = PETSC_DIR
 
 [cray-python]
 name = Python

--- a/easybuild/easyconfigs/s/SLEPc/SLEPc-3.13.4-CrayIntel-20.08-complex.eb
+++ b/easybuild/easyconfigs/s/SLEPc/SLEPc-3.13.4-CrayIntel-20.08-complex.eb
@@ -27,6 +27,8 @@ preconfigopts = 'unset F90FLAGS FFLAGS CXXFLAGS CFLAGS &&'
 
 buildopts = 'SLEPC_DIR=$PWD PETSC_DIR=$PETSC_DIR'
 
+installopts = buildopts 
+
 modextravars = { 'SLEPC_DIR':'$::env(EBROOTSLEPC)'}
 
 parallel = 1

--- a/easybuild/easyconfigs/s/SLEPc/SLEPc-3.13.4-CrayIntel-20.08-complex.eb
+++ b/easybuild/easyconfigs/s/SLEPc/SLEPc-3.13.4-CrayIntel-20.08-complex.eb
@@ -1,0 +1,40 @@
+# @author: gppezzi (CSCS)
+easyblock = 'ConfigureMake'
+
+name = 'SLEPc'
+version = "3.13.4"
+versionsuffix = '-complex'
+
+homepage = 'http://slepc.upv.es/'
+description = """SLEPc (Scalable Library for Eigenvalue Problem Computations) is a software library for the solution of
+ large scale sparse eigenvalue problems on parallel computers. It is an extension of PETSc and can be used for either
+ standard or generalized eigenproblems, with real or complex arithmetic. It can also be used for computing a partial
+ SVD of a large, sparse, rectangular matrix, and to solve quadratic eigenvalue problems."""
+
+toolchain = {'name': 'CrayIntel', 'version': '20.08'}
+#toolchainopts = {'usempi': True}
+
+source_urls = ['http://slepc.upv.es/download/distrib/']
+sources = [SOURCELOWER_TAR_GZ]
+
+dependencies = [
+      ('cray-petsc-complex', EXTERNAL_MODULE),
+      ('cray-tpsl', EXTERNAL_MODULE),
+      ('cray-hdf5-parallel', EXTERNAL_MODULE),
+]
+
+preconfigopts = 'unset F90FLAGS FFLAGS CXXFLAGS CFLAGS &&'
+
+buildopts = 'SLEPC_DIR=$PWD PETSC_DIR=$PETSC_DIR'
+
+modextravars = { 'SLEPC_DIR':'$::env(EBROOTSLEPC)'}
+
+parallel = 1
+
+sanity_check_paths = {
+    'files': ['lib/libslepc.a'],
+    'dirs': [],
+}
+
+moduleclass = 'numlib'
+


### PR DESCRIPTION
EB doesn't find software root with current metadata file. For the discussion I'm proposing here to explicitly use CRAY_PETSC_COMPLEX_PREFIX_DIR as workaround, but @ekouts or @victorusu might have a better solution? Shouldn't this be detected automatically?