### PR TITLE
[daint] Add CP2K 8.1 in production

### DIFF
--- a/jenkins-builds/7.0.UP02-20.08-daint-gpu
+++ b/jenkins-builds/7.0.UP02-20.08-daint-gpu
@@ -6,6 +6,7 @@
  CDO-1.9.5-CrayIntel-20.08.eb
  CMake-3.14.5.eb                                        --set-default-module
  CP2K-7.1-CrayGNU-20.08-cuda.eb                         --set-default-module
+ CP2K-8.1-CrayGNU-20.08-cuda.eb
  CPMD-4.1-CrayIntel-20.08.eb                            --set-default-module
  CPMD-4.3-CrayIntel-20.08-cuda.eb
  FFmpeg-4.2.2-CrayGNU-20.08.eb                          --set-default-module

--- a/jenkins-builds/7.0.UP02-20.08-daint-mc
+++ b/jenkins-builds/7.0.UP02-20.08-daint-mc
@@ -6,6 +6,7 @@
  CDO-1.9.5-CrayIntel-20.08.eb
  CMake-3.14.5.eb                                        --set-default-module
  CP2K-7.1-CrayGNU-20.08.eb                              --set-default-module
+ CP2K-8.1-CrayGNU-20.08.eb
  CPMD-4.1-CrayIntel-20.08.eb                            --set-default-module
  CPMD-4.3-CrayIntel-20.08.eb
  dask-2.2.0-CrayGNU-20.08-python3.eb                    --set-default-module


### PR DESCRIPTION
I have added the recipes of the latest CP2K stable release 8.1 in the production lists on Piz Daint.