### PR TITLE
[dom] Fix netCDF PREFIX

### DIFF
--- a/easybuild/cray_external_modules_metadata-20.10.cfg
+++ b/easybuild/cray_external_modules_metadata-20.10.cfg
@@ -16,7 +16,7 @@ name = LibSci
 
 [cray-netcdf]
 name = netCDF, netCDF-Fortran
-prefix = CRAY_NETCDF_DIR
+prefix = CRAY_NETCDF_PREFIX
 version = 4.7.4.2, 4.7.4.2
 
 [cray-netcdf-hdf5parallel]


### PR DESCRIPTION
The prefix `CRAY_NETCDF_PREFIX` should not be needed on Dom, but it was needed on Eiger.