### PR TITLE
[dom] Fix UDUNITS 2.2.26 download

### DIFF
--- a/easybuild/easyconfigs/u/UDUNITS/UDUNITS-2.2.26.eb
+++ b/easybuild/easyconfigs/u/UDUNITS/UDUNITS-2.2.26.eb
@@ -1,4 +1,4 @@
-# jgp@cscs
+# Contributed by Jean-Guillaume Piccinali and Luca Marsella (CSCS)
 easyblock = 'ConfigureMake'
 
 name = 'UDUNITS'
@@ -11,8 +11,8 @@ description = """UDUNITS supports conversion of unit specifications between form
 toolchain = SYSTEM
 toolchainopts = {'opt': True, 'pic': True}
 
-source_urls = ['ftp://ftp.unidata.ucar.edu/pub/udunits']
-sources = [SOURCELOWER_TAR_GZ]
+# Version 2.2.26 is no longer available for download from ftp://ftp.unidata.ucar.edu/pub/udunits
+sources = ['/apps/common/UES/easybuild/sources/%(nameletterlower)s/%(name)s/' + SOURCELOWER_TAR_GZ]
 
 dependencies = [('expat', '2.2.5')]
 


### PR DESCRIPTION
The tarball of version 2.2.26 is no longer available for download from the FTP server: see https://jira.cscs.ch/browse/UES-13[66-69].