### PR TITLE
[dom-gpu] Remove magma-2.4.0 from dom-gpu production list

### DIFF
--- a/jenkins-builds/7.0.UP02-20.10-dom-gpu
+++ b/jenkins-builds/7.0.UP02-20.10-dom-gpu
@@ -33,7 +33,6 @@
  jupyter-utils-0.1.eb                                   --set-default-module
  LAMMPS-03Mar20-CrayGNU-20.10-cuda.eb                   --set-default-module
  Lmod-7.8.2.eb                                          --set-default-module --hidden
- magma-2.4.0-CrayIntel-20.10-cuda.eb                    --set-default-module
  MATLAB-R2019a.eb                                       --set-default-module
  NAMD-2.14-CrayIntel-20.10-cuda.eb                      --set-default-module
  NCL-6.4.0.eb                                           --set-default-module


### PR DESCRIPTION
For Cuda 11 support, magma has to be upgraded to version 2.5.4: see https://jira.cscs.ch/browse/UES-1318.