### PR TITLE
[daint-mc] LAMMPS with user-mofff

### DIFF
--- a/easybuild/easyconfigs/l/LAMMPS/LAMMPS-03Mar20-CrayGNU-20.08.eb
+++ b/easybuild/easyconfigs/l/LAMMPS/LAMMPS-03Mar20-CrayGNU-20.08.eb
@@ -18,7 +18,7 @@ builddependencies = [
     ('cray-python', EXTERNAL_MODULE),
 ]
 
-prebuildopts = " cd ./src &&  make yes-standard yes-user-cg-cmm yes-user-omp yes-user-reaxc yes-user-misc &&  make no-latte no-voronoi no-reax no-poems no-meam no-kim no-kokkos no-mscg no-gpu no-message &&  make package-update &&  sed -e 's/mpicxx/CC -fopenmp/' ./MAKE/Makefile.mpi > ./MAKE/Makefile.omp &&  sed -i -e 's/mpicxx/CC/' ./MAKE/Makefile.mpi && "
+prebuildopts = " cd ./src &&  make yes-standard yes-user-cg-cmm yes-user-mofff yes-user-omp yes-user-reaxc yes-user-misc &&  make no-latte no-voronoi no-reax no-poems no-meam no-kim no-kokkos no-mscg no-gpu no-message &&  make package-update &&  sed -e 's/mpicxx/CC -fopenmp/' ./MAKE/Makefile.mpi > ./MAKE/Makefile.omp &&  sed -i -e 's/mpicxx/CC/' ./MAKE/Makefile.mpi && "
 buildopts = [
     " mpi ",
     " omp ",


### PR DESCRIPTION
I'm providing an updated recipe for LAMMPS on the multicore nodes, adding the package `user-mofff`: I have tested the build successfully with the ReFrame checks (small and large production), therefore I don't see conflicts with the current packages provided.