### PR TITLE
[dom] fix cmake version in pybind11

### DIFF
--- a/easybuild/easyconfigs/p/pybind11/pybind11-2.6.1-CrayGNU-20.11.eb
+++ b/easybuild/easyconfigs/p/pybind11/pybind11-2.6.1-CrayGNU-20.11.eb
@@ -15,7 +15,7 @@ source_urls = ['https://github.com/pybind/pybind11/archive/']
 sources = ['v%(version)s.tar.gz']
 
 builddependencies = [
-    ('CMake', EXTERNAL_MODULE),
+    ('CMake', '3.14.5', '', True),
 ]
 
 dependencies = [


### PR DESCRIPTION
The former EXTERNAL_MODULE seems to break ReBuildEB