### PR TITLE
[daint,dom] jupyterlab-1.2.16-CrayGNU-20.08-batchspawner-cuda.eb

### DIFF
--- a/easybuild/easyconfigs/j/jupyterlab/jupyterlab-1.2.16-CrayGNU-20.08-batchspawner-cuda.eb
+++ b/easybuild/easyconfigs/j/jupyterlab/jupyterlab-1.2.16-CrayGNU-20.08-batchspawner-cuda.eb
@@ -255,6 +255,7 @@ export JUPYTER=%%(installdir)s/bin/jupyter &&   # Needed for IJulia (and maybe o
 %%(installdir)s/bin/jupyter-labextension install jupyterlab-datawidgets@6.3.0 --no-build && 
 %%(installdir)s/bin/jupyter-labextension install itkwidgets@0.25.3 --no-build && 
 %%(installdir)s/bin/jupyter labextension install jupyter-matplotlib@0.4.2 --no-build && 
+%%(installdir)s/bin/jupyter labextension install -y jupyterlab-plotly@1.0.0 --no-build && 
 %%(installdir)s/bin/jupyter labextension install -y plotlywidget@1.0.0 --no-build && 
 %%(installdir)s/bin/jupyter labextension install -y jupyterlab_bokeh@1.0.0 --no-build && 
 %%(installdir)s/bin/jupyter labextension install -y bqplot@0.4.6 --no-build && 

--- a/easybuild/easyconfigs/j/jupyterlab/jupyterlab-1.2.16-CrayGNU-20.08-batchspawner.eb
+++ b/easybuild/easyconfigs/j/jupyterlab/jupyterlab-1.2.16-CrayGNU-20.08-batchspawner.eb
@@ -254,7 +254,7 @@ export JUPYTER=%%(installdir)s/bin/jupyter &&   # Needed for IJulia (and maybe o
 %%(installdir)s/bin/jupyter-labextension install -y @jupyter-widgets/jupyterlab-manager@1.0 --no-build && 
 %%(installdir)s/bin/jupyter-labextension install jupyterlab-datawidgets@6.3.0 --no-build && 
 %%(installdir)s/bin/jupyter-labextension install itkwidgets@0.25.3 --no-build && 
-%%(installdir)s/bin/jupyter labextension install jupyter-matplotlib@0.4.2 --no-build &&
+%%(installdir)s/bin/jupyter labextension install jupyter-matplotlib@0.4.2 --no-build && 
 %%(installdir)s/bin/jupyter labextension install -y jupyterlab-plotly@1.0.0 --no-build && 
 %%(installdir)s/bin/jupyter labextension install -y plotlywidget@1.0.0 --no-build && 
 %%(installdir)s/bin/jupyter labextension install -y jupyterlab_bokeh@1.0.0 --no-build && 

--- a/easybuild/easyconfigs/j/jupyterlab/jupyterlab-1.2.16-CrayGNU-20.08-batchspawner.eb
+++ b/easybuild/easyconfigs/j/jupyterlab/jupyterlab-1.2.16-CrayGNU-20.08-batchspawner.eb
@@ -254,7 +254,8 @@ export JUPYTER=%%(installdir)s/bin/jupyter &&   # Needed for IJulia (and maybe o
 %%(installdir)s/bin/jupyter-labextension install -y @jupyter-widgets/jupyterlab-manager@1.0 --no-build && 
 %%(installdir)s/bin/jupyter-labextension install jupyterlab-datawidgets@6.3.0 --no-build && 
 %%(installdir)s/bin/jupyter-labextension install itkwidgets@0.25.3 --no-build && 
-%%(installdir)s/bin/jupyter labextension install jupyter-matplotlib@0.4.2 --no-build && 
+%%(installdir)s/bin/jupyter labextension install jupyter-matplotlib@0.4.2 --no-build &&
+%%(installdir)s/bin/jupyter labextension install -y jupyterlab-plotly@1.0.0 --no-build && 
 %%(installdir)s/bin/jupyter labextension install -y plotlywidget@1.0.0 --no-build && 
 %%(installdir)s/bin/jupyter labextension install -y jupyterlab_bokeh@1.0.0 --no-build && 
 %%(installdir)s/bin/jupyter labextension install -y bqplot@0.4.6 --no-build && 


### PR DESCRIPTION
This PR adds the plotly labextension, which was missing from this build. The production builds are already fixed by hand, so this PR should be merged, but should not be force installed. 