### PR TITLE
[dom] Cray external metadata file for PE 20.11 on Dom

### DIFF
--- a/easybuild/cray_external_modules_metadata-20.11.cfg
+++ b/easybuild/cray_external_modules_metadata-20.11.cfg
@@ -1,0 +1,75 @@
+# metadata useful to EasyBuild (hpcugent.github.io/easybuild) for modules provided by Cray on Cray systems
+# authors: Guilherme Peretti-Pezzi (CSCS), Petar Forai (IMP/IMBA), Kenneth Hoste (HPC-UGent), Eirini Koutsaniti (CSCS)
+
+[cray-fftw]
+name = FFTW
+prefix = FFTW_DIR/..
+
+[cray-hdf5]
+name = HDF5
+prefix = CRAY_HDF5_PREFIX
+version = 1.12.0.0
+
+[cray-hdf5-parallel]
+name = HDF5
+
+[cray-libsci]
+name = LibSci
+
+[cray-netcdf]
+name = netCDF, netCDF-Fortran
+prefix = CRAY_NETCDF_PREFIX
+version = 4.7.4.0, 4.7.4.0
+
+[cray-netcdf-hdf5parallel]
+name = netCDF, netCDF-Fortran
+
+[cray-petsc]
+name = PETSc
+
+[cray-petsc-64]
+name = PETSc
+
+[cray-petsc-complex]
+name = PETSc
+prefix = CRAY_PETSC_COMPLEX_PREFIX
+version = 3.13.3.0
+
+[cray-petsc-complex-64]
+name = PETSc
+prefix = CRAY_PETSC_COMPLEX_64_PREFIX
+version = 3.13.3.0
+
+[cray-python]
+name = Python
+prefix = CRAY_PYTHON_PREFIX
+version = 3.8.5.0
+
+[cray-R]
+name = R
+
+[cray-tpsl]
+name = TPSL
+
+[cray-tpsl-64]
+name = TPSL
+
+[cudatoolkit]
+name = CUDA
+version = 11.0.2_3.33-7.0.2.1_3.1__g1ba0366
+prefix = CRAY_CUDATOOLKIT_DIR
+
+[gcc]
+name = GCC
+prefix = GCC_PATH
+
+[papi]
+name = PAPI
+
+[pmi]
+name = pmi
+
+[slurm/.default]
+name = slurm
+version = .default
+prefix = SLURMDIR


### PR DESCRIPTION
I provide the initial metadata file for Cray PE 20.11 on Dom.