### PR TITLE
[pilatus] VASP 6.2.0 on Pilatus

### DIFF
--- a/easybuild/easyconfigs/v/VASP/VASP-6.2.0-cpeIntel-21.02.eb
+++ b/easybuild/easyconfigs/v/VASP/VASP-6.2.0-cpeIntel-21.02.eb
@@ -1,0 +1,38 @@
+# contributed by Luca Marsella (CSCS)
+easyblock = 'MakeCp'
+
+name = 'VASP'
+version = '6.2.0'
+
+homepage = 'http://www.vasp.at'
+description = "The Vienna Ab initio Simulation Package (VASP) is a computer program for atomic scale materials modelling, e.g. electronic structure calculations and quantum-mechanical molecular dynamics, from first principles. "
+
+toolchain = {'name': 'cpeIntel', 'version': '21.02'}
+toolchainopts = {'usempi': True}
+
+sources = [
+    '/apps/common/UES/easybuild/sources/%(nameletterlower)s/%(name)s/%(namelower)s-%(version)s.tar.bz2',
+]
+patches = [
+    ('%(name)s-%(version)s-%(toolchain_name)s.makefile.include', '%(builddir)s/%(namelower)s-%(version)s'),
+]
+
+builddependencies = [
+    ('Wannier90', '3.1.0'),
+]
+
+prebuildopts = " mv %(name)s-%(version)s-%(toolchain_name)s.makefile.include makefile.include &&  module unload cray-libsci && module list && "
+# build type
+buildopts = " std gam ncl "
+
+# don't use parallel make, results in compilation failure
+parallel = 1
+
+files_to_copy = [(['./bin/vasp_*'], 'bin')]
+
+sanity_check_paths = {
+    'files': ['bin/vasp_gam', 'bin/vasp_ncl', 'bin/vasp_std'],
+    'dirs': [],
+}
+
+moduleclass = 'phys'

--- a/easybuild/easyconfigs/v/VASP/VASP-6.2.0-cpeIntel.makefile.include
+++ b/easybuild/easyconfigs/v/VASP/VASP-6.2.0-cpeIntel.makefile.include
@@ -1,0 +1,1 @@
+VASP-6.1.0-cpeIntel.makefile.include

--- a/jenkins-builds/1.3.2-21.02-pilatus
+++ b/jenkins-builds/1.3.2-21.02-pilatus
@@ -10,4 +10,4 @@
  jupyterlab-2.2.8-cpeGNU-21.02.eb
  matplotlib-3.3.4-cpeGNU-21.02.eb
  GSL-2.6-cpeIntel-21.02.eb
- VASP-6.1.0-cpeIntel-21.02.eb
+ VASP-6.2.0-cpeIntel-21.02.eb


### PR DESCRIPTION
I provide the recipe of the latest stable release of VASP with the toolchain `cpeIntel` and PE 21.02 on Pilatus.