### PR TITLE
[daint-gpu] Add latest QuantumESPRESSO release in production as non default

### DIFF
--- a/jenkins-builds/7.0.UP02-20.08-daint-gpu
+++ b/jenkins-builds/7.0.UP02-20.08-daint-gpu
@@ -49,6 +49,7 @@
  PyExtensions-python3-CrayGNU-20.08.eb                  --set-default-module
  Python-bare-3.7.3.eb                                   --hidden
  QuantumESPRESSO-6.5a1-CrayPGI-20.08-cuda.eb            --set-default-module
+ QuantumESPRESSO-6.6a2-CrayPGI-20.08-cuda.eb
  QuantumESPRESSO-SIRIUS-6.5-rc4-CrayGNU-20.08-cuda.eb   --set-default-module
  singularity-3.5.3-daint.eb
  Spark-2.3.1-CrayGNU-20.08-Hadoop-2.7.eb                --set-default-module

--- a/jenkins-builds/7.0.UP02-20.08-daint-mc
+++ b/jenkins-builds/7.0.UP02-20.08-daint-mc
@@ -47,6 +47,7 @@
  PyExtensions-python3-CrayGNU-20.08.eb
  Python-bare-3.7.3.eb                                   --hidden
  QuantumESPRESSO-6.5-CrayIntel-20.08.eb                 --set-default-module
+ QuantumESPRESSO-6.6-CrayIntel-20.08.eb
  singularity-3.5.3-daint.eb
  Spark-2.3.1-CrayGNU-20.08-Hadoop-2.7.eb                --set-default-module
  VASP-6.1.0-CrayIntel-20.08.eb                          --set-default-module

--- a/jenkins-builds/7.0.UP02-20.08-dom-gpu
+++ b/jenkins-builds/7.0.UP02-20.08-dom-gpu
@@ -49,6 +49,7 @@
  PyExtensions-python3-CrayGNU-20.08.eb                  --set-default-module
  Python-bare-3.7.3.eb                                   --hidden
  QuantumESPRESSO-6.5a1-CrayPGI-20.08-cuda.eb            --set-default-module
+ QuantumESPRESSO-6.6a2-CrayPGI-20.08-cuda.eb
  QuantumESPRESSO-SIRIUS-6.5-rc4-CrayGNU-20.08-cuda.eb   --set-default-module
  singularity-3.5.3-daint.eb
  Spark-2.3.1-CrayGNU-20.08-Hadoop-2.7.eb                --set-default-module

--- a/jenkins-builds/7.0.UP02-20.08-dom-mc
+++ b/jenkins-builds/7.0.UP02-20.08-dom-mc
@@ -47,6 +47,7 @@
  PyExtensions-python3-CrayGNU-20.08.eb
  Python-bare-3.7.3.eb                                   --hidden
  QuantumESPRESSO-6.5-CrayIntel-20.08.eb                 --set-default-module
+ QuantumESPRESSO-6.6-CrayIntel-20.08.eb
  singularity-3.5.3-daint.eb
  Spark-2.3.1-CrayGNU-20.08-Hadoop-2.7.eb                --set-default-module
  VASP-6.1.0-CrayIntel-20.08.eb                          --set-default-module


### PR DESCRIPTION
Updating `daint-gpu`, `daint-mc` as well as `dom-gpu` and `dom-mc` to keep Dom in sync with Piz Daint.