### PR TITLE
[dom-mc] CP2K 8.1 with PE 20.11 (multicore)

### DIFF
--- a/easybuild/easyconfigs/c/CP2K/CP2K-8.1-CrayGNU-20.11.eb
+++ b/easybuild/easyconfigs/c/CP2K/CP2K-8.1-CrayGNU-20.11.eb
@@ -1,0 +1,54 @@
+# contributed by Luca Marsella (CSCS)
+easyblock = 'MakeCp'
+
+name = 'CP2K'
+version = '8.1'
+
+homepage = 'http://www.cp2k.org/'
+description = """
+    CP2K is a freely available (GPL) program, written in Fortran 95, to
+    perform atomistic and molecular simulations of solid state, liquid,
+    molecular and biological systems. It provides a general framework for
+    different methods such as e.g. density functional theory (DFT) using a
+    mixed Gaussian and plane waves approach (GPW), and classical pair and
+    many-body potentials.
+"""
+
+toolchain = {'name': 'CrayGNU', 'version': '20.11'}
+toolchainopts = {'usempi': True, 'openmp': True}
+
+source_urls = ['https://github.com/%(namelower)s/%(namelower)s/releases/download/v%(version)s.0']
+sources = [SOURCELOWER_TAR_BZ2]
+patches = [('%(name)s-%(version)s-%(toolchain_name)s.psmp', '%(builddir)s/%(namelower)s-%(version)s/arch')]
+
+builddependencies = [
+    ('cray-fftw', EXTERNAL_MODULE),
+    ('cray-libsci', EXTERNAL_MODULE),
+    ('Bison', '3.3.2'),
+    ('flex', '2.6.4'),
+]
+dependencies = [
+    ('ELPA', '2020.11.001'),
+    ('Libint-CP2K', '2.6.0'),
+    ('libxc', '4.3.4'),
+]
+
+# build type
+buildopts = "ARCH=%(name)s-%(version)s-%(toolchain_name)s VERSION=psmp"
+
+files_to_copy = [
+    (['./arch/%(name)s-%(version)s-%(toolchain_name)s.psmp'], 'arch'),
+    (['./exe/%(name)s-%(version)s-%(toolchain_name)s/*'], 'bin'),
+    (['./data'], '.'),
+    (['./tests'], '.'),
+]
+
+sanity_check_paths = {
+    'files': ['arch/%(name)s-%(version)s-%(toolchain_name)s.psmp', 'bin/%(namelower)s.psmp'],
+    'dirs': ['data', 'tests'],
+}
+
+# set custom CP2K_DATA_DIR
+modextravars = {'CP2K_DATA_DIR': '%(installdir)s/data'}
+
+moduleclass = 'chem'

--- a/easybuild/easyconfigs/c/CP2K/CP2K-8.1-CrayGNU.psmp
+++ b/easybuild/easyconfigs/c/CP2K/CP2K-8.1-CrayGNU.psmp
@@ -5,7 +5,7 @@ FC       = ftn
 LD       = ftn
 AR       = ar -r
 # LIBXSMM (-D__LIBXSMM) is slower than LIBSMM (-D__HAS_smm_dnn)
-DFLAGS   = -D__FFTW3 -D__GFORTRAN -D__ELPA=201911 -D__LIBINT -D__LIBXC -D__MAX_CONTR=4 -D__parallel -D__SCALAPACK -D__HAS_smm_dnn
+DFLAGS   = -D__FFTW3 -D__GFORTRAN -D__ELPA=202011 -D__LIBINT -D__LIBXC -D__MAX_CONTR=4 -D__parallel -D__SCALAPACK -D__HAS_smm_dnn
 CFLAGS   = $(DFLAGS) -g -O2 -fopenmp
 CXXFLAGS = $(CFLAGS)
 FCFLAGS  = $(DFLAGS) -g -O3 -mavx -fopenmp -funroll-loops -ftree-vectorize -ffree-form -ffree-line-length-512

--- a/easybuild/easyconfigs/e/ELPA/ELPA-2020.11.001-CrayGNU-20.11.eb
+++ b/easybuild/easyconfigs/e/ELPA/ELPA-2020.11.001-CrayGNU-20.11.eb
@@ -1,0 +1,27 @@
+# Contributed by Luca Marsella (CSCS)
+easyblock = 'ConfigureMake'
+
+name = 'ELPA'
+version = '2020.11.001'
+
+homepage = 'http://elpa.rzg.mpg.de'
+description = "Eigenvalue SoLvers for Petaflop-Applications ."
+
+toolchain = {'name': 'CrayGNU', 'version': '20.11'}
+toolchainopts = {'usempi': True, 'openmp': True}
+
+# download from http://%(namelower)s.mpcdf.mpg.de/html/Releases/%(version)s often fails
+sources = ['/apps/common/UES/easybuild/sources/%(nameletterlower)s/%(name)s/' + SOURCELOWER_TAR_GZ]
+
+configopts = "CC=cc --disable-avx512 --enable-openmp --enable-static"
+
+sanity_check_paths = {
+    'files': ['lib/libelpa_openmp.a', 'lib/libelpa_openmp.so'],
+    'dirs': ['bin', 'include/elpa_openmp-%(version)s/%(namelower)s', 'include/elpa_openmp-%(version)s/modules', 'lib/pkgconfig'],
+}
+
+modextrapaths = {'CPATH': ['include/elpa_openmp-%(version)s']}
+
+modextravars = {'ELPA_INCLUDE_DIR': '%(installdir)s/include/elpa_openmp-%(version)s'}
+
+moduleclass = 'math'

--- a/jenkins-builds/7.0.UP02-20.11-dom-mc
+++ b/jenkins-builds/7.0.UP02-20.11-dom-mc
@@ -5,7 +5,7 @@
  CDO-1.9.5-CrayGNU-20.11.eb                             --set-default-module
  CDO-1.9.5-CrayIntel-20.11.eb
  CMake-3.14.5.eb                                        --set-default-module
- CP2K-7.1-CrayGNU-20.11.eb                              --set-default-module
+ CP2K-8.1-CrayGNU-20.11.eb                              --set-default-module
  CPMD-4.1-CrayIntel-20.11.eb                            --set-default-module
  CPMD-4.3-CrayIntel-20.11.eb
  dask-2.2.0-CrayGNU-20.11-python3.eb                    --set-default-module


### PR DESCRIPTION
CP2K latest stable release with the corresponding architecture file and ELPA dependency updated (multicore).