### PR TITLE
[dom-gpu] Minor changes in UpdateEB

### DIFF
--- a/jenkins/JenkinsfileUpdateEB
+++ b/jenkins/JenkinsfileUpdateEB
@@ -83,9 +83,6 @@ stage('Update Stage') {
                     /* define eb_flags and command to build software */
                     def eb_flags = "--ignore-locks -r"
                     def tc_flags = "--try-toolchain-version=${params.cdt_version}"
-                    //def build_command = architecture == "" ?
-                        //"srun -u -J $env.JOB_BASE_NAME --account=${params.account} -t 06:00:00 eb $eb_flags" :
-                        //"srun -u -C $architecture -J $env.JOB_BASE_NAME --account=${params.account} -t 06:00:00 eb $eb_flags"
                     def build_command = "eb $eb_flags"
                         
                     /* create the new toolchains and build the software stack */
@@ -98,7 +95,6 @@ stage('Update Stage') {
 
                         export EASYBUILD_PREFIX="${params.eb_prefix}/$machineLabel/${params.cdt_version}"
                         export EASYBUILD_TMPDIR="\$EASYBUILD_PREFIX/tmp"
-                        export EASYBUILD_BUILDPATH="/tmp/$env.BUILD_TAG"
                         export EB_CUSTOM_REPOSITORY="$WORKSPACE/easybuild"
 
                         # create symbolic link to EasyBuild-custom/cscs
@@ -174,10 +170,12 @@ stage('Update Stage') {
                                 continue
                             fi
 
-                            echo -e "\nSubmitting job and building..."
+                            echo -e "\nBuilding using the following command:"
                             if [[ \$recipe =~ Cray[a-zA-Z]+-${params.cdt_current} ]]; then
+                                echo "$build_command $tc_flags \$recipe"
                                 $build_command $tc_flags \$recipe
                             else
+                                echo "$build_command \$recipe"
                                 $build_command \$recipe
                             fi
                             status=\$[status+\$?]
@@ -197,8 +195,8 @@ stage('Update Stage') {
 
                         # change permission of tmp folders if failed is not null
                         if [ -n "\$failed" ]; then
-                            chmod -R o+r "\${EASYBUILD_TMPDIR}"
-                            find "\${EASYBUILD_TMPDIR}" -type d -exec chmod o+x '{}' \\;
+                            chmod -R +r "\${EASYBUILD_TMPDIR}"
+                            find "\${EASYBUILD_TMPDIR}" -type d -exec chmod 755 '{}' \\;
                         fi
 
                         # print successful and failed updates

--- a/jenkins/JenkinsfileUpdateEB
+++ b/jenkins/JenkinsfileUpdateEB
@@ -196,7 +196,7 @@ stage('Update Stage') {
                         # change permission of tmp folders if failed is not null
                         if [ -n "\$failed" ]; then
                             chmod -R +r "\${EASYBUILD_TMPDIR}"
-                            find "\${EASYBUILD_TMPDIR}" -type d -exec chmod 755 '{}' \\;
+                            find "\${EASYBUILD_TMPDIR}" -type d -exec chmod +x '{}' \\;
                         fi
 
                         # print successful and failed updates


### PR DESCRIPTION
I have changed `BUILDPATH` to the default one under `$XDG_RUNTIME_DIR` since we use the login node and `/tmp` is not reliable: see my comments in some issues of https://jira.cscs.ch/browse/UES-1240. I have also fixed `TMPDIR` general access.