### PR TITLE
[daint] Add Julia 1.5.3 and improve Julia admin path handling

### DIFF
--- a/easybuild/easyblocks/julia.py
+++ b/easybuild/easyblocks/julia.py
@@ -160,7 +160,7 @@ if !( isempty(LOAD_PATH) || isempty(DEPOT_PATH) || (length(LOAD_PATH)==1 && LOAD
     user_load_path = []
     std_load_path = []
     while !isempty(LOAD_PATH)
-        entry = pop!(LOAD_PATH)
+        entry = popfirst!(LOAD_PATH)
         if entry in STD_LOAD_PATH
             push!(std_load_path, entry)
         else
@@ -170,19 +170,19 @@ if !( isempty(LOAD_PATH) || isempty(DEPOT_PATH) || (length(LOAD_PATH)==1 && LOAD
 
     # Add user load path to LOAD_PATH
     while !isempty(user_load_path)
-        entry = pop!(user_load_path)
+        entry = popfirst!(user_load_path)
         push!(LOAD_PATH, entry)
     end
 
     # Add admin load path to LOAD_PATH
     while !isempty(ADMIN_LOAD_PATH)
-        entry = pop!(ADMIN_LOAD_PATH)
+        entry = popfirst!(ADMIN_LOAD_PATH)
         push!(LOAD_PATH, entry)
     end
 
     # Add std load path to LOAD_PATH
     while !isempty(std_load_path)
-        entry = pop!(std_load_path)
+        entry = popfirst!(std_load_path)
         push!(LOAD_PATH, entry)
     end
 
@@ -193,7 +193,7 @@ if !( isempty(LOAD_PATH) || isempty(DEPOT_PATH) || (length(LOAD_PATH)==1 && LOAD
     user_depot_path = []
     std_depot_path = []
     while !isempty(DEPOT_PATH)
-        depot = pop!(DEPOT_PATH)
+        depot = popfirst!(DEPOT_PATH)
         if depot in STD_DEPOT_PATH
             push!(std_depot_path, depot)
         else
@@ -203,19 +203,19 @@ if !( isempty(LOAD_PATH) || isempty(DEPOT_PATH) || (length(LOAD_PATH)==1 && LOAD
 
     # Add user depots to DEPOT_PATH
     while !isempty(user_depot_path)
-        depot = pop!(user_depot_path)
+        depot = popfirst!(user_depot_path)
         push!(DEPOT_PATH, depot)
     end
 
     # Add admin depots to DEPOT_PATH
     while !isempty(ADMIN_DEPOT_PATH)
-        depot = pop!(ADMIN_DEPOT_PATH)
+        depot = popfirst!(ADMIN_DEPOT_PATH)
         push!(DEPOT_PATH, depot)
     end
 
     # Add std depots to DEPOT_PATH
     while !isempty(std_depot_path)
-        depot = pop!(std_depot_path)
+        depot = popfirst!(std_depot_path)
         push!(DEPOT_PATH, depot)
     end
 

--- a/easybuild/easyblocks/julia.py
+++ b/easybuild/easyblocks/julia.py
@@ -88,21 +88,21 @@ class EB_Julia(PackedBinary):
         return user_depot_path
 
     def __init__(self, *args, **kwargs):
-        """Initliaze RPackage-specific class variables."""
         super(EB_Julia, self).__init__(*args, **kwargs)
 
         self.user_depot = self.get_user_depot_path()
-        extensions_depot = os.path.join(self.installdir, 'extensions')
         local_share_depot = os.path.join(self.installdir, 'local', 'share', 'julia')
         share_depot = os.path.join(self.installdir, 'share', 'julia')
-        self.admin_depots = ':'.join([extensions_depot, local_share_depot, share_depot])
-        self.julia_depot_path = ':'.join([self.user_depot, self.admin_depots])
+        self.std_depots = ':'.join([local_share_depot, share_depot])
+        self.julia_depot_path = ':'.join([self.user_depot, self.std_depots])
+        self.admin_depots = os.path.join(self.installdir, 'extensions')
 
         self.julia_project = os.path.join(self.user_depot, "environments", '-'.join([self.version, self.get_environment_folder()]))
 
         self.user_load_path = '@:@#.#.#-%s' % self.get_environment_folder()
-        self.admin_load_path = '%s:@stdlib' % os.path.join(extensions_depot, "environments", '-'.join([self.version, self.get_environment_folder()]))
-        self.julia_load_path = ':'.join([self.user_load_path, self.admin_load_path])
+        self.std_load_paths = '@stdlib'
+        self.julia_load_path = ':'.join([self.user_load_path, self.std_load_paths])
+        self.admin_load_path = os.path.join(self.admin_depots, "environments", '-'.join([self.version, self.get_environment_folder()]))
 
     def sanity_check_step(self):
         """Custom sanity check for Julia."""
@@ -123,43 +123,104 @@ class EB_Julia(PackedBinary):
 
         super(EB_Julia, self).install_step(*args, **kwargs)
         txt = """
-# depot path modifications
-if haskey(ENV, "EBJULIA_USER_DEPOT_PATH")
-    USER_DEPOT_PATH  = split(ENV["EBJULIA_USER_DEPOT_PATH"],':')
+## Read EB environment variables
+
+if haskey(ENV, "EBJULIA_ADMIN_LOAD_PATH")
+    ADMIN_LOAD_PATH = split(ENV["EBJULIA_ADMIN_LOAD_PATH"],':')
 else
-    USER_DEPOT_PATH = []
+    ADMIN_LOAD_PATH = []
 end
+
+if haskey(ENV, "EBJULIA_STD_LOAD_PATH")
+    STD_LOAD_PATH = split(ENV["EBJULIA_STD_LOAD_PATH"],':')
+else
+    STD_LOAD_PATH = []
+end
+
 if haskey(ENV, "EBJULIA_ADMIN_DEPOT_PATH")
     ADMIN_DEPOT_PATH = split(ENV["EBJULIA_ADMIN_DEPOT_PATH"],':')
 else
     ADMIN_DEPOT_PATH = []
 end
 
-if (length(DEPOT_PATH) != length(USER_DEPOT_PATH) + length(ADMIN_DEPOT_PATH))
-    error("There is an error in your configuration of the DEPOT_PATH; please contact your support team.")
-end
-
-DEPOT_PATH .= [USER_DEPOT_PATH; ADMIN_DEPOT_PATH]
-
-# load path modifications
-if haskey(ENV, "EBJULIA_USER_LOAD_PATH")
-    USER_LOAD_PATH  = split(ENV["EBJULIA_USER_LOAD_PATH"],':')
+if haskey(ENV, "EBJULIA_STD_DEPOT_PATH")
+    STD_DEPOT_PATH = split(ENV["EBJULIA_STD_DEPOT_PATH"],':')
 else
-    USER_LOAD_PATH  = []
+    STD_DEPOT_PATH = []
 end
 
-if haskey(ENV, "EBJULIA_ADMIN_LOAD_PATH")
-    ADMIN_LOAD_PATH = split(ENV["EBJULIA_ADMIN_LOAD_PATH"],':')
-else
-    ADMIN_LOAD_PATH  = []
+
+## Inject the admin paths, except if paths empty (or only "@" for LOAD_PATH) or all entries in std path.
+if !( isempty(LOAD_PATH) || isempty(DEPOT_PATH) || (length(LOAD_PATH)==1 && LOAD_PATH[1]=="@") ||
+      all([entry in STD_LOAD_PATH for entry in LOAD_PATH]) || all([entry in STD_DEPOT_PATH for entry in DEPOT_PATH]) )
+
+    ## Inject the admin load path into the LOAD_PATH
+
+    # Empty the LOAD_PATH, separating load path into user and std load path.
+    user_load_path = []
+    std_load_path = []
+    while !isempty(LOAD_PATH)
+        entry = pop!(LOAD_PATH)
+        if entry in STD_LOAD_PATH
+            push!(std_load_path, entry)
+        else
+            push!(user_load_path, entry)
+        end
+    end
+
+    # Add user load path to LOAD_PATH
+    while !isempty(user_load_path)
+        entry = pop!(user_load_path)
+        push!(LOAD_PATH, entry)
+    end
+
+    # Add admin load path to LOAD_PATH
+    while !isempty(ADMIN_LOAD_PATH)
+        entry = pop!(ADMIN_LOAD_PATH)
+        push!(LOAD_PATH, entry)
+    end
+
+    # Add std load path to LOAD_PATH
+    while !isempty(std_load_path)
+        entry = pop!(std_load_path)
+        push!(LOAD_PATH, entry)
+    end
+
+
+    ## Inject the admin depot path into the DEPOT_PATH
+
+    # Empty the DEPOT_PATH, separating depots into user and std depots.
+    user_depot_path = []
+    std_depot_path = []
+    while !isempty(DEPOT_PATH)
+        depot = pop!(DEPOT_PATH)
+        if depot in STD_DEPOT_PATH
+            push!(std_depot_path, depot)
+        else
+            push!(user_depot_path, depot)
+        end
+    end
+
+    # Add user depots to DEPOT_PATH
+    while !isempty(user_depot_path)
+        depot = pop!(user_depot_path)
+        push!(DEPOT_PATH, depot)
+    end
+
+    # Add admin depots to DEPOT_PATH
+    while !isempty(ADMIN_DEPOT_PATH)
+        depot = pop!(ADMIN_DEPOT_PATH)
+        push!(DEPOT_PATH, depot)
+    end
+
+    # Add std depots to DEPOT_PATH
+    while !isempty(std_depot_path)
+        depot = pop!(std_depot_path)
+        push!(DEPOT_PATH, depot)
+    end
+
 end
 
-if (length(LOAD_PATH) != length(USER_LOAD_PATH) + length(ADMIN_LOAD_PATH))
-    error("There is an error in your configuration of the LOAD_PATH; please contact your support team.\nLOAD_PATH: $LOAD_PATH\nUSER_LOAD_PATH: $USER_LOAD_PATH\nADMIN_LOAD_PATH: $ADMIN_LOAD_PATH")
-    #error("There is an error in your configuration of the LOAD_PATH; please contact your support team.")
-end
-
-LOAD_PATH .= [USER_LOAD_PATH; ADMIN_LOAD_PATH]
         """
         with open(os.path.join(self.installdir, 'etc', 'julia', 'startup.jl'), 'w') as startup_file:
             startup_file.write(txt)
@@ -169,15 +230,16 @@ LOAD_PATH .= [USER_LOAD_PATH; ADMIN_LOAD_PATH]
         txt = super(EB_Julia, self).make_module_extra(*args, **kwargs)
 
         txt += self.module_generator.set_environment('JULIA_PROJECT', self.julia_project)
-
         txt += self.module_generator.set_environment('JULIA_DEPOT_PATH', self.julia_depot_path)
         txt += self.module_generator.set_environment('EBJULIA_USER_DEPOT_PATH', self.user_depot)
         txt += self.module_generator.set_environment('EBJULIA_ADMIN_DEPOT_PATH', self.admin_depots)
+        txt += self.module_generator.set_environment('EBJULIA_STD_DEPOT_PATH', self.std_depots)
 
 
         txt += self.module_generator.set_environment('JULIA_LOAD_PATH', self.julia_load_path)
         txt += self.module_generator.set_environment('EBJULIA_USER_LOAD_PATH', self.user_load_path)
         txt += self.module_generator.set_environment('EBJULIA_ADMIN_LOAD_PATH', self.admin_load_path)
+        txt += self.module_generator.set_environment('EBJULIA_STD_LOAD_PATH', self.std_load_paths)
 
         txt += self.module_generator.set_environment('EBJULIA_ENV_NAME', '-'.join([self.version, self.get_environment_folder()]))
 

--- a/easybuild/easyblocks/juliabundle.py
+++ b/easybuild/easyblocks/juliabundle.py
@@ -96,7 +96,6 @@ class JuliaBundle(Bundle):
         return user_depot_path
 
     def __init__(self, *args, **kwargs):
-        """Initliaze RPackage-specific class variables."""
         super(JuliaBundle, self).__init__(*args, **kwargs)
         self.cfg['exts_defaultclass'] = 'JuliaPackage'
 
@@ -139,10 +138,8 @@ class JuliaBundle(Bundle):
     def make_module_extra(self, *args, **kwargs):
         txt = super(Bundle, self).make_module_extra(*args, **kwargs)
 
-        txt += self.module_generator.prepend_paths('JULIA_DEPOT_PATH', self.extensions_depot)
         txt += self.module_generator.prepend_paths('EBJULIA_ADMIN_DEPOT_PATH', self.extensions_depot)
 
-        txt += self.module_generator.prepend_paths('JULIA_LOAD_PATH', self.admin_load_path)
         txt += self.module_generator.prepend_paths('EBJULIA_ADMIN_LOAD_PATH', self.admin_load_path)
 
         return txt

--- a/easybuild/easyblocks/juliapackage.py
+++ b/easybuild/easyblocks/juliapackage.py
@@ -58,8 +58,6 @@ class JuliaPackage(ExtensionEasyBlock):
         return ExtensionEasyBlock.extra_options(extra_vars=extra_vars)
 
     def __init__(self, *args, **kwargs):
-        """Initliaze RPackage-specific class variables."""
-
         super(JuliaPackage, self).__init__(*args, **kwargs)
         self.package_name = self.name
         names = self.package_name.split('.')
@@ -98,7 +96,7 @@ class JuliaPackage(ExtensionEasyBlock):
         else:
             install_opts = "name=\"%s\", version=\"%s\"" % (self.package_name, self.version)
 
-        pre_cmd = '%s unset EBJULIA_USER_DEPOT_PATH && export EBJULIA_ADMIN_DEPOT_PATH=%s && export JULIA_DEPOT_PATH=%s && export JULIA_PROJECT=%s' % (self.cfg['preinstallopts'], self.depot, self.depot, self.projectdir)
+        pre_cmd = '%s unset EBJULIA_USER_DEPOT_PATH && unset EBJULIA_ADMIN_DEPOT_PATH && export JULIA_DEPOT_PATH=%s && export JULIA_PROJECT=%s' % (self.cfg['preinstallopts'], self.depot, self.projectdir)
 
         has_mpi = False
         if self.toolchain.options.get('usempi', None):
@@ -152,7 +150,7 @@ class JuliaPackage(ExtensionEasyBlock):
         Custom sanity check for Julia packages
         """
         #NOTE: we don't use Pkg.status with arguments as only supported for Julia >=v1.1
-        cmd = "unset EBJULIA_USER_DEPOT_PATH && export EBJULIA_ADMIN_DEPOT_PATH=%s && export JULIA_DEPOT_PATH=%s && export JULIA_PROJECT=%s && julia --eval 'using Pkg; Pkg.status()'" % (self.depot, self.depot, self.projectdir)
+        cmd = "unset EBJULIA_USER_DEPOT_PATH && unset EBJULIA_ADMIN_DEPOT_PATH && export JULIA_DEPOT_PATH=%s && export JULIA_PROJECT=%s && julia --eval 'using Pkg; Pkg.status()'" % (self.depot, self.projectdir)
         cmdttdouterr, _ = run_cmd(cmd, log_all=True, simple=False, regexp=False)
         self.log.error("Julia package %s sanity returned %s" % (self.name, cmdttdouterr))
         return len(parse_log_for_error(cmdttdouterr, regExp="%s\s+v%s" % (self.package_name, self.version))) != 0

--- a/easybuild/easyconfigs/j/Julia/Julia-1.5.3-CrayGNU-20.08-cuda.eb
+++ b/easybuild/easyconfigs/j/Julia/Julia-1.5.3-CrayGNU-20.08-cuda.eb
@@ -1,0 +1,42 @@
+# Recipe for linux, x86_64 created by Samuel Omlin (CSCS), Victor Holanda Rusu (CSCS)
+name = 'Julia'
+version = '1.5.3'
+versionsuffix = '-cuda'
+
+homepage = 'https://julialang.org'
+description = "Julia is a high-level general-purpose dynamic programming language that was originally designed to address the needs of high-performance numerical analysis and computational science, without the typical need of separate compilation to be fast, also usable for client and server web use, low-level systems programming or as a specification language (wikipedia.org). Julia provides ease and expressiveness for high-level numerical computing, in the same way as languages such as R, MATLAB, and Python, but also supports general programming. To achieve this, Julia builds upon the lineage of mathematical programming languages, but also borrows much from popular dynamic languages, including Lisp, Perl, Python, Lua, and Ruby (julialang.org)."
+
+toolchain = {'name': 'CrayGNU', 'version': '20.08'}
+toolchainopts = {'usempi': True, 'pic': True, 'verbose': True}
+
+source_urls = ['https://julialang-s3.julialang.org/bin/linux/x64/%(version_major_minor)s/']
+sources = ['%(namelower)s-%(version)s-linux-%(arch)s.tar.gz']
+
+builddependencies = [
+    ('cudatoolkit', EXTERNAL_MODULE),
+]
+dependencies = [
+    ('craype-accel-nvidia60', EXTERNAL_MODULE),
+]
+
+arch_name = 'gpu'
+exts_defaultclass = 'JuliaPackage'
+
+exts_list = [
+    ('MPI.jl', '0.16.1', {'mpiexec': 'srun', 'mpiexec_args': '-C gpu', 'source_tmpl': 'v0.16.1.tar.gz', 'source_urls': ['https://github.com/JuliaParallel/MPI.jl/archive/']}),
+    ('CUDA.jl', '2.4.1', {'source_tmpl': 'v2.4.1.tar.gz', 'source_urls': ['https://github.com/JuliaGPU/CUDA.jl/archive/']}),
+]
+
+modextravars = {
+    'JULIA_CUDA_USE_BINARYBUILDER': 'false',
+    'JULIA_MPICC': 'cc',
+    'JULIA_MPIEXEC': 'srun',
+    'JULIA_MPIEXEC_ARGS': "-C gpu",
+    'JULIA_MPI_BINARY': 'system',
+    'JULIA_MPI_PATH': '$::env(CRAY_MPICH_DIR)',
+    'JULIA_MPI_TEST_ARRAYTYPE': 'CuArray',
+}
+
+modtclfooter = "module unload cray-libsci_acc"
+
+moduleclass = 'lang'

--- a/easybuild/easyconfigs/j/Julia/Julia-1.5.3-CrayGNU-20.08.eb
+++ b/easybuild/easyconfigs/j/Julia/Julia-1.5.3-CrayGNU-20.08.eb
@@ -1,0 +1,29 @@
+# Recipe for linux, x86_64 created by Samuel Omlin (CSCS), Victor Holanda Rusu (CSCS)
+name = 'Julia'
+version = '1.5.3'
+
+homepage = 'https://julialang.org'
+description = "Julia is a high-level general-purpose dynamic programming language that was originally designed to address the needs of high-performance numerical analysis and computational science, without the typical need of separate compilation to be fast, also usable for client and server web use, low-level systems programming or as a specification language (wikipedia.org). Julia provides ease and expressiveness for high-level numerical computing, in the same way as languages such as R, MATLAB, and Python, but also supports general programming. To achieve this, Julia builds upon the lineage of mathematical programming languages, but also borrows much from popular dynamic languages, including Lisp, Perl, Python, Lua, and Ruby (julialang.org)."
+
+toolchain = {'name': 'CrayGNU', 'version': '20.08'}
+toolchainopts = {'usempi': True, 'pic': True, 'verbose': True}
+
+source_urls = ['https://julialang-s3.julialang.org/bin/linux/x64/%(version_major_minor)s/']
+sources = ['%(namelower)s-%(version)s-linux-%(arch)s.tar.gz']
+
+arch_name = 'mc'
+exts_defaultclass = 'JuliaPackage'
+
+exts_list = [
+    ('MPI.jl', '0.16.1', {'mpiexec': 'srun', 'mpiexec_args': '-C mc', 'source_tmpl': 'v0.16.1.tar.gz', 'source_urls': ['https://github.com/JuliaParallel/MPI.jl/archive/']}),
+]
+
+modextravars = {
+    'JULIA_MPICC': 'cc',
+    'JULIA_MPIEXEC': 'srun',
+    'JULIA_MPIEXEC_ARGS': "-C mc",
+    'JULIA_MPI_BINARY': 'system',
+    'JULIA_MPI_PATH': '$::env(CRAY_MPICH_DIR)',
+}
+
+moduleclass = 'lang'

--- a/easybuild/easyconfigs/j/JuliaExtensions/JuliaExtensions-1.5.3-CrayGNU-20.08-cuda.eb
+++ b/easybuild/easyconfigs/j/JuliaExtensions/JuliaExtensions-1.5.3-CrayGNU-20.08-cuda.eb
@@ -1,0 +1,26 @@
+# Recipe for linux, x86_64 created by Samuel Omlin (CSCS), Victor Holanda Rusu (CSCS)
+easyblock = 'JuliaBundle'
+
+name = 'JuliaExtensions'
+version = '1.5.3'
+versionsuffix = '-cuda'
+
+homepage = 'https://julialang.org'
+description = "Extensions for julia"
+
+toolchain = {'name': 'CrayGNU', 'version': '20.08'}
+toolchainopts = {'pic': True, 'verbose': True}
+
+dependencies = [
+    ('Julia', version, versionsuffix),
+]
+
+arch_name = 'gpu'
+
+exts_list = [
+    ('Plots.jl', '1.10.1', {'source_tmpl': 'v1.10.1.tar.gz', 'source_urls': ['https://github.com/JuliaPlots/Plots.jl/archive/']}),
+    ('PyCall.jl', '1.92.2', {'source_tmpl': 'v1.92.2.tar.gz', 'source_urls': ['https://github.com/JuliaPy/PyCall.jl/archive/']}),
+    ('HDF5.jl', '0.15.2', {'source_tmpl': 'v0.15.2.tar.gz', 'source_urls': ['https://github.com/JuliaIO/HDF5.jl/archive/']}),
+]
+
+moduleclass = 'tools'

--- a/easybuild/easyconfigs/j/JuliaExtensions/JuliaExtensions-1.5.3-CrayGNU-20.08.eb
+++ b/easybuild/easyconfigs/j/JuliaExtensions/JuliaExtensions-1.5.3-CrayGNU-20.08.eb
@@ -1,0 +1,25 @@
+# Recipe for linux, x86_64 created by Samuel Omlin (CSCS), Victor Holanda Rusu (CSCS)
+easyblock = 'JuliaBundle'
+
+name = 'JuliaExtensions'
+version = '1.5.3'
+
+homepage = 'https://julialang.org'
+description = "Extensions for julia"
+
+toolchain = {'name': 'CrayGNU', 'version': '20.08'}
+toolchainopts = {'pic': True, 'verbose': True}
+
+dependencies = [
+    ('Julia', version),
+]
+
+arch_name = 'mc'
+
+exts_list = [
+    ('Plots.jl', '1.10.1', {'source_tmpl': 'v1.10.1.tar.gz', 'source_urls': ['https://github.com/JuliaPlots/Plots.jl/archive/']}),
+    ('PyCall.jl', '1.92.2', {'source_tmpl': 'v1.92.2.tar.gz', 'source_urls': ['https://github.com/JuliaPy/PyCall.jl/archive/']}),
+    ('HDF5.jl', '0.15.2', {'source_tmpl': 'v0.15.2.tar.gz', 'source_urls': ['https://github.com/JuliaIO/HDF5.jl/archive/']}),
+]
+
+moduleclass = 'tools'

--- a/easybuild/easyconfigs/j/jupyterlab/jupyterlab-1.2.16-CrayGNU-20.08-batchspawner-cuda.eb
+++ b/easybuild/easyconfigs/j/jupyterlab/jupyterlab-1.2.16-CrayGNU-20.08-batchspawner-cuda.eb
@@ -233,11 +233,9 @@ modextravars = {
 }
 
 modtclfooter = """
-prepend-path JULIA_DEPOT_PATH "%s"
 prepend-path EBJULIA_ADMIN_DEPOT_PATH "%s"
-prepend-path JULIA_LOAD_PATH "%s"
 prepend-path EBJULIA_ADMIN_LOAD_PATH "%s"
-""" % (_ijulia_depot, _ijulia_depot, _ijulia_projectdir_tcl, _ijulia_projectdir_tcl)
+""" % (_ijulia_depot, _ijulia_projectdir_tcl)
 
 
 # install extensions 

--- a/easybuild/easyconfigs/j/jupyterlab/jupyterlab-1.2.16-CrayGNU-20.08-batchspawner-cuda.eb
+++ b/easybuild/easyconfigs/j/jupyterlab/jupyterlab-1.2.16-CrayGNU-20.08-batchspawner-cuda.eb
@@ -8,7 +8,7 @@ versionsuffix = '-batchspawner-cuda'
 
 _jl_maj_ver = '1'
 _jl_min_ver = '5'
-_jl_rev_ver = '0'
+_jl_rev_ver = '3'
 
 _jlver = '%s.%s.%s' % (_jl_maj_ver, _jl_min_ver, _jl_rev_ver)
 _jlshortver = '%s.%s' % (_jl_maj_ver, _jl_min_ver)

--- a/easybuild/easyconfigs/j/jupyterlab/jupyterlab-1.2.16-CrayGNU-20.08-batchspawner.eb
+++ b/easybuild/easyconfigs/j/jupyterlab/jupyterlab-1.2.16-CrayGNU-20.08-batchspawner.eb
@@ -233,11 +233,9 @@ modextravars = {
 }
 
 modtclfooter = """
-prepend-path JULIA_DEPOT_PATH "%s"
 prepend-path EBJULIA_ADMIN_DEPOT_PATH "%s"
-prepend-path JULIA_LOAD_PATH "%s"
 prepend-path EBJULIA_ADMIN_LOAD_PATH "%s"
-""" % (_ijulia_depot, _ijulia_depot, _ijulia_projectdir_tcl, _ijulia_projectdir_tcl)
+""" % (_ijulia_depot, _ijulia_projectdir_tcl)
 
 
 # install extensions and batchspawner components

--- a/easybuild/easyconfigs/j/jupyterlab/jupyterlab-1.2.16-CrayGNU-20.08-batchspawner.eb
+++ b/easybuild/easyconfigs/j/jupyterlab/jupyterlab-1.2.16-CrayGNU-20.08-batchspawner.eb
@@ -8,7 +8,7 @@ versionsuffix = '-batchspawner'
 
 _jl_maj_ver = '1'
 _jl_min_ver = '5'
-_jl_rev_ver = '0'
+_jl_rev_ver = '3'
 
 _jlver = '%s.%s.%s' % (_jl_maj_ver, _jl_min_ver, _jl_rev_ver)
 _jlshortver = '%s.%s' % (_jl_maj_ver, _jl_min_ver)

--- a/jenkins-builds/7.0.UP02-20.08-daint-gpu
+++ b/jenkins-builds/7.0.UP02-20.08-daint-gpu
@@ -31,8 +31,10 @@
  IDL-8.5.1.eb                                           --set-default-module
  IDL-8.7.2-CSCS.eb
  ipcmagic-0.1-CrayGNU-20.08.eb                          --set-default-module
- Julia-1.5.0-CrayGNU-20.08-cuda.eb                      --set-default-module
- JuliaExtensions-1.5.0-CrayGNU-20.08-cuda.eb            --set-default-module
+ Julia-1.5.0-CrayGNU-20.08-cuda.eb
+ Julia-1.5.3-CrayGNU-20.08-cuda.eb                      --set-default-module
+ JuliaExtensions-1.5.0-CrayGNU-20.08-cuda.eb
+ JuliaExtensions-1.5.3-CrayGNU-20.08-cuda.eb            --set-default-module
  jupyterlab-1.1.1-CrayGNU-20.08-batchspawner.eb         --set-default-module
  jupyterlab-1.2.16-CrayGNU-20.08-batchspawner-cuda.eb
  jupyterlab-2.0.2-CrayGNU-20.08-batchspawner-cuda.eb

--- a/jenkins-builds/7.0.UP02-20.08-daint-mc
+++ b/jenkins-builds/7.0.UP02-20.08-daint-mc
@@ -30,8 +30,10 @@
  IDL-8.5.1.eb                                           --set-default-module
  IDL-8.7.2-CSCS.eb
  ipcmagic-0.1-CrayGNU-20.08.eb                          --set-default-module
- Julia-1.5.0-CrayGNU-20.08.eb                           --set-default-module
- JuliaExtensions-1.5.0-CrayGNU-20.08.eb                 --set-default-module
+ Julia-1.5.0-CrayGNU-20.08.eb
+ Julia-1.5.3-CrayGNU-20.08.eb                           --set-default-module
+ JuliaExtensions-1.5.0-CrayGNU-20.08.eb
+ JuliaExtensions-1.5.3-CrayGNU-20.08.eb                 --set-default-module
  jupyter-utils-0.1.eb                                   --set-default-module
  jupyterlab-1.1.1-CrayGNU-20.08-batchspawner.eb         --set-default-module
  jupyterlab-1.2.16-CrayGNU-20.08-batchspawner.eb

--- a/jenkins-builds/7.0.UP02-20.08-dom-gpu
+++ b/jenkins-builds/7.0.UP02-20.08-dom-gpu
@@ -29,8 +29,10 @@
  IDL-8.5.1.eb                                           --set-default-module
  IDL-8.7.2-CSCS.eb
  ipcmagic-0.1-CrayGNU-20.08.eb                          --set-default-module
- Julia-1.5.0-CrayGNU-20.08-cuda.eb                      --set-default-module
- JuliaExtensions-1.5.0-CrayGNU-20.08-cuda.eb            --set-default-module
+ Julia-1.5.0-CrayGNU-20.08-cuda.eb
+ Julia-1.5.3-CrayGNU-20.08-cuda.eb                      --set-default-module
+ JuliaExtensions-1.5.0-CrayGNU-20.08-cuda.eb
+ JuliaExtensions-1.5.3-CrayGNU-20.08-cuda.eb            --set-default-module
  jupyterlab-1.1.1-CrayGNU-20.08-batchspawner.eb         --set-default-module
  jupyterlab-1.2.16-CrayGNU-20.08-batchspawner-cuda.eb
  jupyterlab-2.0.2-CrayGNU-20.08-batchspawner-cuda.eb

--- a/jenkins-builds/7.0.UP02-20.08-dom-mc
+++ b/jenkins-builds/7.0.UP02-20.08-dom-mc
@@ -28,8 +28,10 @@
  IDL-8.5.1.eb                                           --set-default-module
  IDL-8.7.2-CSCS.eb
  ipcmagic-0.1-CrayGNU-20.08.eb                          --set-default-module
- Julia-1.5.0-CrayGNU-20.08.eb                           --set-default-module
- JuliaExtensions-1.5.0-CrayGNU-20.08.eb                 --set-default-module
+ Julia-1.5.0-CrayGNU-20.08.eb
+ Julia-1.5.3-CrayGNU-20.08.eb                           --set-default-module
+ JuliaExtensions-1.5.0-CrayGNU-20.08.eb
+ JuliaExtensions-1.5.3-CrayGNU-20.08.eb                 --set-default-module
  jupyter-utils-0.1.eb                                   --set-default-module
  jupyterlab-1.1.1-CrayGNU-20.08-batchspawner.eb         --set-default-module
  jupyterlab-1.2.16-CrayGNU-20.08-batchspawner.eb


### PR DESCRIPTION
## The problem
Building and testing of certain packages from within the Julia Pkg manager can fail due to the Julia startup file. Either because 1) it gives an error if the DEPOT_PATH/LOAD_PATH were modified and the length does not correspond to length(USER_DEPOT_PATH) + length(ADMIN_DEPOT_PATH) or length(USER_LOAD_PATH) + length(ADMIN_LOAD_PATH)  or 2) the startup file is deactivated (according to the documentation, building happens without startup file by default except if julia is called explicitly with --startup-file=yes).

## Solution
1. The modules leave the DEPOT_PATH and LOAD_PATH essentially as defined by default by the Julia installation (introducing though mc and daint as well as using #.#.#).
2. The modules define the ADMIN_DEPOT_PATH and ADMIN_LOAD_PATH environment variables as before, with the exception that the standard Julia  installation depot paths  (/apps/daint/UES/omlins/julia-1.5.3/software/Julia/1.5.3-CrayGNU-20.08/local/share/julia and /apps/daint/UES/omlins/julia-1.5.3/software/Julia/1.5.3-CrayGNU-20.08/share/julia) and load path (@stdlib) are not added (as already in the DEPOT_PATH  and LOAD_PATH)
3. USER_DEPOT_PATH and USER_LOAD_PATH are not defined or just not used (and kept for possible other usage).
4. STD_DEPOT_PATH and STD_LOAD_PATH environment variables are additionally defined.
5. The startup file injects the entries of ADMIN_DEPOT_PATH  and ADMIN_LOAD_PATH to the DEPOT_PATH and LOAD_PATH after any user path, but before the standard Julia installation depot and load paths.
6. The startup file does nothing in certain conditions to ensure proper and consisting working in any case (Pkg build, test ...):  if paths empty (or only "@" for LOAD_PATH) or all entries in std path.

## Result
1. Standard usage of Julia is as before. 
2. For specific operations which are run with --startup-file=no  (implicitly or explicitly) the admin packages are simply deactivated. 
3. For specific operations which are run with --startup-file=yes  (implicitly or explicitly) the admin packages are also deactivated if the  conditions listed in point 6 above apply. Else, the admin paths are activated, but there is no constraint on the DEPOT_PATH/LOAD_PATH defined by the user or Pkg manager.
4. In addition, each user has the choice to easily completely deactivate the usage of admin packages  by creating a julia alias with --startup-file=no. 