### PR TITLE
[eiger] Update production list 1.3.1-20.10-eiger

### DIFF
--- a/jenkins-builds/1.3.1-20.10-eiger
+++ b/jenkins-builds/1.3.1-20.10-eiger
@@ -8,4 +8,5 @@
  GSL-2.6-cpeCCE-20.10.eb                               --set-default-module
  GSL-2.6-cpeGNU-20.10.eb                               --set-default-module
  LAMMPS-29Oct20-cpeGNU-20.10.eb                        --set-default-module
+ matplotlib-3.3.3-cpeGNU-20.10.eb                      --set-default-module
  NCO-4.9.5-cpeGNU-20.10.eb                             --set-default-module


### PR DESCRIPTION
Add `matplotlib` in production (replaces `PyExtensions`)