### PR TITLE
[daint, dom] ADIOS2 for Parallel IO tutorial

### DIFF
--- a/easybuild/easyconfigs/a/adios/adios-2.6.0-CrayGnu-20.08.eb
+++ b/easybuild/easyconfigs/a/adios/adios-2.6.0-CrayGnu-20.08.eb
@@ -1,0 +1,52 @@
+# contributed by Jean Favre (CSCS)
+
+easyblock = 'CMakeMake'
+
+name = "adios"
+version = '2.6.0'
+
+homepage = 'https://csmd.ornl.gov/software/adios2'
+description = """The Adaptable IO System (ADIOS) provides a simple, flexible way for scientists 
+to describe the data in their code that may need to be written, read, or processed outside of the running simulation"""
+
+toolchain = {'name': 'CrayGNU', 'version': '20.08'}
+toolchainopts = {'usempi': True, 'pic': True}
+
+source_urls = ['https://github.com/ornladios/ADIOS2/archive/']
+sources = ["release_26.zip"]
+
+builddependencies = [
+    ('CMake', '3.14.5', '', True),
+]
+
+configopts  = '-DCMAKE_BUILD_TYPE=Release '
+configopts += "-DCMAKE_Fortran_FLAGS='-O2 -DNDEBUG -fPIC -fno-math-errno ' "
+configopts += "-DCMAKE_C_FLAGS='-DNDEBUG -fPIC -std=c11' "
+configopts += "-DCMAKE_CXX_FLAGS='-O2 -DNDEBUG -fPIC -std=gnu++11 ' "
+#configopts  = '-DCMAKE_BUILD_TYPE=RelWithDebInfo '
+configopts  += '-DBUILD_SHARED_LIBS:BOOL=ON -DADIOS2_BUILD_EXAMPLES:BOOL=OFF -DADIOS2_BUILD_TESTING:BOOL=OFF '
+configopts  += '-DADIOS2_USE_MPI:BOOL=ON '
+configopts  += '-DADIOS2_USE_HDF5:BOOL=ON '
+configopts  += '-DADIOS2_USE_Python:BOOL=ON '
+configopts  += '-DADIOS2_USE_Fortran:BOOL=ON '
+configopts  += '-DADIOS2_USE_BZip2:BOOL=ON '
+configopts  += '-DADIOS2_USE_Blosc:BOOL=ON '
+
+dependencies = [
+    ('pmi', EXTERNAL_MODULE),
+    ('cray-python', EXTERNAL_MODULE),
+    ('cray-hdf5-parallel', EXTERNAL_MODULE),
+    ('bzip2', EXTERNAL_MODULE),
+    ('blosc', '1.20.1'),
+]
+
+parallel = 16
+
+sanity_check_paths = {
+    'files': ['include/adios2.h', 'include/adios2_c.h', 'bin/bpls'  ],
+    'files': ['include/adios2.h', 'include/adios2_c.h', 'bin/bpls',  'lib64/libadios2_core.so', 'lib64/libadios2_core_mpi.so', 'lib64/cmake/adios2/adios2-config.cmake'],
+    'dirs': [".", "lib/python3.8"]
+}
+
+# check other easyconfigs for possible options
+moduleclass = 'base'

--- a/easybuild/easyconfigs/a/adios/adios-2.6.0-CrayGnu-20.08.eb
+++ b/easybuild/easyconfigs/a/adios/adios-2.6.0-CrayGnu-20.08.eb
@@ -36,7 +36,7 @@ dependencies = [
     ('pmi', EXTERNAL_MODULE),
     ('cray-python', EXTERNAL_MODULE),
     ('cray-hdf5-parallel', EXTERNAL_MODULE),
-    ('bzip2', EXTERNAL_MODULE),
+    ('bzip2', '1.0.6'),
     ('blosc', '1.20.1'),
 ]
 

--- a/easybuild/easyconfigs/b/blosc/blosc-1.20.1-CrayGNU-20.08.eb
+++ b/easybuild/easyconfigs/b/blosc/blosc-1.20.1-CrayGNU-20.08.eb
@@ -1,0 +1,34 @@
+# CrayGNU version by Jean Favre (CSCS)
+
+easyblock = 'CMakeMake'
+
+name = 'blosc'
+version = '1.20.1'
+
+homepage = "http://www.blosc.org"
+description = "Blosc is a high performance compressor optimized for binary data."
+
+toolchain = {'name': 'CrayGNU', 'version': '20.08'}
+toolchainopts = {'pic': True, 'usempi': True, 'verbose': False}
+
+source_urls = ['https://github.com/Blosc/c-blosc/archive']
+sources = ["v%(version)s.tar.gz"]
+
+dependencies = []
+
+builddependencies = [('CMake', '3.14.5','', True)]
+
+separate_build_dir = True
+
+maxparallel = 16
+
+configopts =  '-DCMAKE_BUILD_TYPE=Release '
+configopts += '-DBUILD_BENCHMARKS:BOOL=OFF '
+configopts += '-DBUILD_TESTS:BOOL=OFF '
+
+sanity_check_paths = {
+    'files': ['include/blosc.h', 'include/blosc-export.h', 'lib64/libblosc.so'],
+    'dirs': [ 'lib64/pkgconfig' ]
+}
+
+moduleclass = 'vis'


### PR DESCRIPTION
ADIOS2 with MPI, hdf5, Python, Fortran, Bzip2 and Blosc support

== COMPLETED: Installation ended successfully (took 17 sec)
== Results of the build can be found in the log file(s) /scratch/snx3000/jfavre/daint/software/blosc/1.20.1-CrayGNU-20.08/easybuild/easybuild-blosc-1.20.1-20200914.192603.log

== COMPLETED: Installation ended successfully (took 2 min 37 sec)
== Results of the build can be found in the log file(s) /scratch/snx3000/jfavre/daint/software/adios/2.6.0-CrayGNU-20.08/easybuild/easybuild-adios-2.6.0-20200914.193208.log

