### PR TITLE
[pilatus] Reframe 3.4.2 as default on Pilatus

### DIFF
--- a/jenkins-builds/1.3.2-21.02-pilatus
+++ b/jenkins-builds/1.3.2-21.02-pilatus
@@ -1,5 +1,6 @@
  Buildah-1.19.0.eb                    --set-default-module
  CMake-3.19.5.eb                      --set-default-module
+ reframe-3.4.2.eb                     --set-default-module
  GSL-2.6-cpeAMD-21.02.eb
  GSL-2.6-cpeCray-21.02.eb              
  GSL-2.6-cpeGNU-21.02.eb

--- a/jenkins/README.md
+++ b/jenkins/README.md
@@ -21,3 +21,5 @@ The following dictionary keys are provided:
 * `JenkinsfileTestingEB:` This is the Jenkins pipeline script used for the testing Jenkins project.
 
 * `JenkinsfileProductionEB:` This is the Jenkins pipeline script used for the production Jenkins project.
+
+* `JenkinsfileUpdateEB:` This is the Jenkins pipeline script used for the update Jenkins project.


### PR DESCRIPTION
I have added the recipe of the latest ReFrame release in the production list of Pilatus.