### PR TITLE
[daint dom] Set h5py parallel default

### DIFF
--- a/jenkins-builds/7.0.UP02-20.08-daint-gpu
+++ b/jenkins-builds/7.0.UP02-20.08-daint-gpu
@@ -29,7 +29,7 @@
  HPX-1.5.0-CrayGNU-20.08-nonetworking-cuda.eb
  hub-2.14.2.eb                                          --set-default-module
  h5py-2.10.0-CrayGNU-20.08-python3-parallel.eb          --set-default-module
- h5py-2.10.0-CrayGNU-20.08-python3-serial.eb            --set-default-module
+ h5py-2.10.0-CrayGNU-20.08-python3-serial.eb
  IDL-8.5.1.eb                                           --set-default-module
  IDL-8.7.2-CSCS.eb
  ipcmagic-0.1-CrayGNU-20.08.eb                          --set-default-module

--- a/jenkins-builds/7.0.UP02-20.08-daint-mc
+++ b/jenkins-builds/7.0.UP02-20.08-daint-mc
@@ -28,7 +28,7 @@
  HPX-1.5.0-CrayGNU-20.08-nonetworking.eb
  hub-2.14.2.eb                                          --set-default-module
  h5py-2.10.0-CrayGNU-20.08-python3-parallel.eb          --set-default-module
- h5py-2.10.0-CrayGNU-20.08-python3-serial.eb            --set-default-module
+ h5py-2.10.0-CrayGNU-20.08-python3-serial.eb
  IDL-8.5.1.eb                                           --set-default-module
  IDL-8.7.2-CSCS.eb
  ipcmagic-0.1-CrayGNU-20.08.eb                          --set-default-module

--- a/jenkins-builds/7.0.UP02-20.11-dom-gpu
+++ b/jenkins-builds/7.0.UP02-20.11-dom-gpu
@@ -23,7 +23,7 @@
  HPX-1.5.0-CrayGNU-20.11-nonetworking-cuda.eb
  hub-2.14.2.eb                                          --set-default-module
  h5py-2.10.0-CrayGNU-20.11-python3-parallel.eb          --set-default-module
- h5py-2.10.0-CrayGNU-20.11-python3-serial.eb            --set-default-module
+ h5py-2.10.0-CrayGNU-20.11-python3-serial.eb
  IDL-8.5.1.eb                                           --set-default-module
  IDL-8.7.2-CSCS.eb
  ipcmagic-0.1-CrayGNU-20.11.eb                          --set-default-module

--- a/jenkins-builds/7.0.UP02-20.11-dom-mc
+++ b/jenkins-builds/7.0.UP02-20.11-dom-mc
@@ -22,7 +22,7 @@
  HPX-1.5.0-CrayGNU-20.11-nonetworking.eb
  hub-2.14.2.eb                                          --set-default-module
  h5py-2.10.0-CrayGNU-20.11-python3-parallel.eb          --set-default-module
- h5py-2.10.0-CrayGNU-20.11-python3-serial.eb            --set-default-module
+ h5py-2.10.0-CrayGNU-20.11-python3-serial.eb
  IDL-8.5.1.eb                                           --set-default-module
  IDL-8.7.2-CSCS.eb
  ipcmagic-0.1-CrayGNU-20.11.eb                          --set-default-module


### PR DESCRIPTION
Remove the flag `--set-default` from the `-serial` build of `h5py` in the production lists of Dom and Piz Daint.