### PR TITLE
[daint-mc dom-mc] Remove oq-engine from production lists 

### DIFF
--- a/jenkins-builds/7.0.UP02-20.08-daint-mc
+++ b/jenkins-builds/7.0.UP02-20.08-daint-mc
@@ -43,7 +43,6 @@
  ncview-2.1.7-CrayGNU-20.08.eb                          --set-default-module
  netcdf-python-1.5.4-CrayGNU-20.08-python3.eb           --set-default-module
  numpy-1.17.2-CrayGNU-20.08.eb                          --set-default-module
- oq-engine-3.9.0-CrayGNU-20.08.eb                       --hidden
  ParaView-5.8.1-CrayGNU-20.08-OSMesa-python3.eb         --set-default-module
  PLUMED-2.5.1-CrayGNU-20.08.eb                          --set-default-module
  PLUMED-2.5.1-CrayIntel-20.08.eb

--- a/jenkins-builds/7.0.UP02-20.08-dom-mc
+++ b/jenkins-builds/7.0.UP02-20.08-dom-mc
@@ -43,7 +43,6 @@
  ncview-2.1.7-CrayGNU-20.08.eb                          --set-default-module
  netcdf-python-1.5.4-CrayGNU-20.08-python3.eb           --set-default-module
  numpy-1.17.2-CrayGNU-20.08.eb                          --set-default-module
- oq-engine-3.9.0-CrayGNU-20.08.eb                       --hidden
  ParaView-5.8.1-CrayGNU-20.08-OSMesa-python3.eb         --set-default-module
  PLUMED-2.5.1-CrayGNU-20.08.eb                          --set-default-module
  PLUMED-2.5.1-CrayIntel-20.08.eb


### PR DESCRIPTION
Remove `oq-engine` from `daint-mc` and `dom-mc` production lists: users can build the application using the easyconfigs provided in the repository. The current installation features a bug in the extension `celery` (see CSCS RT #40274), therefore it will be manually removed from the system as soon as this request is merged.