### PR TITLE
[pilatus] PROJ 8 and dependencies

### DIFF
--- a/easybuild/easyconfigs/l/libreadline/libreadline-8.1-cpeGNU-21.02.eb
+++ b/easybuild/easyconfigs/l/libreadline/libreadline-8.1-cpeGNU-21.02.eb
@@ -1,0 +1,28 @@
+# contributed by Luca Marsella (CSCS) 
+easyblock = 'ConfigureMake'
+
+name = 'libreadline'
+version = "8.1"
+
+homepage = 'http://cnswww.cns.cwru.edu/php/chet/readline/rltop.html'
+description = """The GNU Readline library provides a set of functions for use by applications that
+ allow users to edit command lines as they are typed in. Both Emacs and vi editing modes are available.
+ The Readline library includes additional functions to maintain a list of previously-entered command lines,
+ to recall and perhaps reedit those lines, and perform csh-like history expansion on previous commands."""
+
+toolchain = {'name': 'cpeGNU', 'version': '21.02'}
+toolchainopts = {'pic': True}
+
+sources = ['readline-%(version)s.tar.gz']
+source_urls = ['http://ftp.gnu.org/gnu/readline']
+
+dependencies = [('ncurses', '6.2')]
+
+sanity_check_paths = {
+    'files' : ['lib/libreadline.a', 'lib/libhistory.a'] +
+              ['include/readline/%s' % x for x in ['chardefs.h', 'history.h', 'keymaps.h', 'readline.h', 'rlconf.h',
+                                                   'rlstdc.h', 'rltypedefs.h', 'tilde.h']],
+    'dirs' : [],
+}
+
+moduleclass = 'lib'

--- a/easybuild/easyconfigs/n/ncurses/ncurses-6.2-cpeGNU-21.02.eb
+++ b/easybuild/easyconfigs/n/ncurses/ncurses-6.2-cpeGNU-21.02.eb
@@ -1,0 +1,22 @@
+# contributed by Luca Marsella (CSCS)
+name = 'ncurses'
+version = '6.2'
+
+homepage = 'http://www.gnu.org/software/ncurses/'
+description = """The Ncurses (new curses) library is a free software emulation
+of curses in System V Release 4.0, and more. It uses Terminfo format, supports
+pads and color and multiple highlights and forms characters and function-key
+mapping, and has all the other SYSV-curses enhancements over BSD Curses."""
+
+toolchain = {'name': 'cpeGNU', 'version': '21.02'}
+toolchainopts = {'optarch': True, 'pic': True}
+
+source_urls = [GNU_SOURCE]
+sources = [SOURCE_TAR_GZ]
+
+sanity_check_paths = {
+    'files': ['bin/captoinfo', 'bin/clear', 'bin/infocmp', 'bin/infotocap', 'bin/ncurses6-config', 'bin/reset', 'bin/tabs', 'bin/tic', 'bin/toe', 'bin/tput', 'bin/tset', 'lib/libform.a', 'lib/libform.a', 'lib/libmenu.a', 'lib/libmenu_g.a', 'lib/libncurses.a', 'lib/libncurses++.a', 'lib/libncurses_g.a', 'lib/libpanel.a', 'lib/libpanel_g.a'],
+    'dirs': ['include'],
+}
+
+moduleclass = 'devel'

--- a/easybuild/easyconfigs/p/PROJ/PROJ-8.0.0-cpeGNU-21.02.eb
+++ b/easybuild/easyconfigs/p/PROJ/PROJ-8.0.0-cpeGNU-21.02.eb
@@ -1,0 +1,28 @@
+# Contributed by Theofilos Manitaras and Luca Marsella (CSCS)
+easyblock = 'ConfigureMake'
+
+name = 'PROJ'
+version = '8.0.0'
+
+homepage = 'https://proj.org'
+description = """PROJ is a generic coordinate transformation software that
+transforms geospatial coordinates from one coordinate reference system (CRS) to another."""
+
+toolchain = {'name': 'cpeGNU', 'version': '21.02'}
+toolchainopts = {'pic': True, 'usempi': True}
+
+source_urls = ['http://download.osgeo.org/proj/']
+sources = [SOURCELOWER_TAR_GZ]
+
+dependencies = [
+    ('LibTIFF', '4.2.0'),
+    ('SQLite', '3.34.1')
+]
+
+sanity_check_paths = {
+    'files': ['bin/cs2cs', 'bin/geod', 'bin/invgeod', 
+              'bin/invproj', 'bin/proj'],
+    'dirs': [],
+}
+
+moduleclass = 'lib'

--- a/easybuild/easyconfigs/s/SQLite/SQLite-3.34.1-cpeGNU-21.02.eb
+++ b/easybuild/easyconfigs/s/SQLite/SQLite-3.34.1-cpeGNU-21.02.eb
@@ -1,0 +1,38 @@
+# Contributed by Luca Marsella (CSCS)
+#
+# This file is an EasyBuild reciPY as per https://github.com/hpcugent/easybuild
+#
+# Copyright:: Copyright 2012-2014 Uni.Lu/LCSB, NTUA
+# Authors::   Fotis Georgatos <fotis@cern.ch>
+# License::   MIT/GPL
+# $Id$
+#
+# This work implements a part of the HPCBIOS project and is a component of the policy:
+# http://hpcbios.readthedocs.org/en/latest/
+easyblock = 'ConfigureMake'
+
+name = 'SQLite'
+version = '3.34.1'
+
+homepage = 'http://www.sqlite.org/'
+description = 'SQLite: SQL Database Engine in a C Library'
+
+toolchain = {'name': 'cpeGNU', 'version': '21.02'}
+
+# https://www.sqlite.org/2021/sqlite-autoconf-3340100.tar.gz
+source_urls = ['http://www.sqlite.org/2021/']
+local_version = '%%(version_major)s%s00' % ''.join('%02d' % int(x) for x in version.split('.')[1:])
+sources = ['sqlite-autoconf-%s.tar.gz' % local_version]
+
+dependencies = [
+    ('libreadline', '8.1'),
+]
+
+parallel = 1
+
+sanity_check_paths = {
+    'files': ['bin/sqlite3', 'include/sqlite3ext.h', 'include/sqlite3.h', 'lib/libsqlite3.a', 'lib/libsqlite3.%s' % SHLIB_EXT],
+    'dirs': ['lib/pkgconfig'],
+}
+
+moduleclass = 'devel'


### PR DESCRIPTION
I provide the recipe and dependencies of `PROJ` (latest stable release 8.0.0) with Cray PE 21.02 on Pilatus: I'm not adding the module directly in the production list, since it will be a dependency of the new module `CDO` (to be submitted soon).