### PR TITLE
[pilatus] Rename toolchain cpeCCE as cpeCray

### DIFF
--- a/easybuild/easyconfigs/c/cpeCray/cpeCray-21.02.eb
+++ b/easybuild/easyconfigs/c/cpeCray/cpeCray-21.02.eb
@@ -1,0 +1,50 @@
+# Compiler toolchain for Cray EX Programming Environment Cray compiler (cpe-cray)
+easyblock = 'cpeToolchain'
+
+name = 'cpeCray'
+version = "21.02"
+
+homepage = 'https://pubs.cray.com'
+description = """Toolchain using Cray compiler wrapper with cpe-cray module (CPE release: %s).\n""" % version
+
+toolchain = SYSTEM
+
+dependencies = [
+   ('cpe-cray', EXTERNAL_MODULE)
+]
+
+modluafooter = '''
+if not ( isloaded("cce/11.0.2") ) then
+    load("cce/11.0.2")
+end
+if not ( isloaded("cray-dsmml/0.1.3") ) then
+    load("cray-dsmml/0.1.3")
+end
+if not ( isloaded("cray-libsci/20.12.1.2") ) then
+    load("cray-libsci/20.12.1.2")
+end
+if not ( isloaded("cray-mpich/8.1.2") ) then
+    load("cray-mpich/8.1.2")
+end
+if not ( isloaded("craype/2.7.5") ) then
+    load("craype/2.7.5")
+end
+if not ( isloaded("craype-x86-rome") ) then
+    load("craype-x86-rome")
+end
+if not ( isloaded("craype-network-ofi") ) then
+    load("craype-network-ofi")
+end
+if not ( isloaded("libfabric/1.11.0.0.233") ) then
+    load("libfabric/1.11.0.0.233")
+end
+if not ( isloaded("perftools-base/21.02.0") ) then
+    load("perftools-base/21.02.0")
+end
+if not ( isloaded("xpmem/2.2.35-7.0.1.0_1.9__gd50fabf.shasta") ) then
+    load("xpmem/2.2.35-7.0.1.0_1.9__gd50fabf.shasta")
+end
+prepend_path("MODULEPATH",root:gsub("software","modules/all/Toolchain"))
+''' 
+
+moduleclass = 'toolchain'

--- a/easybuild/easyconfigs/g/GSL/GSL-2.6-cpeCray-21.02.eb
+++ b/easybuild/easyconfigs/g/GSL/GSL-2.6-cpeCray-21.02.eb
@@ -1,0 +1,29 @@
+# contributed by Luca Marsella (CSCS)
+easyblock = 'ConfigureMake'
+
+name = 'GSL'
+version = '2.6'
+
+homepage = 'http://www.gnu.org/software/gsl/'
+description = """
+    The GNU Scientific Library (GSL) is a numerical library for C and C++
+    programmers. The library provides a wide range of mathematical routines
+    such as random number generators, special functions and least-squares
+    fitting.
+"""
+
+toolchain = {'name': 'cpeCray', 'version': '21.02'}
+toolchainopts = {'opt': True, 'optarch': True, 'unroll': True, 'pic': True}
+
+source_urls = [GNU_SOURCE]
+sources = [SOURCELOWER_TAR_GZ]
+
+configopts = '--with-pic'
+
+
+sanity_check_paths = {
+    'files': ['lib/libgsl.so', 'lib/libgsl.a'],
+    'dirs': ['include'],
+}
+
+moduleclass = 'numlib'

--- a/jenkins-builds/1.3.2-21.02-pilatus
+++ b/jenkins-builds/1.3.2-21.02-pilatus
@@ -1,7 +1,7 @@
  Buildah-1.19.0.eb                    --set-default-module
  CMake-3.19.5.eb                      --set-default-module
  GSL-2.6-cpeAMD-21.02.eb
- GSL-2.6-cpeCCE-21.02.eb              
+ GSL-2.6-cpeCray-21.02.eb              
  GSL-2.6-cpeGNU-21.02.eb
  GSL-2.6-cpeIntel-21.02.eb
  VASP-6.1.0-cpeIntel-21.02.eb


### PR DESCRIPTION
The new name will be used on Eiger after the upgrade as well.