### PR TITLE
[dom-gpu] Remove NAMD 2.13 from dom-gpu

### DIFF
--- a/jenkins-builds/7.0.UP02-20.10-dom-gpu
+++ b/jenkins-builds/7.0.UP02-20.10-dom-gpu
@@ -16,10 +16,7 @@
  HDFView-2.14.eb                                        --set-default-module
  Horovod-0.19.1-CrayGNU-20.10-tf-2.2.0.eb               --set-default-module
  Horovod-0.19.5-CrayGNU-20.10-pt-1.6.0.eb
- HPX-1.4.0-CrayGNU-20.10-cuda.eb                        --set-default-module
- HPX-1.4.0-CrayGNU-20.10-APEX-cuda.eb
- HPX-1.4.0-CrayGNU-20.10-nonetworking-cuda.eb
- HPX-1.5.0-CrayGNU-20.10-cuda.eb
+ HPX-1.5.0-CrayGNU-20.10-cuda.eb                        --set-default-module
  HPX-1.5.0-CrayGNU-20.10-APEX-cuda.eb
  HPX-1.5.0-CrayGNU-20.10-nonetworking-cuda.eb
  hub-2.14.2.eb                                          --set-default-module
@@ -53,8 +50,7 @@
  pycuda-2018.1.1-CrayGNU-20.10-python3-cuda.eb          --set-default-module
  PyExtensions-python3-CrayGNU-20.10.eb                  --set-default-module
  Python-bare-3.7.3.eb                                   --hidden
- QuantumESPRESSO-6.5a1-CrayPGI-20.10-cuda.eb            --set-default-module
- QuantumESPRESSO-6.6a2-CrayPGI-20.10-cuda.eb
+ QuantumESPRESSO-6.6a2-CrayPGI-20.10-cuda.eb            --set-default-module
  QuantumESPRESSO-SIRIUS-6.5-rc4-CrayGNU-20.10-cuda.eb   --set-default-module
  singularity-3.6.4-daint.eb
  Spark-2.3.1-CrayGNU-20.10-Hadoop-2.7.eb                --set-default-module

--- a/jenkins-builds/7.0.UP02-20.10-dom-gpu
+++ b/jenkins-builds/7.0.UP02-20.10-dom-gpu
@@ -38,8 +38,7 @@
  Lmod-7.8.2.eb                                          --set-default-module --hidden
  magma-2.4.0-CrayIntel-20.10-cuda.eb                    --set-default-module
  MATLAB-R2019a.eb                                       --set-default-module
- NAMD-2.13-CrayIntel-20.10-cuda.eb                      --set-default-module
- NAMD-2.14-CrayIntel-20.10-cuda.eb
+ NAMD-2.14-CrayIntel-20.10-cuda.eb                      --set-default-module
  NCL-6.4.0.eb                                           --set-default-module
  NCO-4.8.1-CrayGNU-20.10.eb                             --set-default-module
  ncview-2.1.7-CrayGNU-20.10.eb                          --set-default-module


### PR DESCRIPTION
Remove older NAMD release from the updated GPU production list on Dom. 