### PR TITLE
[daint,dom] ipcmagic is back

### DIFF
--- a/easybuild/easyconfigs/j/jupyterlab/jupyterlab-2.0.2-CrayGNU-20.08-batchspawner-cuda.eb
+++ b/easybuild/easyconfigs/j/jupyterlab/jupyterlab-2.0.2-CrayGNU-20.08-batchspawner-cuda.eb
@@ -223,7 +223,7 @@ exts_list = [
     ('ipyparallel', '6.3.0'),
     ('ipcmagic', '4bd1bb3', {
         'source_urls': ['https://github.com/eth-cscs/ipcluster_magic/tarball/%(version)s'],
-        'modulename': '',
+        'modulename': False,
 }),
     
 # kernels

--- a/easybuild/easyconfigs/j/jupyterlab/jupyterlab-2.0.2-CrayGNU-20.08-batchspawner-cuda.eb
+++ b/easybuild/easyconfigs/j/jupyterlab/jupyterlab-2.0.2-CrayGNU-20.08-batchspawner-cuda.eb
@@ -218,6 +218,13 @@ exts_list = [
     ('black', '19.10b0'),
     ('jupyterlab_code_formatter', '1.3.5'), #bumped from 1.1.0 to 1.3.5 
 
+# ipcluster magics
+    ('docopt', '0.6.2'),
+    ('ipyparallel', '6.3.0'),
+    ('ipcmagic', '4bd1bb3', {
+        'source_urls': ['https://github.com/eth-cscs/ipcluster_magic/tarball/%(version)s'],
+}),
+    
 # kernels
 # bash kernel, requires kernel install below, twr
     ('bash_kernel', '0.7.2', {

--- a/easybuild/easyconfigs/j/jupyterlab/jupyterlab-2.0.2-CrayGNU-20.08-batchspawner-cuda.eb
+++ b/easybuild/easyconfigs/j/jupyterlab/jupyterlab-2.0.2-CrayGNU-20.08-batchspawner-cuda.eb
@@ -223,6 +223,7 @@ exts_list = [
     ('ipyparallel', '6.3.0'),
     ('ipcmagic', '4bd1bb3', {
         'source_urls': ['https://github.com/eth-cscs/ipcluster_magic/tarball/%(version)s'],
+        'modulename': '',
 }),
     
 # kernels

--- a/easybuild/easyconfigs/j/jupyterlab/jupyterlab-2.0.2-CrayGNU-20.08-batchspawner.eb
+++ b/easybuild/easyconfigs/j/jupyterlab/jupyterlab-2.0.2-CrayGNU-20.08-batchspawner.eb
@@ -217,6 +217,14 @@ exts_list = [
     ('black', '19.10b0'),
     ('jupyterlab_code_formatter', '1.3.5'), #bumped from 1.1.0 to 1.3.5 
 
+# ipcluster magics
+    ('docopt', '0.6.2'),
+    ('ipyparallel', '6.3.0'),
+    ('ipcmagic', '4bd1bb3', {
+        'source_urls': ['https://github.com/eth-cscs/ipcluster_magic/tarball/%(version)s'],
+        'modulename': False,
+}),
+    
 # kernels
 # bash kernel, requires kernel install below, twr
     ('bash_kernel', '0.7.2', {


### PR DESCRIPTION
Adding ipcmagic and dependencies back into the build. It was too messy with a separate module, and it led to a bug where the use of ipython at the command line failed with: ModuleNotFoundError: No module named 'ipyparallel'. The reason for this was the startup file /apps/daint/UES/jenkins/7.0.UP02/gpu/easybuild/software/IPython/7.7.0-CrayGNU-20.08-python3/startup/01-ipcmagic-cscs.py. So, previously, for this not to fail you needed to load the ipcmagic module in your .jupyterhub.env.
This should fix a bug needed for JF's course next week.