### PR TITLE
[dom-mc] Fix ELPA download (multicore)

### DIFF
--- a/easybuild/easyconfigs/e/ELPA/ELPA-2019.11.001-CrayGNU-20.10.eb
+++ b/easybuild/easyconfigs/e/ELPA/ELPA-2019.11.001-CrayGNU-20.10.eb
@@ -10,13 +10,12 @@ description = "Eigenvalue SoLvers for Petaflop-Applications ."
 toolchain = {'name': 'CrayGNU', 'version': '20.10'}
 toolchainopts = {'usempi': True, 'openmp': True}
 
-source_urls = ['http://%(namelower)s.mpcdf.mpg.de/html/Releases/%(version)s/']
-sources = [SOURCELOWER_TAR_GZ]
+# download from http://%(namelower)s.mpcdf.mpg.de/html/Releases/%(version)s often fails
+sources = ['/apps/common/UES/easybuild/sources/%(nameletterlower)s/%(name)s/' + SOURCELOWER_TAR_GZ]
 
 configopts = "--disable-avx512 --enable-openmp --enable-static"
 
 prebuildopts = " make clean && "
-
 
 sanity_check_paths = {
     'files': ['lib/libelpa_openmp.a', 'lib/libelpa_openmp.so'],


### PR DESCRIPTION
Download from ELPA web server is often unreliable, use local downloaded file instead (see https://jira.cscs.ch/browse/UES-1365).