### PR TITLE
[dom-gpu] Fix ELPA cuda download

### DIFF
--- a/easybuild/easyconfigs/e/ELPA/ELPA-2019.11.001-CrayGNU-20.10-cuda.eb
+++ b/easybuild/easyconfigs/e/ELPA/ELPA-2019.11.001-CrayGNU-20.10-cuda.eb
@@ -11,8 +11,8 @@ description = "Eigenvalue SoLvers for Petaflop-Applications ."
 toolchain = {'name': 'CrayGNU', 'version': '20.10'}
 toolchainopts = {'usempi': True, 'openmp': True}
 
-source_urls = ['http://%(namelower)s.mpcdf.mpg.de/html/Releases/%(version)s/']
-sources = [SOURCELOWER_TAR_GZ]
+# download from http://%(namelower)s.mpcdf.mpg.de/html/Releases/%(version)s often fails
+sources = ['/apps/common/UES/easybuild/sources/%(nameletterlower)s/%(name)s/' + SOURCELOWER_TAR_GZ]
 
 builddependencies = [
     ('cudatoolkit', EXTERNAL_MODULE),


### PR DESCRIPTION
Download from ELPA web server is often unreliable, use local downloaded file instead (see https://jira.cscs.ch/browse/UES-1364).