### PR TITLE
[dom] Update Cray metadata for CDT 20.09

### DIFF
--- a/easybuild/cray_external_modules_metadata-20.09.cfg
+++ b/easybuild/cray_external_modules_metadata-20.09.cfg
@@ -6,23 +6,18 @@ name = FFTW
 
 [cray-hdf5]
 name = HDF5
-prefix = HDF5_DIR
 
 [cray-hdf5-parallel]
 name = HDF5
-prefix = HDF5_DIR
 
 [cray-libsci]
 name = LibSci
-prefix = CRAY_LIBSCI_PREFIX
 
 [cray-netcdf]
 name = netCDF, netCDF-Fortran
-prefix = NETCDF_DIR
 
 [cray-netcdf-hdf5parallel]
 name = netCDF, netCDF-Fortran
-prefix = NETCDF_DIR
 
 [cray-petsc]
 name = PETSc

--- a/easybuild/cray_external_modules_metadata-20.09.cfg
+++ b/easybuild/cray_external_modules_metadata-20.09.cfg
@@ -64,7 +64,7 @@ prefix = CRAY_CUDATOOLKIT_DIR
 
 [gcc]
 name = GCC
-version = 10.1.0
+version = 9.3.0
 prefix = GCC_PATH
 
 [papi]

--- a/easybuild/cray_external_modules_metadata-20.09.cfg
+++ b/easybuild/cray_external_modules_metadata-20.09.cfg
@@ -6,27 +6,22 @@ name = FFTW
 
 [cray-hdf5]
 name = HDF5
-version = 1.12.0.0
 prefix = HDF5_DIR
 
 [cray-hdf5-parallel]
 name = HDF5
-version = 1.12.0.0
 prefix = HDF5_DIR
 
 [cray-libsci]
 name = LibSci
-version = 20.09.1
 prefix = CRAY_LIBSCI_PREFIX
 
 [cray-netcdf]
 name = netCDF, netCDF-Fortran
-version = 4.7.4.0, 4.7.4.0
 prefix = NETCDF_DIR
 
 [cray-netcdf-hdf5parallel]
 name = netCDF, netCDF-Fortran
-version = 4.7.4.0, 4.7.4.0
 prefix = NETCDF_DIR
 
 [cray-petsc]
@@ -64,7 +59,6 @@ prefix = CRAY_CUDATOOLKIT_DIR
 
 [gcc]
 name = GCC
-version = 9.3.0
 prefix = GCC_PATH
 
 [papi]

--- a/easybuild/cray_external_modules_metadata-20.09.cfg
+++ b/easybuild/cray_external_modules_metadata-20.09.cfg
@@ -1,0 +1,79 @@
+# metadata useful to EasyBuild (hpcugent.github.io/easybuild) for modules provided by Cray on Cray systems
+# authors: Guilherme Peretti-Pezzi (CSCS), Petar Forai (IMP/IMBA), Kenneth Hoste (HPC-UGent), Eirini Koutsaniti (CSCS)
+
+[cray-fftw]
+name = FFTW
+
+[cray-hdf5]
+name = HDF5
+version = 1.12.0.0
+prefix = HDF5_DIR
+
+[cray-hdf5-parallel]
+name = HDF5
+version = 1.12.0.0
+prefix = HDF5_DIR
+
+[cray-libsci]
+name = LibSci
+version = 20.09.1
+prefix = CRAY_LIBSCI_PREFIX
+
+[cray-netcdf]
+name = netCDF, netCDF-Fortran
+version = 4.7.4.0, 4.7.4.0
+prefix = NETCDF_DIR
+
+[cray-netcdf-hdf5parallel]
+name = netCDF, netCDF-Fortran
+version = 4.7.4.0, 4.7.4.0
+prefix = NETCDF_DIR
+
+[cray-petsc]
+name = PETSc
+
+[cray-petsc-64]
+name = PETSc
+
+[cray-petsc-complex]
+name = PETSc
+prefix = CRAY_PETSC_COMPLEX_PREFIX
+version = 3.13.3.0
+
+[cray-petsc-complex-64]
+name = PETSc
+prefix = CRAY_PETSC_COMPLEX_64_PREFIX
+version = 3.13.3.0
+
+[cray-python]
+name = Python
+
+[cray-R]
+name = R
+
+[cray-tpsl]
+name = TPSL
+
+[cray-tpsl-64]
+name = TPSL
+
+[cudatoolkit]
+name = CUDA
+version = 11.0.2_3.33-7.0.2.1_3.1__g1ba0366
+prefix = CRAY_CUDATOOLKIT_DIR
+
+[gcc]
+name = GCC
+version = 10.1.0
+prefix = GCC_PATH
+
+[papi]
+name = PAPI
+
+[pmi]
+name = pmi
+
+[slurm/.default]
+name = slurm
+version = .default
+prefix = SLURMDIR


### PR DESCRIPTION
I provide an updated version of the Cray metadata file with CUDA 11.0 and GCC 9.3.0 supported by Nvidia: please let me know if the versions of Cray modulefiles still need to be hardcoded or if we can use the defaults.