### PR TITLE
[dom daint] Add MATLAB to production lists

### DIFF
--- a/jenkins-builds/7.0.UP02-20.08-daint-gpu
+++ b/jenkins-builds/7.0.UP02-20.08-daint-gpu
@@ -35,6 +35,7 @@
  LAMMPS-03Mar20-CrayGNU-20.08-cuda.eb                   --set-default-module
  Lmod-7.8.2.eb                                          --set-default-module --hidden
  magma-2.4.0-CrayIntel-20.08-cuda.eb                    --set-default-module
+ MATLAB-R2019a.eb                                       --set-default-module
  NAMD-2.13-CrayIntel-20.08-cuda.eb                      --set-default-module
  NCL-6.4.0.eb                                           --set-default-module
  NCO-4.8.1-CrayGNU-20.08.eb                             --set-default-module

--- a/jenkins-builds/7.0.UP02-20.08-daint-mc
+++ b/jenkins-builds/7.0.UP02-20.08-daint-mc
@@ -33,6 +33,7 @@
  jupyterlab-2.0.2-CrayGNU-20.08-batchspawner.eb
  LAMMPS-03Mar20-CrayGNU-20.08.eb                        --set-default-module
  Lmod-7.8.2.eb                                          --set-default-module --hidden
+ MATLAB-R2019a.eb                                       --set-default-module
  NAMD-2.13-CrayIntel-20.08.eb                           --set-default-module
  NCL-6.4.0.eb                                           --set-default-module
  NCO-4.8.1-CrayGNU-20.08.eb                             --set-default-module

--- a/jenkins-builds/7.0.UP02-20.08-dom-gpu
+++ b/jenkins-builds/7.0.UP02-20.08-dom-gpu
@@ -35,6 +35,7 @@
  LAMMPS-03Mar20-CrayGNU-20.08-cuda.eb                   --set-default-module
  Lmod-7.8.2.eb                                          --set-default-module --hidden
  magma-2.4.0-CrayIntel-20.08-cuda.eb                    --set-default-module
+ MATLAB-R2019a.eb                                       --set-default-module
  NAMD-2.13-CrayIntel-20.08-cuda.eb                      --set-default-module
  NCL-6.4.0.eb                                           --set-default-module
  NCO-4.8.1-CrayGNU-20.08.eb                             --set-default-module

--- a/jenkins-builds/7.0.UP02-20.08-dom-mc
+++ b/jenkins-builds/7.0.UP02-20.08-dom-mc
@@ -33,6 +33,7 @@
  jupyterlab-2.0.2-CrayGNU-20.08-batchspawner.eb
  LAMMPS-03Mar20-CrayGNU-20.08.eb                        --set-default-module
  Lmod-7.8.2.eb                                          --set-default-module --hidden
+ MATLAB-R2019a.eb                                       --set-default-module
  NAMD-2.13-CrayIntel-20.08.eb                           --set-default-module
  NCL-6.4.0.eb                                           --set-default-module
  NCO-4.8.1-CrayGNU-20.08.eb                             --set-default-module


### PR DESCRIPTION
MATLAB recipe on `daint-gpu`, `daint-mc`, `dom-gpu` and `dom-mc` production lists (the latter to keep the systems in sync).