### PR TITLE
[eiger] Updated CDO and metadata with production list for Eiger

### DIFF
--- a/easybuild/cray_external_modules_metadata-20.10.cfg
+++ b/easybuild/cray_external_modules_metadata-20.10.cfg
@@ -15,6 +15,8 @@ name = LibSci
 
 [cray-netcdf]
 name = netCDF, netCDF-Fortran
+prefix = CRAY_NETCDF_DIR
+version = 4.7.4.2, 4.7.4.2
 
 [cray-netcdf-hdf5parallel]
 name = netCDF, netCDF-Fortran

--- a/easybuild/easyconfigs/c/CDO/CDO-1.9.9-cpeGNU-20.10.eb
+++ b/easybuild/easyconfigs/c/CDO/CDO-1.9.9-cpeGNU-20.10.eb
@@ -1,0 +1,39 @@
+# Updated by @gppezzi, @jgphpc, @omlins
+easyblock = 'ConfigureMake'
+
+name = 'CDO'
+version = '1.9.9'
+
+homepage = 'https://code.zmaw.de/projects/cdo'
+description = """
+    CDO is a collection of command line Operators to manipulate and analyse
+    Climate and NWP model Data.
+"""
+
+toolchain = {'name': 'cpeGNU', 'version': '20.10'}
+toolchainopts = {'opt': True, 'pic': True}
+
+# Files visible at https://code.mpimet.mpg.de/projects/cdo/files,
+# however link is different for each version!
+source_urls = ['https://code.mpimet.mpg.de/attachments/download/23323/']
+sources = [SOURCELOWER_TAR_GZ]
+checksums = ['959b5b58f495d521a7fd1daa84644888ec87d6a0df43f22ad950d17aee5ba98d']
+
+dependencies = [
+    ('cray-hdf5', EXTERNAL_MODULE),
+    ('cray-netcdf', EXTERNAL_MODULE),
+    # CDO: OpenMP support for compute intensive operators:
+    # https://code.zmaw.de/projects/cdo/wiki/OpenMP_support
+    # No MPI support
+]
+
+preconfigopts = "export NC_CONFIG=`which nc-config` && "
+configopts = "--with-hdf5=$HDF5_DIR --with-netcdf=$EBROOTNETCDFMINFORTRAN "
+
+
+sanity_check_paths = {
+    'files': ['bin/%(namelower)s'],
+    'dirs': [],
+}
+
+moduleclass = 'data'

--- a/jenkins-builds/1.3.1-20.10-eiger
+++ b/jenkins-builds/1.3.1-20.10-eiger
@@ -1,6 +1,6 @@
  Buildah-1.17.0.eb                                     --set-default-module
- CMake-3.18.4.eb                                       --set-default-module
  CDO-1.9.9-cpeGNU-20.10.eb                             --set-default-module
+ CMake-3.18.4.eb                                       --set-default-module
  GREASY-19.03-cscs-cpeGNU-20.10.eb                     --set-default-module
  GROMACS-2020.3-cpeGNU-20.10.eb                        --set-default-module
  GSL-2.6-cpeCCE-20.10.eb                               --set-default-module

--- a/jenkins-builds/1.3.1-20.10-eiger
+++ b/jenkins-builds/1.3.1-20.10-eiger
@@ -1,5 +1,6 @@
  Buildah-1.17.0.eb                                     --set-default-module
  CMake-3.18.4.eb                                       --set-default-module
+ CDO-1.9.9-cpeGNU-20.10.eb                             --set-default-module
  GREASY-19.03-cscs-cpeGNU-20.10.eb                     --set-default-module
  GROMACS-2020.3-cpeGNU-20.10.eb                        --set-default-module
  GSL-2.6-cpeCCE-20.10.eb                               --set-default-module


### PR DESCRIPTION
I had to insert `prefix` and `version` in the metadata file for the `CDO` dependency `cray-netcdf`, otherwise I was getting an error from the EasyBuild function `get_software_root`.