### PR TITLE
[dom-gpu] to compile for NVIDIA Pascal, -arch=sm_60 is better suited and passes…

### DIFF
--- a/easybuild/easyconfigs/o/OptiX/OptiX-6.5.0-CrayGNU-20.10.eb
+++ b/easybuild/easyconfigs/o/OptiX/OptiX-6.5.0-CrayGNU-20.10.eb
@@ -1,0 +1,22 @@
+# contributed by Jean Favre (CSCS)
+easyblock = "Tarball"
+
+name = 'OptiX'
+version = '6.5.0'
+
+homepage = 'https://developer.nvidia.com/optix'
+description = """A software development kit for achieving high performance ray tracing on the GPU"""
+
+toolchain = {'name': 'CrayGNU', 'version': '20.10'}
+
+# NVIDIA OptiX is behind a secure wall and one needs credentials to access it. I downloaded the package to
+# my desktop, re-tarred it, and placed it in /apps/common/UES/easybuild/sources/o/OptiX
+
+sources = ['/apps/common/UES/easybuild/sources/%(nameletterlower)s/%(name)s/' + SOURCE_TAR_GZ]
+
+sanity_check_paths={
+    'files': [],
+    'dirs': ['include', 'lib64']
+}
+
+moduleclass = 'devel'

--- a/easybuild/easyconfigs/v/VisRTX/VisRTX-0.1.6-CrayGNU-20.10-cuda.eb
+++ b/easybuild/easyconfigs/v/VisRTX/VisRTX-0.1.6-CrayGNU-20.10-cuda.eb
@@ -23,7 +23,6 @@ dependencies = [
 ]
 
 preconfigopts = ' sed -i "s/sm_30/sm_60/g" %(builddir)s/%(name)s-%(version)s/CMakeLists.txt && '
-prebuildopts = " module switch gcc/9.3.0; "
 
 configopts = "-DCMAKE_BUILD_TYPE=Release -DMDL_INSTALL_DIR=$EBROOTMDL -DOptiX_INSTALL_DIR=$EBROOTOPTIX -DVISRTX_BUILD_SAMPLE:BOOL=OFF  "
 

--- a/easybuild/easyconfigs/v/VisRTX/VisRTX-0.1.6-CrayGNU-20.10-cuda.eb
+++ b/easybuild/easyconfigs/v/VisRTX/VisRTX-0.1.6-CrayGNU-20.10-cuda.eb
@@ -18,11 +18,14 @@ builddependencies = [
     ('cudatoolkit', EXTERNAL_MODULE),
 ]
 dependencies = [
-    ('OptiX', '6.0.0'),
+    ('OptiX', '6.5.0'),
     ('mdl', '317500.2554'),
 ]
 
-configopts = "-DCMAKE_BUILD_TYPE=RelWithDebInfo  -DCMAKE_BUILD_TYPE=Release -DMDL_INSTALL_DIR=$EBROOTMDL -DOptiX_INSTALL_DIR=$EBROOTOPTIX -DVISRTX_BUILD_SAMPLE:BOOL=OFF  "
+preconfigopts = ' sed -i "s/sm_30/sm_60/g" %(builddir)s/%(name)s-%(version)s/CMakeLists.txt && '
+prebuildopts = " module switch gcc/9.3.0; "
+
+configopts = "-DCMAKE_BUILD_TYPE=Release -DMDL_INSTALL_DIR=$EBROOTMDL -DOptiX_INSTALL_DIR=$EBROOTOPTIX -DVISRTX_BUILD_SAMPLE:BOOL=OFF  "
 
 
 sanity_check_paths = {


### PR DESCRIPTION
… the CUDA-11 test

the correct sed command is issued but I don't understand why the module switch of gcc is not done by cdt-cuda automatically. So compilation fails so far.