### PR TITLE
[pilatus] Update production list 1.3.2-21.02-pilatus

### DIFF
--- a/jenkins-builds/1.3.2-21.02-pilatus
+++ b/jenkins-builds/1.3.2-21.02-pilatus
@@ -7,7 +7,7 @@
  GREASY-19.03-cscs-cpeGNU-21.02.eb
  GROMACS-2020.5-cpeGNU-21.02.eb
  GSL-2.6-cpeGNU-21.02.eb
- jupyterlab-2.2.8-cpeGNU-20.10.eb
+ jupyterlab-2.2.8-cpeGNU-21.02.eb
  matplotlib-3.3.4-cpeGNU-21.02.eb
  GSL-2.6-cpeIntel-21.02.eb
  VASP-6.1.0-cpeIntel-21.02.eb

--- a/jenkins-builds/1.3.2-21.02-pilatus
+++ b/jenkins-builds/1.3.2-21.02-pilatus
@@ -1,11 +1,13 @@
  Buildah-1.19.0.eb                    --set-default-module
  CMake-3.19.6.eb                      --set-default-module
+ jupyter-utils-0.1.eb                 --set-default-module
  reframe-3.4.2.eb                     --set-default-module
  GSL-2.6-cpeAMD-21.02.eb
  GSL-2.6-cpeCray-21.02.eb              
  GREASY-19.03-cscs-cpeGNU-21.02.eb
  GROMACS-2020.5-cpeGNU-21.02.eb
  GSL-2.6-cpeGNU-21.02.eb
+ jupyterlab-2.2.8-cpeGNU-20.10.eb
  matplotlib-3.3.4-cpeGNU-21.02.eb
  GSL-2.6-cpeIntel-21.02.eb
  VASP-6.1.0-cpeIntel-21.02.eb


### PR DESCRIPTION
I have added `jupyter-utils` and `juypterlab` on Pilatus: the first one is built with the system toolchain, therefore the corresponding modulefile will be installed under the `Core` folder. 
The `jupyterlab` modulefile will be installed under to corresponding toolchain folder instead and it will be available for loading only after the toolchain modulefile `cpeGNU/21.02` is loaded (Lmod hierarchy).