### PR TITLE
[pilatus] Update jupyterlab-2.2.8-cpeGNU-21.02.eb

### DIFF
--- a/easybuild/easyconfigs/j/jupyterlab/jupyterlab-2.2.8-cpeGNU-21.02.eb
+++ b/easybuild/easyconfigs/j/jupyterlab/jupyterlab-2.2.8-cpeGNU-21.02.eb
@@ -238,10 +238,6 @@ exts_list = [
     ('jupyter-server-proxy', '1.5.0'),  
     ('dask_labextension', '3.0.0'),
 
-#JupyterLab GPU Dashboard (nvdashboard)
-    ('pynvml', '8.0.4'),
-    ('jupyterlab-nvdashboard', '0.4.0'), 
-
 # xarray and seaborn
     ('xarray', '0.16.1'),
     ('seaborn', '0.11.0'),


### PR DESCRIPTION
This PR removes the NVIDIA dashboard python modules. This was causing warnings in the jupyter logfile related to missing pynvml.