### PR TITLE
[eiger] on eiger, the libpython3.8.so is in a different place

### DIFF
--- a/easybuild/easyconfigs/p/ParaView/ParaView-5.9.0-cpeCCE-20.10-OSMesa-python3.eb
+++ b/easybuild/easyconfigs/p/ParaView/ParaView-5.9.0-cpeCCE-20.10-OSMesa-python3.eb
@@ -66,7 +66,7 @@ modextrapaths = {
 }
 
 modtclfooter = """
-    prepend-path LD_LIBRARY_PATH /opt/python/%(pyver)s/lib
+    prepend-path LD_LIBRARY_PATH ${CRAY_PYTHON_PREFIX}/lib
 """
 
 postinstallcmds = [ "export GALLIUM_DRIVER=swr;"


### PR DESCRIPTION
This fix enables correct loading of the python library for all executables (pvbatch, pvserver, pvpython). Thanks to @teojgo who identified the bug