### PR TITLE
[dom-gpu] Remove Amber from dom-gpu

### DIFF
--- a/jenkins-builds/7.0.UP02-20.10-dom-gpu
+++ b/jenkins-builds/7.0.UP02-20.10-dom-gpu
@@ -1,4 +1,3 @@
- Amber-20-3-0-CrayIntel-20.10-cuda.eb                   --set-default-module
  Boost-1.70.0-CrayGNU-20.10-python3.eb                  --set-default-module
  Boost-1.70.0-CrayGNU-20.10.eb
  Buildah-1.14.9.eb


### PR DESCRIPTION
Amber GPU fails to build on Dom with CUDA 11 with the error:
```
Error: Unsupported CUDA version 11.0 detected
```