### PR TITLE
[dom-mc] Update PyExtensions-python3-CrayGNU-20.10.eb

### DIFF
--- a/easybuild/easyconfigs/p/PyExtensions/PyExtensions-python3-CrayGNU-20.10.eb
+++ b/easybuild/easyconfigs/p/PyExtensions/PyExtensions-python3-CrayGNU-20.10.eb
@@ -1,5 +1,5 @@
 # contributed by Luca Marsella (CSCS), Theofilos Manitaras (CSCS)
-
+#edit for profit
 easyblock = 'PythonBundle'
 
 name = 'PyExtensions'


### PR DESCRIPTION
This PR is just a test as it seems PyExtensions 20.10 can no longer be built on Dom. The software was installed on November 6th. What has changed since then? WIP 