### PR TITLE
[pilatus] QuantumESPRESSO 6.7.0

### DIFF
--- a/easybuild/cray_external_modules_metadata-21.02.cfg
+++ b/easybuild/cray_external_modules_metadata-21.02.cfg
@@ -17,6 +17,8 @@ version = 1.12.0.3
 
 [cray-hdf5-parallel]
 name = HDF5
+prefix = CRAY_HDF5_PARALLEL_PREFIX
+version = 1.12.0.3
 
 [cray-libsci]
 name = LibSci
@@ -30,6 +32,8 @@ version = 4.7.4.3, 4.7.4.3
 
 [cray-netcdf-hdf5parallel]
 name = netCDF, netCDF-Fortran
+prefix = CRAY_NETCDF_HDF5PARALLEL_PREFIX
+version = 4.7.4.3, 4.7.4.3
 
 [cray-python]
 name = Python
@@ -47,13 +51,16 @@ name = TPSL
 
 [gcc]
 name = GCC
-prefix = GCC_PATH
+prefix = GCC_PREFIX
+version = 10.2.0
 
 [papi]
 name = PAPI
 
 [pmi]
 name = pmi
+prefix = CRAY_PMI_PREFIX
+version = 6.0.9
 
 [slurm/.default]
 name = slurm

--- a/easybuild/easyconfigs/l/libxc/libxc-5.1.2-cpeGNU-21.02.eb
+++ b/easybuild/easyconfigs/l/libxc/libxc-5.1.2-cpeGNU-21.02.eb
@@ -1,0 +1,30 @@
+# contributed by Luca Marsella (CSCS)
+easyblock = 'ConfigureMake'
+
+name = 'libxc'
+version = '5.1.2'
+
+homepage = 'http://www.tddft.org/programs/octopus/wiki/index.php/Libxc'
+description = """Libxc is a library of exchange-correlation functionals for density-functional theory.
+ The aim is to provide a portable, well tested and reliable set of exchange and correlation functionals."""
+
+toolchain = {'name': 'cpeGNU', 'version': '21.02'}
+toolchainopts = {'opt': True}
+
+source_urls = ['https://www.tddft.org/programs/%(name)s/down.php?file=%(version)s']
+sources = [SOURCE_TAR_GZ]
+
+builddependencies = [
+    ('bzip2', '1.0.8'),
+]
+
+configopts = ' --enable-shared ' 
+
+sanity_check_paths = {
+    'files': ['lib/%(name)s.a', 'lib/%(name)s.so', 
+              'lib/%(name)sf90.a', 'lib/%(name)sf90.so',
+              'lib/%(name)sf03.a', 'lib/%(name)sf03.so'],
+    'dirs': ['include'],
+}
+
+moduleclass = 'chem'

--- a/easybuild/easyconfigs/q/QuantumESPRESSO/QuantumESPRESSO-6.7-cpeGNU-21.02.eb
+++ b/easybuild/easyconfigs/q/QuantumESPRESSO/QuantumESPRESSO-6.7-cpeGNU-21.02.eb
@@ -1,0 +1,44 @@
+# created by Luca Marsella (CSCS)
+easyblock = 'ConfigureMake'
+
+name = 'QuantumESPRESSO'
+version = '6.7'
+
+homepage = 'http://www.quantum-espresso.org/'
+description = """Quantum ESPRESSO is an integrated suite of computer codes
+ for electronic-structure calculations and materials modeling at the nanoscale.
+ It is based on density-functional theory, plane waves, and pseudopotentials
+  (both norm-conserving and ultrasoft)."""
+
+toolchain = {'name': 'cpeGNU', 'version': '21.02'}
+toolchainopts = {'opt': True, 'usempi': True, 'pic': True, 'verbose': False, 'openmp': True}
+
+sources = ['https://github.com/QEF/q-e/archive/qe-%(version)s.tar.gz']
+
+dependencies = [
+    ('cray-fftw', EXTERNAL_MODULE),
+    ('cray-hdf5-parallel', EXTERNAL_MODULE),
+    ('cray-libsci', EXTERNAL_MODULE),
+    ('libxc', '5.0.0')
+]
+
+preconfigopts = " module list && sed -i 's#\/xc_version.h#\/include/xc_version.h#p' install/configure && "
+configopts = ' CC=gcc FC=gfortran F77=gfortran MPIF90=ftn SCALAPACK_LIBS="-L$CRAY_LIBSCI_PREFIX_DIR/lib" LAPACK_LIBS="$CRAY_LIBSCI_PREFIX_DIR/lib/libsci_gnu_82_mpi_mp.a" BLAS_LIBS="$CRAY_LIBSCI_PREFIX_DIR/lib/libsci_gnu_82_mpi_mp.a" FFT_LIBS="-L$FFTW_DIR" --with-hdf5=yes --with-hdf5-include="$CRAY_HDF5_PREFIX/include" --with-hdf5-libs="-L$CRAY_HDF5_PREFIX/lib" --with-libxc=yes --with-libxc-prefix="$EBROOTLIBXC" --with-libxc-include="$EBROOTLIBXC/include" --enable-openmp --enable-parallel --with-scalapack '
+
+# fix FLAGS, add FFTW and HDF5 include PATH, adapt to libxc version 5 Fortran interface
+prebuildopts = ' sed -i -e "s/xc_f03/xc_f90/" $(grep -lR "xc_f03") && '
+prebuildopts += """ 
+    sed -i -e 's/^DFLAGS .*/& -D__FFTW3 -D__HDF5/' -e 's#^IFLAGS.*#& -I$(FFTW_INC) -I$(CRAY_HDF5_PREFIX)/include#' -e 's/^CPPFLAGS .*/CPPFLAGS       = -P -traditional -Uvector $(DFLAGS) $(IFLAGS)/' -e 's/^F90FLAGS .*/F90FLAGS       = $(FFLAGS) -cpp -fopenmp $(FDFLAGS) $(CUDA_F90FLAGS) $(IFLAGS) $(MODFLAGS)/' -e 's/^FFLAGS .*/FFLAGS         = -O3 -g -fallow-argument-mismatch -fopenmp/' -e 's/^LDFLAGS .*/LDFLAGS        = -g -pthread -fopenmp/' make.inc && 
+    cat make.inc && 
+"""
+buildopts = "all epw"
+
+# single make process: parallel builds fail for target 'epw'
+maxparallel = 1
+
+sanity_check_paths = {
+    'files': ['bin/pw.x'],
+    'dirs': [''],
+}
+
+moduleclass = 'chem'

--- a/easybuild/easyconfigs/q/QuantumESPRESSO/QuantumESPRESSO-6.7.0-cpeGNU-21.02.eb
+++ b/easybuild/easyconfigs/q/QuantumESPRESSO/QuantumESPRESSO-6.7.0-cpeGNU-21.02.eb
@@ -2,7 +2,7 @@
 easyblock = 'ConfigureMake'
 
 name = 'QuantumESPRESSO'
-version = '6.7'
+version = '6.7.0'
 
 homepage = 'http://www.quantum-espresso.org/'
 description = """Quantum ESPRESSO is an integrated suite of computer codes
@@ -19,15 +19,14 @@ dependencies = [
     ('cray-fftw', EXTERNAL_MODULE),
     ('cray-hdf5-parallel', EXTERNAL_MODULE),
     ('cray-libsci', EXTERNAL_MODULE),
-    ('libxc', '5.0.0')
+    ('libxc', '4.3.4')
 ]
 
 preconfigopts = " module list && sed -i 's#\/xc_version.h#\/include/xc_version.h#p' install/configure && "
 configopts = ' CC=gcc FC=gfortran F77=gfortran MPIF90=ftn SCALAPACK_LIBS="-L$CRAY_LIBSCI_PREFIX_DIR/lib" LAPACK_LIBS="$CRAY_LIBSCI_PREFIX_DIR/lib/libsci_gnu_82_mpi_mp.a" BLAS_LIBS="$CRAY_LIBSCI_PREFIX_DIR/lib/libsci_gnu_82_mpi_mp.a" FFT_LIBS="-L$FFTW_DIR" --with-hdf5=yes --with-hdf5-include="$CRAY_HDF5_PREFIX/include" --with-hdf5-libs="-L$CRAY_HDF5_PREFIX/lib" --with-libxc=yes --with-libxc-prefix="$EBROOTLIBXC" --with-libxc-include="$EBROOTLIBXC/include" --enable-openmp --enable-parallel --with-scalapack '
 
-# fix FLAGS, add FFTW and HDF5 include PATH, adapt to libxc version 5 Fortran interface
-prebuildopts = ' sed -i -e "s/xc_f03/xc_f90/" $(grep -lR "xc_f03") && '
-prebuildopts += """ 
+# fix FLAGS, add FFTW and HDF5 include PATH
+prebuildopts = """ 
     sed -i -e 's/^DFLAGS .*/& -D__FFTW3 -D__HDF5/' -e 's#^IFLAGS.*#& -I$(FFTW_INC) -I$(CRAY_HDF5_PREFIX)/include#' -e 's/^CPPFLAGS .*/CPPFLAGS       = -P -traditional -Uvector $(DFLAGS) $(IFLAGS)/' -e 's/^F90FLAGS .*/F90FLAGS       = $(FFLAGS) -cpp -fopenmp $(FDFLAGS) $(CUDA_F90FLAGS) $(IFLAGS) $(MODFLAGS)/' -e 's/^FFLAGS .*/FFLAGS         = -O3 -g -fallow-argument-mismatch -fopenmp/' -e 's/^LDFLAGS .*/LDFLAGS        = -g -pthread -fopenmp/' make.inc && 
     cat make.inc && 
 """

--- a/jenkins-builds/1.3.2-21.02-pilatus
+++ b/jenkins-builds/1.3.2-21.02-pilatus
@@ -1,11 +1,12 @@
- Buildah-1.19.0.eb                    --set-default-module
- CMake-3.19.6.eb                      --set-default-module
- reframe-3.4.2.eb                     --set-default-module
+ Buildah-1.19.0.eb                      --set-default-module
+ CMake-3.19.6.eb                        --set-default-module
+ reframe-3.4.2.eb                       --set-default-module
  GSL-2.6-cpeAMD-21.02.eb
  GSL-2.6-cpeCray-21.02.eb              
  GREASY-19.03-cscs-cpeGNU-21.02.eb
  GROMACS-2020.5-cpeGNU-21.02.eb
  GSL-2.6-cpeGNU-21.02.eb
  matplotlib-3.3.4-cpeGNU-21.02.eb
+ QuantumESPRESSO-6.7.0-cpeGNU-21.02.eb
  GSL-2.6-cpeIntel-21.02.eb
  VASP-6.1.0-cpeIntel-21.02.eb


### PR DESCRIPTION
I provide the recipe of QuantumESPRESSO 6.7.0 with the toolchain `cpeGNU/21.02`: the more recent version of the `libxc` library is added for future use, since it could not be used immediately as a dependency.
The `prefix` and `version` of some key modules provided by the Cray Programming Environment have been added to the metadata file, in order to get the correct library path of the corresponding library with the `EBROOT` variables. 