### PR TITLE
[eiger] Last stable release of LAMMPS

### DIFF
--- a/easybuild/easyconfigs/l/LAMMPS/LAMMPS-29Oct20-cpeGNU-20.10.eb
+++ b/easybuild/easyconfigs/l/LAMMPS/LAMMPS-29Oct20-cpeGNU-20.10.eb
@@ -18,7 +18,7 @@ builddependencies = [
     ('cray-python', EXTERNAL_MODULE)
 ]
 
-prebuildopts = " cd ./src &&  make yes-standard yes-user-mofff yes-user-omp yes-user-reaxc yes-user-misc &&  make no-latte no-voronoi no-poems no-kim no-kokkos no-mscg no-gpu no-message &&  make package-update &&  sed -e 's/mpicxx/CC -fopenmp/' -e 's#^CCFLAGS.*#& -I$(EBROOTPYTHON)/include/python%(pyshortver)s#' ./MAKE/Makefile.mpi > ./MAKE/Makefile.omp &&  sed -i -e 's/mpicxx/CC/' -e 's#^CCFLAGS.*#& -I$(EBROOTPYTHON)/include/python#%(pyshortver)s' ./MAKE/Makefile.mpi && "
+prebuildopts = " cd ./src &&  make yes-standard yes-user-mofff yes-user-omp yes-user-reaxc yes-user-misc &&  make no-latte no-voronoi no-poems no-kim no-kokkos no-mscg no-gpu no-message &&  make package-update &&  sed -e 's/mpicxx/CC -fopenmp/' -e 's#^CCFLAGS.*#& -I$(EBROOTPYTHON)/include/python%(pyshortver)s#' -e 's#^LINKFLAGS.*#& -L$(EBROOTPYTHON)/lib -lpython%(pyshortver)s#' ./MAKE/Makefile.mpi > ./MAKE/Makefile.omp &&  sed -i -e 's/mpicxx/CC/' -e 's#^CCFLAGS.*#& -I$(EBROOTPYTHON)/include/python%(pyshortver)s#' -e 's#^LINKFLAGS.*#& -L$(EBROOTPYTHON)/lib -lpython%(pyshortver)s#' ./MAKE/Makefile.mpi && "
 buildopts = [
     " mpi ",
     " omp ",

--- a/easybuild/easyconfigs/l/LAMMPS/LAMMPS-29Oct20-cpeGNU-20.10.eb
+++ b/easybuild/easyconfigs/l/LAMMPS/LAMMPS-29Oct20-cpeGNU-20.10.eb
@@ -1,0 +1,34 @@
+# Contributed by TWR and Luca Marsella (CSCS)
+easyblock = 'MakeCp'
+
+name = 'LAMMPS'
+version = '29Oct20'
+
+homepage = 'http://lammps.sandia.gov/'
+description = "LAMMPS (Large-scale Atomic/Molecular Massively Parallel Simulator) is a classical molecular dynamics simulation code designed to run efficiently on parallel computers."
+
+toolchain = {'name': 'cpeGNU', 'version': '20.10'}
+toolchainopts = {'usempi': True, 'openmp': True}
+
+source_urls = ['https://github.com/%(namelower)s/%(namelower)s/archive']
+sources = ['stable_29Oct2020.tar.gz']
+
+builddependencies = [
+    ('cray-fftw', EXTERNAL_MODULE),
+    ('cray-python', EXTERNAL_MODULE)
+]
+
+prebuildopts = " cd ./src &&  make yes-standard yes-user-mofff yes-user-omp yes-user-reaxc yes-user-misc &&  make no-latte no-voronoi no-poems no-kim no-kokkos no-mscg no-gpu no-message &&  make package-update &&  sed -e 's/mpicxx/CC -fopenmp/' -e 's#^CCFLAGS.*#& -I$(EBROOTPYTHON)/include/python%(pyshortver)s#' ./MAKE/Makefile.mpi > ./MAKE/Makefile.omp &&  sed -i -e 's/mpicxx/CC/' -e 's#^CCFLAGS.*#& -I$(EBROOTPYTHON)/include/python#%(pyshortver)s' ./MAKE/Makefile.mpi && "
+buildopts = [
+    " mpi ",
+    " omp ",
+]
+
+files_to_copy = [(['src/lmp*'], 'bin')]
+
+sanity_check_paths = {
+    'files': ['bin/lmp_mpi', 'bin/lmp_omp'],
+    'dirs': [],
+}
+
+moduleclass = 'chem'

--- a/jenkins-builds/1.3.1-20.10-eiger
+++ b/jenkins-builds/1.3.1-20.10-eiger
@@ -4,3 +4,4 @@
  GROMACS-2020.3-cpeGNU-20.10.eb                        --set-default-module
  GSL-2.6-cpeCCE-20.10.eb                               --set-default-module
  GSL-2.6-cpeGNU-20.10.eb                               --set-default-module
+ LAMMPS-29Oct20-cpeGNU-20.10.eb                        --set-default-module


### PR DESCRIPTION
I had to add include and library flags for `cray-python`, since the Cray wrappers do not seem to add them to the compile and link lines, when the corresponding module is loaded.

I also had to remove some packages that are no longer available: see https://lammps.sandia.gov/doc/Commands_removed.html