### PR TITLE
[daint] Add Boost 1.75.0 with CrayGNU 20.08

### DIFF
--- a/easybuild/easyconfigs/b/Boost/Boost-1.75.0-CrayGNU-20.08.eb
+++ b/easybuild/easyconfigs/b/Boost/Boost-1.75.0-CrayGNU-20.08.eb
@@ -1,0 +1,27 @@
+
+name = 'Boost'
+version = '1.75.0'
+
+homepage = 'http://www.boost.org/'
+description = """
+    Boost provides free peer-reviewed portable C++ source libraries.
+"""
+
+toolchain = {'name': 'CrayGNU', 'version': '20.08'}
+toolchainopts = {'usempi': True, 'pic': True, 'verbose': False}
+
+source_urls = [SOURCEFORGE_SOURCE]
+sources = ['%(namelower)s_1_75_0.tar.gz']
+
+dependencies = [
+    ('bzip2', '1.0.6'),
+    ('zlib', '1.2.11'),
+]
+
+configopts = '--without-libraries=python'
+
+boost_mpi = True
+
+modextravars = {'BOOST_ROOT': '%(installdir)s'}
+
+moduleclass = 'devel'

--- a/easybuild/easyconfigs/b/Boost/Boost-1.75.0-CrayIntel-20.08.eb
+++ b/easybuild/easyconfigs/b/Boost/Boost-1.75.0-CrayIntel-20.08.eb
@@ -1,0 +1,28 @@
+# contributed by Luca Marsella (CSCS)
+name = 'Boost'
+version = '1.75.0'
+
+homepage = 'http://www.boost.org/'
+description = """
+    Boost provides free peer-reviewed portable C++ source libraries.
+"""
+
+toolchain = {'name': 'CrayIntel', 'version': '20.08'}
+toolchainopts = {'pic': True, 'usempi': True, 'verbose': False}
+
+sources = ['%%(namelower)s_%s.tar.bz2' % '_'.join(version.split('.'))]
+source_urls = ['https://dl.bintray.com/boostorg/release/%(version)s/source/']
+
+dependencies = [
+    ('bzip2', '1.0.6'),
+    ('zlib', '1.2.11'),
+]
+
+configopts = '--without-libraries=python'
+boost_mpi = True
+
+modextravars = {
+    'BOOST_ROOT' : "%(installdir)s",
+}
+
+moduleclass = 'devel'

--- a/jenkins-builds/7.0.UP02-20.08-daint-gpu
+++ b/jenkins-builds/7.0.UP02-20.08-daint-gpu
@@ -1,6 +1,7 @@
  Amber-20-3-0-CrayIntel-20.08-cuda.eb                   --set-default-module
  Boost-1.70.0-CrayGNU-20.08-python3.eb                  --set-default-module
  Boost-1.70.0-CrayGNU-20.08.eb
+ Boost-1.75.0-CrayGNU-20.08.eb
  Buildah-1.14.9.eb
  CDO-1.9.5-CrayGNU-20.08.eb                             --set-default-module
  CDO-1.9.5-CrayIntel-20.08.eb

--- a/jenkins-builds/7.0.UP02-20.08-daint-gpu
+++ b/jenkins-builds/7.0.UP02-20.08-daint-gpu
@@ -2,6 +2,7 @@
  Boost-1.70.0-CrayGNU-20.08-python3.eb                  --set-default-module
  Boost-1.70.0-CrayGNU-20.08.eb
  Boost-1.75.0-CrayGNU-20.08.eb
+ Boost-1.75.0-CrayIntel-20.08.eb
  Buildah-1.14.9.eb
  CDO-1.9.5-CrayGNU-20.08.eb                             --set-default-module
  CDO-1.9.5-CrayIntel-20.08.eb

--- a/jenkins-builds/7.0.UP02-20.08-daint-mc
+++ b/jenkins-builds/7.0.UP02-20.08-daint-mc
@@ -1,6 +1,7 @@
  Amber-20-3-0-CrayIntel-20.08.eb                        --set-default-module
  Boost-1.70.0-CrayGNU-20.08-python3.eb                  --set-default-module
  Boost-1.70.0-CrayGNU-20.08.eb
+ Boost-1.75.0-CrayGNU-20.08.eb
  Buildah-1.14.9.eb                                      --set-default-module
  CDO-1.9.5-CrayGNU-20.08.eb                             --set-default-module
  CDO-1.9.5-CrayIntel-20.08.eb

--- a/jenkins-builds/7.0.UP02-20.08-daint-mc
+++ b/jenkins-builds/7.0.UP02-20.08-daint-mc
@@ -2,6 +2,7 @@
  Boost-1.70.0-CrayGNU-20.08-python3.eb                  --set-default-module
  Boost-1.70.0-CrayGNU-20.08.eb
  Boost-1.75.0-CrayGNU-20.08.eb
+ Boost-1.75.0-CrayIntel-20.08.eb
  Buildah-1.14.9.eb                                      --set-default-module
  CDO-1.9.5-CrayGNU-20.08.eb                             --set-default-module
  CDO-1.9.5-CrayIntel-20.08.eb


### PR DESCRIPTION
Recipe for Boost 1.75.0 on Daint with Cray Programming Environment 20.08 both GNU and Intel (required for HPX CI). Built and tested locally.