### PR TITLE
[daint-mc] slepc 3.13.4 with 20.08 + fix for PETSc metadata 

### DIFF
--- a/easybuild/cray_external_modules_metadata-20.08.cfg
+++ b/easybuild/cray_external_modules_metadata-20.08.cfg
@@ -37,9 +37,13 @@ name = PETSc
 
 [cray-petsc-complex]
 name = PETSc
+prefix = CRAY_PETSC_COMPLEX_PREFIX
+version = 3.13.3.0
 
 [cray-petsc-complex-64]
 name = PETSc
+prefix = CRAY_PETSC_COMPLEX_64_PREFIX
+version = 3.13.3.0
 
 [cray-python]
 name = Python

--- a/easybuild/easyconfigs/s/SLEPc/SLEPc-3.13.4-CrayIntel-20.08-complex-mc.eb
+++ b/easybuild/easyconfigs/s/SLEPc/SLEPc-3.13.4-CrayIntel-20.08-complex-mc.eb
@@ -1,0 +1,43 @@
+# @author: gppezzi (CSCS)
+easyblock = 'ConfigureMake'
+
+name = 'SLEPc'
+version = "3.13.4"
+versionsuffix = '-complex'
+
+homepage = 'http://slepc.upv.es/'
+description = """SLEPc (Scalable Library for Eigenvalue Problem Computations) is a software library for the solution of
+ large scale sparse eigenvalue problems on parallel computers. It is an extension of PETSc and can be used for either
+ standard or generalized eigenproblems, with real or complex arithmetic. It can also be used for computing a partial
+ SVD of a large, sparse, rectangular matrix, and to solve quadratic eigenvalue problems."""
+
+toolchain = {'name': 'CrayIntel', 'version': '20.08'}
+#toolchainopts = {'usempi': True}
+
+source_urls = ['http://slepc.upv.es/download/distrib/']
+sources = [SOURCELOWER_TAR_GZ]
+
+dependencies = [
+      ('cray-petsc-complex', EXTERNAL_MODULE),
+      ('cray-tpsl', EXTERNAL_MODULE),
+      ('cray-hdf5-parallel', EXTERNAL_MODULE),
+]
+
+preconfigopts = 'unset F90FLAGS FFLAGS CXXFLAGS CFLAGS &&'
+preconfigopts += 'export PETSC_DIR=$PETSC_DIR/19.1/haswell && '
+
+buildopts = 'SLEPC_DIR=$PWD PETSC_DIR=$PETSC_DIR/19.1/haswell'
+
+installopts = buildopts 
+
+modextravars = { 'SLEPC_DIR':'$::env(EBROOTSLEPC)'}
+
+parallel = 1
+
+sanity_check_paths = {
+    'files': ['lib/libslepc.a'],
+    'dirs': [],
+}
+
+moduleclass = 'numlib'
+


### PR DESCRIPTION
Slepc with workaround due to broken `PETSC_DIR` with `craype-broadwell` + fix for `cray-petsc` metadata