### PR TITLE
[daint-gpu] QE-SIRIUS with perftools-lite

### DIFF
--- a/easybuild/easyconfigs/q/QuantumESPRESSO/QuantumESPRESSO-SIRIUS-6.5-rc4-CrayGNU-20.08-cuda-pat.eb
+++ b/easybuild/easyconfigs/q/QuantumESPRESSO/QuantumESPRESSO-SIRIUS-6.5-rc4-CrayGNU-20.08-cuda-pat.eb
@@ -1,0 +1,45 @@
+# created by Anton Kozhevnikov (CSCS)
+# modified by Simon Pintarelli (CSCS)
+easyblock = 'ConfigureMake'
+
+name = 'QuantumESPRESSO-SIRIUS'
+version = '6.5-rc4'
+versionsuffix = '-cuda-pat'
+
+homepage = 'https://github.com/electronic-structure/q-e-sirius/'
+description = " SIRIUS-enabled version of Quantum ESPRESSO "
+
+toolchain = {'name': 'CrayGNU', 'version': '20.08'}
+toolchainopts = {'opt': True, 'usempi': True, 'pic': True, 'verbose': False, 'openmp': True}
+
+sources = ['https://github.com/electronic-structure/q-e-sirius/archive/v%(version)s-sirius.tar.gz']
+
+builddependencies = [
+    ('perftools-lite', EXTERNAL_MODULE)
+]
+
+dependencies = [
+    ('SIRIUS', '6.5.7', '-cuda')
+]
+
+preconfigopts = "module unload perftools-lite && module unload cray-libsci && module load gcc/8.3.0 && module list &&  CC=cc FC=ftn CPP=cpp MPIF90=ftn "
+configopts = " --enable-parallel --with-scalapack "
+
+prebuildopts = 'module unload cray-libsci && module load gcc/8.3.0 && cat make.inc && '
+prebuildopts += 'sed -i -e "s/^DFLAGS\ *=\ *.*/DFLAGS = -cpp -D__MPI -D__SCALAPACK -D__DFTI -I\$\(EBROOTSIRIUS\)\/include\/sirius/" make.inc && '
+prebuildopts += 'sed -i -e "s/^BLAS_LIBS\ *=\ *.*/BLAS_LIBS =/" make.inc && '
+prebuildopts += 'sed -i -e "s/^LAPACK_LIBS\ *=\ *.*/LAPACK_LIBS = -L\$MKLROOT\/lib\/intel64 -lmkl_scalapack_lp64 -lmkl_intel_lp64 -lmkl_gnu_thread -lmkl_core -lmkl_blacs_intelmpi_lp64 -fopenmp/" make.inc && '
+prebuildopts += 'sed -i -e "s/LAPACK_LIBS_SWITCH = internal/LAPACK_LIBS_SWITCH = external/" make.inc && '
+prebuildopts += 'sed -i -e "s/BLAS_LIBS_SWITCH = internal/BLAS_LIBS_SWITCH = external/" make.inc && '
+prebuildopts += 'sed -i -e "s/^LD_LIBS\ *=\ *.*/LD_LIBS = -lsirius -L\$MKLROOT\/lib\/intel64 -lmkl_scalapack_lp64 -lmkl_intel_lp64 -lmkl_gnu_thread -lmkl_core -lmkl_blacs_intelmpi_lp64 -fopenmp/" make.inc && '
+prebuildopts += 'sed -i -e "s/^FFLAGS\ *=\ *.*/FFLAGS = -cpp -march=core-avx2 -O3 -march=haswell -fopenmp -ftree-vectorize -fopt-info -fopt-info-missed -fopt-info-vec -fopt-info-loop /" make.inc && '
+prebuildopts += 'cat make.inc && '
+buildopts = 'pw'
+
+
+sanity_check_paths = {
+    'files': ['bin/pw.x'],
+    'dirs': [''],
+}
+
+moduleclass = 'chem'

--- a/easybuild/easyconfigs/q/QuantumESPRESSO/QuantumESPRESSO-SIRIUS-6.5-rc4-CrayGNU-20.08-cuda-pat.eb
+++ b/easybuild/easyconfigs/q/QuantumESPRESSO/QuantumESPRESSO-SIRIUS-6.5-rc4-CrayGNU-20.08-cuda-pat.eb
@@ -19,7 +19,7 @@ builddependencies = [
 ]
 
 dependencies = [
-    ('SIRIUS', '6.5.7', '-cuda')
+    ('SIRIUS', '6.5.7', '-cuda-pat')
 ]
 
 preconfigopts = "module unload perftools-lite && module unload cray-libsci && module load gcc/8.3.0 && module list &&  CC=cc FC=ftn CPP=cpp MPIF90=ftn "

--- a/easybuild/easyconfigs/s/SIRIUS/SIRIUS-6.5.7-CrayGNU-20.08-cuda-pat.eb
+++ b/easybuild/easyconfigs/s/SIRIUS/SIRIUS-6.5.7-CrayGNU-20.08-cuda-pat.eb
@@ -28,6 +28,7 @@ dependencies = [
     ('spglib', '1.16.0'),
 ]
 
+preconfigopts = ' module unload perftools-lite && ' 
 configopts = "-DUSE_CUDA=1 -DBUILD_TESTS=0 -DUSE_MAGMA=0 -DUSE_MKL=1 -DUSE_SCALAPACK=0 -DUSE_ELPA=0 -DGPU_MODEL='P100' -DSpFFT_DIR=$EBROOTSPFFT/lib64/cmake/SpFFT"
 
 prebuildopts = "module unload cray-libsci && module unload cray-libsci_acc && module load gcc/8.3.0 && module list &&"

--- a/easybuild/easyconfigs/s/SIRIUS/SIRIUS-6.5.7-CrayGNU-20.08-cuda-pat.eb
+++ b/easybuild/easyconfigs/s/SIRIUS/SIRIUS-6.5.7-CrayGNU-20.08-cuda-pat.eb
@@ -1,0 +1,37 @@
+# created by Anton Kozhevnikov (CSCS)
+easyblock = 'CMakeMake'
+
+name = 'SIRIUS'
+version = '6.5.7'
+versionsuffix = '-cuda-pat'
+
+homepage = 'https://electronic-structure.github.io/SIRIUS/'
+description = "Domain specific library for electronic structure calculations."
+
+toolchain = {'name': 'CrayGNU', 'version': '20.08'}
+toolchainopts = {'opt': True, 'usempi': True, 'pic': True, 'verbose': False, 'openmp': True}
+
+source_urls = ['https://github.com/electronic-structure/%(name)s/archive/']
+sources = ['v%(version)s.tar.gz']
+
+builddependencies = [
+    ('CMake', '3.14.5', '', True),
+    ('cudatoolkit', EXTERNAL_MODULE),
+    ('intel/19.1.1.217', EXTERNAL_MODULE),
+    ('perftools-lite', EXTERNAL_MODULE)
+]
+dependencies = [
+    ('cray-hdf5', EXTERNAL_MODULE),
+    ('GSL', '2.5'),
+    ('libxc', '4.3.4'),
+    ('SpFFT', '0.9.10', '-cuda-mkl'),
+    ('spglib', '1.16.0'),
+]
+
+configopts = "-DUSE_CUDA=1 -DBUILD_TESTS=0 -DUSE_MAGMA=0 -DUSE_MKL=1 -DUSE_SCALAPACK=0 -DUSE_ELPA=0 -DGPU_MODEL='P100' -DSpFFT_DIR=$EBROOTSPFFT/lib64/cmake/SpFFT"
+
+prebuildopts = "module unload cray-libsci && module unload cray-libsci_acc && module load gcc/8.3.0 && module list &&"
+
+modextrapaths = {'CPATH': ['include/%(namelower)s']}
+
+moduleclass = 'chem'


### PR DESCRIPTION
I provide the recipe to build the instrumented executable of QE-SIRIUS with the latest SIRIUS release.

The build was successful on the login node with my username on Piz Daint:  
```
== COMPLETED: Installation ended successfully (took 1 min 41 sec)
== Results of the build can be found in the log file(s) /apps/daint/UES/7.0.UP02/craypat/easybuild/software/QuantumESPRESSO-SIRIUS/6.5-rc4-CrayGNU-20.08-cuda-pat/easybuild/easybuild-QuantumESPRESSO-SIRIUS-6.5-rc4-20200922.100748.log
```