### PR TITLE
[dom] create LAMMPS-29Oct20-CrayGNU-20.10.eb

### DIFF
--- a/easybuild/easyconfigs/l/LAMMPS/LAMMPS-29Oct20-CrayGNU-20.10-cuda.eb
+++ b/easybuild/easyconfigs/l/LAMMPS/LAMMPS-29Oct20-CrayGNU-20.10-cuda.eb
@@ -1,0 +1,36 @@
+# Contributed by TWR (CSCS)
+easyblock = 'MakeCp'
+
+name = 'LAMMPS'
+version = '29Oct20'
+versionsuffix = '-cuda'
+
+homepage = 'http://lammps.sandia.gov/'
+description = "LAMMPS (Large-scale Atomic/Molecular Massively Parallel Simulator) is a classical molecular dynamics simulation code designed to run efficiently on parallel computers."
+
+toolchain = {'name': 'CrayGNU', 'version': '20.10'}
+toolchainopts = {'usempi': True, 'openmp': True}
+
+source_urls = ['https://github.com/%(namelower)s/%(namelower)s/archive']
+sources = ['stable_29Oct2020.tar.gz']
+
+builddependencies = [
+    ('cudatoolkit', EXTERNAL_MODULE),
+    ('cray-fftw', EXTERNAL_MODULE),
+    ('cray-python', EXTERNAL_MODULE),
+]
+
+prebuildopts = """ cd ./src &&  make yes-standard yes-user-cg-cmm yes-user-mofff yes-user-omp yes-user-reaxc yes-gpu yes-k-space yes-molecule yes-mpiio yes-rigid yes-misc yes-user-misc  &&  make no-latte no-voronoi no-poems no-kim no-kokkos no-mscg no-message &&  make package-update &&  pushd ../lib/gpu && sed -e "s/-march=bdver1//g" -e "s/sm_[0-9]*/sm_60/g" Makefile.xk7 > Makefile.gpu &&  make -f Makefile.gpu && popd &&  sed -e 's/mpicxx/CC -fopenmp/' ./MAKE/Makefile.mpi > ./MAKE/Makefile.omp &&  sed -i -e 's/mpicxx/CC/' ./MAKE/Makefile.mpi && """
+buildopts = [
+    " mpi ",
+    " omp ",
+]
+
+files_to_copy = [(['src/lmp*'], 'bin')]
+
+sanity_check_paths = {
+    'files': ['bin/lmp_mpi', 'bin/lmp_omp'],
+    'dirs': [],
+}
+
+moduleclass = 'chem'

--- a/easybuild/easyconfigs/l/LAMMPS/LAMMPS-29Oct20-CrayGNU-20.10-cuda.eb
+++ b/easybuild/easyconfigs/l/LAMMPS/LAMMPS-29Oct20-CrayGNU-20.10-cuda.eb
@@ -20,7 +20,7 @@ builddependencies = [
     ('cray-python', EXTERNAL_MODULE),
 ]
 
-prebuildopts = """ cd ./src &&  make yes-standard yes-user-mofff yes-user-omp yes-user-reaxc yes-gpu yes-k-space yes-molecule yes-mpiio yes-rigid yes-misc yes-user-misc  &&  make no-latte no-voronoi no-poems no-kim no-kokkos no-mscg no-message &&  make package-update &&  pushd ../lib/gpu && sed -e "s/-march=bdver1//g" -e "s/sm_[0-9]*/sm_60/g" Makefile.xk7 > Makefile.gpu &&  make -f Makefile.gpu && popd &&  sed -e 's/mpicxx/CC -fopenmp/' ./MAKE/Makefile.mpi > ./MAKE/Makefile.omp &&  sed -i -e 's/mpicxx/CC/' ./MAKE/Makefile.mpi && """
+prebuildopts = """ cd ./src &&  make yes-standard yes-user-mofff yes-user-omp yes-user-reaxc yes-gpu yes-molecule yes-mpiio yes-rigid yes-misc yes-user-misc  &&  make no-latte no-voronoi no-poems no-kim no-kokkos no-mscg no-message &&  make package-update &&  pushd ../lib/gpu && sed -e "s/-march=bdver1//g" -e "s/sm_[0-9]*/sm_60/g" Makefile.xk7 > Makefile.gpu &&  make -f Makefile.gpu && popd &&  sed -e 's/mpicxx/CC -fopenmp/' ./MAKE/Makefile.mpi > ./MAKE/Makefile.omp &&  sed -i -e 's/mpicxx/CC/' ./MAKE/Makefile.mpi && """
 buildopts = [
     " mpi ",
     " omp ",

--- a/easybuild/easyconfigs/l/LAMMPS/LAMMPS-29Oct20-CrayGNU-20.10-cuda.eb
+++ b/easybuild/easyconfigs/l/LAMMPS/LAMMPS-29Oct20-CrayGNU-20.10-cuda.eb
@@ -20,7 +20,7 @@ builddependencies = [
     ('cray-python', EXTERNAL_MODULE),
 ]
 
-prebuildopts = """ cd ./src &&  make yes-standard yes-user-cg-cmm yes-user-mofff yes-user-omp yes-user-reaxc yes-gpu yes-k-space yes-molecule yes-mpiio yes-rigid yes-misc yes-user-misc  &&  make no-latte no-voronoi no-poems no-kim no-kokkos no-mscg no-message &&  make package-update &&  pushd ../lib/gpu && sed -e "s/-march=bdver1//g" -e "s/sm_[0-9]*/sm_60/g" Makefile.xk7 > Makefile.gpu &&  make -f Makefile.gpu && popd &&  sed -e 's/mpicxx/CC -fopenmp/' ./MAKE/Makefile.mpi > ./MAKE/Makefile.omp &&  sed -i -e 's/mpicxx/CC/' ./MAKE/Makefile.mpi && """
+prebuildopts = """ cd ./src &&  make yes-standard yes-user-mofff yes-user-omp yes-user-reaxc yes-gpu yes-k-space yes-molecule yes-mpiio yes-rigid yes-misc yes-user-misc  &&  make no-latte no-voronoi no-poems no-kim no-kokkos no-mscg no-message &&  make package-update &&  pushd ../lib/gpu && sed -e "s/-march=bdver1//g" -e "s/sm_[0-9]*/sm_60/g" Makefile.xk7 > Makefile.gpu &&  make -f Makefile.gpu && popd &&  sed -e 's/mpicxx/CC -fopenmp/' ./MAKE/Makefile.mpi > ./MAKE/Makefile.omp &&  sed -i -e 's/mpicxx/CC/' ./MAKE/Makefile.mpi && """
 buildopts = [
     " mpi ",
     " omp ",

--- a/easybuild/easyconfigs/l/LAMMPS/LAMMPS-29Oct20-CrayGNU-20.10.eb
+++ b/easybuild/easyconfigs/l/LAMMPS/LAMMPS-29Oct20-CrayGNU-20.10.eb
@@ -18,7 +18,7 @@ builddependencies = [
     ('cray-python', EXTERNAL_MODULE),
 ]
 
-prebuildopts = " cd ./src &&  make yes-standard yes-user-mofff yes-user-omp yes-user-reaxc yes-user-misc &&  make no-latte no-voronoi no-reax no-poems no-meam no-kim no-kokkos no-mscg no-gpu no-message &&  make package-update &&  sed -e 's/mpicxx/CC -fopenmp/' ./MAKE/Makefile.mpi > ./MAKE/Makefile.omp &&  sed -i -e 's/mpicxx/CC/' ./MAKE/Makefile.mpi && "
+prebuildopts = " cd ./src &&  make yes-standard yes-user-mofff yes-user-omp yes-user-reaxc yes-user-misc &&  make no-latte no-voronoi no-poems no-meam no-kim no-kokkos no-mscg no-gpu no-message &&  make package-update &&  sed -e 's/mpicxx/CC -fopenmp/' ./MAKE/Makefile.mpi > ./MAKE/Makefile.omp &&  sed -i -e 's/mpicxx/CC/' ./MAKE/Makefile.mpi && "
 buildopts = [
     " mpi ",
     " omp ",

--- a/easybuild/easyconfigs/l/LAMMPS/LAMMPS-29Oct20-CrayGNU-20.10.eb
+++ b/easybuild/easyconfigs/l/LAMMPS/LAMMPS-29Oct20-CrayGNU-20.10.eb
@@ -1,0 +1,34 @@
+# Contributed by TWR (CSCS)
+easyblock = 'MakeCp'
+
+name = 'LAMMPS'
+version = '29Oct20'
+
+homepage = 'http://lammps.sandia.gov/'
+description = "LAMMPS (Large-scale Atomic/Molecular Massively Parallel Simulator) is a classical molecular dynamics simulation code designed to run efficiently on parallel computers."
+
+toolchain = {'name': 'CrayGNU', 'version': '20.10'}
+toolchainopts = {'usempi': True, 'openmp': True}
+
+source_urls = ['https://github.com/%(namelower)s/%(namelower)s/archive']
+sources = ['stable_29Oct2020.tar.gz']
+
+builddependencies = [
+    ('cray-fftw', EXTERNAL_MODULE),
+    ('cray-python', EXTERNAL_MODULE),
+]
+
+prebuildopts = " cd ./src &&  make yes-standard yes-user-cg-cmm yes-user-mofff yes-user-omp yes-user-reaxc yes-user-misc &&  make no-latte no-voronoi no-reax no-poems no-meam no-kim no-kokkos no-mscg no-gpu no-message &&  make package-update &&  sed -e 's/mpicxx/CC -fopenmp/' ./MAKE/Makefile.mpi > ./MAKE/Makefile.omp &&  sed -i -e 's/mpicxx/CC/' ./MAKE/Makefile.mpi && "
+buildopts = [
+    " mpi ",
+    " omp ",
+]
+
+files_to_copy = [(['src/lmp*'], 'bin')]
+
+sanity_check_paths = {
+    'files': ['bin/lmp_mpi', 'bin/lmp_omp'],
+    'dirs': [],
+}
+
+moduleclass = 'chem'

--- a/easybuild/easyconfigs/l/LAMMPS/LAMMPS-29Oct20-CrayGNU-20.10.eb
+++ b/easybuild/easyconfigs/l/LAMMPS/LAMMPS-29Oct20-CrayGNU-20.10.eb
@@ -18,7 +18,7 @@ builddependencies = [
     ('cray-python', EXTERNAL_MODULE),
 ]
 
-prebuildopts = " cd ./src &&  make yes-standard yes-user-mofff yes-user-omp yes-user-reaxc yes-user-misc &&  make no-latte no-voronoi no-poems no-meam no-kim no-kokkos no-mscg no-gpu no-message &&  make package-update &&  sed -e 's/mpicxx/CC -fopenmp/' ./MAKE/Makefile.mpi > ./MAKE/Makefile.omp &&  sed -i -e 's/mpicxx/CC/' ./MAKE/Makefile.mpi && "
+prebuildopts = " cd ./src &&  make yes-standard yes-user-mofff yes-user-omp yes-user-reaxc yes-user-misc &&  make no-latte no-voronoi no-poems no-kim no-kokkos no-mscg no-gpu no-message &&  make package-update &&  sed -e 's/mpicxx/CC -fopenmp/' ./MAKE/Makefile.mpi > ./MAKE/Makefile.omp &&  sed -i -e 's/mpicxx/CC/' ./MAKE/Makefile.mpi && "
 buildopts = [
     " mpi ",
     " omp ",

--- a/easybuild/easyconfigs/l/LAMMPS/LAMMPS-29Oct20-CrayGNU-20.10.eb
+++ b/easybuild/easyconfigs/l/LAMMPS/LAMMPS-29Oct20-CrayGNU-20.10.eb
@@ -18,7 +18,7 @@ builddependencies = [
     ('cray-python', EXTERNAL_MODULE),
 ]
 
-prebuildopts = " cd ./src &&  make yes-standard yes-user-cg-cmm yes-user-mofff yes-user-omp yes-user-reaxc yes-user-misc &&  make no-latte no-voronoi no-reax no-poems no-meam no-kim no-kokkos no-mscg no-gpu no-message &&  make package-update &&  sed -e 's/mpicxx/CC -fopenmp/' ./MAKE/Makefile.mpi > ./MAKE/Makefile.omp &&  sed -i -e 's/mpicxx/CC/' ./MAKE/Makefile.mpi && "
+prebuildopts = " cd ./src &&  make yes-standard yes-user-mofff yes-user-omp yes-user-reaxc yes-user-misc &&  make no-latte no-voronoi no-reax no-poems no-meam no-kim no-kokkos no-mscg no-gpu no-message &&  make package-update &&  sed -e 's/mpicxx/CC -fopenmp/' ./MAKE/Makefile.mpi > ./MAKE/Makefile.omp &&  sed -i -e 's/mpicxx/CC/' ./MAKE/Makefile.mpi && "
 buildopts = [
     " mpi ",
     " omp ",

--- a/jenkins-builds/7.0.UP02-20.10-dom-gpu
+++ b/jenkins-builds/7.0.UP02-20.10-dom-gpu
@@ -31,7 +31,7 @@
  jupyterlab-1.2.16-CrayGNU-20.10-batchspawner-cuda.eb
  jupyterlab-2.0.2-CrayGNU-20.10-batchspawner-cuda.eb
  jupyter-utils-0.1.eb                                   --set-default-module
- LAMMPS-03Mar20-CrayGNU-20.10-cuda.eb                   --set-default-module
+ LAMMPS-29Oct20-CrayGNU-20.10-cuda.eb                   --set-default-module
  Lmod-7.8.2.eb                                          --set-default-module --hidden
  magma-2.5.4-CrayIntel-20.10-cuda.eb                    --set-default-module
  MATLAB-R2019a.eb                                       --set-default-module

--- a/jenkins-builds/7.0.UP02-20.10-dom-mc
+++ b/jenkins-builds/7.0.UP02-20.10-dom-mc
@@ -34,7 +34,7 @@
  jupyterlab-1.1.1-CrayGNU-20.10-batchspawner.eb         --set-default-module
  jupyterlab-1.2.16-CrayGNU-20.10-batchspawner.eb
  jupyterlab-2.0.2-CrayGNU-20.10-batchspawner.eb
- LAMMPS-03Mar20-CrayGNU-20.10.eb                        --set-default-module
+ LAMMPS-29Oct20-CrayGNU-20.10.eb                        --set-default-module
  Lmod-7.8.2.eb                                          --set-default-module --hidden
  MATLAB-R2019a.eb                                       --set-default-module
  NAMD-2.13-CrayIntel-20.10.eb                           --set-default-module


### PR DESCRIPTION
Add LAMMPS 29 October 2020 version, as the March version could not compile with OpenMP and GCC 9+. A couple of pacakges have been removed from "core" so packages options have been changed slightly (as was done for Eiger). i did not modify the Python stuff - @lucamar if this is needed for forwards compatibility please let me know. Otherwise I think this is ready to just be merged. 