### PR TITLE
[pilatus] NCO with PE 21.02

### DIFF
--- a/easybuild/easyconfigs/a/ANTLR/ANTLR-2.7.7-cpeGNU-21.02-python3.eb
+++ b/easybuild/easyconfigs/a/ANTLR/ANTLR-2.7.7-cpeGNU-21.02-python3.eb
@@ -1,0 +1,33 @@
+# contributed by Luca Marsella (CSCS), updated by Samuel Omlin (CSCS)
+easyblock = 'ConfigureMake'
+
+name = 'ANTLR'
+version = '2.7.7'
+versionsuffix = '-python%(pymajver)s'
+
+homepage = 'http://www.antlr.org/'
+description = """
+    ANTLR, ANother Tool for Language Recognition, (formerly PCCTS) is a
+    language tool that provides a framework for constructing recognizers,
+    compilers, and translators from grammatical descriptions containing
+    Java, C#, C++, or Python actions.
+"""
+
+toolchain = {'name': 'cpeGNU', 'version': '21.02'}
+
+source_urls = ['http://www.antlr2.org/download/']
+sources = [SOURCELOWER_TAR_GZ]
+patches = ['%(name)s-%(version)s_includes.patch']
+
+dependencies = [
+    ('cray-python', EXTERNAL_MODULE),
+]
+
+configopts = "--disable-examples --disable-csharp "
+
+sanity_check_paths = {
+    'files': ['bin/%(namelower)s', 'bin/%(namelower)s-config'],
+    'dirs': ['include'],
+}
+
+moduleclass = 'tools'

--- a/easybuild/easyconfigs/n/NCO/NCO-4.9.7-cpeGNU-21.01.eb
+++ b/easybuild/easyconfigs/n/NCO/NCO-4.9.7-cpeGNU-21.01.eb
@@ -1,0 +1,28 @@
+# contributed by Luca Marsella (CSCS), updated by Samuel Omlin (CSCS)
+easyblock = 'ConfigureMake'
+
+name = 'NCO'
+version = '4.9.7'
+
+homepage = 'http://nco.sourceforge.net/'
+description = "The NCO toolkit manipulates and analyzes data stored in netCDF-accessible formats, including DAP, HDF4, and HDF5."
+
+toolchain = {'name': 'cpeGNU', 'version': '21.02'}
+toolchainopts = {'opt': True, 'pic': True}
+
+sources = ['https://github.com/%(namelower)s/%(namelower)s/archive/%(version)s.tar.gz']
+
+dependencies = [
+    ('ANTLR', '2.7.7', '-python3'),
+    ('cray-hdf5', EXTERNAL_MODULE),
+    ('cray-netcdf', EXTERNAL_MODULE),
+    ('JasPer', '2.0.25'),
+    ('UDUNITS', '2.2.28')
+]
+
+sanity_check_paths = {
+    'files': ['bin/ncbo'],
+    'dirs': [],
+}
+
+moduleclass = 'data'

--- a/easybuild/easyconfigs/u/UDUNITS/UDUNITS-2.2.28-cpeGNU-21.02.eb
+++ b/easybuild/easyconfigs/u/UDUNITS/UDUNITS-2.2.28-cpeGNU-21.02.eb
@@ -1,0 +1,42 @@
+# contributed by Luca Marsella (CSCS)
+#
+# This file is an EasyBuild reciPY as per https://github.com/hpcugent/easybuild
+#
+# Copyright:: Copyright 2012-2013 University of Luxembourg, Ghent University
+# Authors::   Fotis Georgatos <fotis@cern.ch>, Kenneth Hoste (Ghent University)
+# License::   MIT/GPL
+# $Id$
+#
+# This work implements a part of the HPCBIOS project and is a component of the policy:
+# http://hpcbios.readthedocs.org/en/latest/HPCBIOS_2012-97.html
+#
+easyblock = 'ConfigureMake'
+
+name = 'UDUNITS'
+version = '2.2.28'
+
+homepage = 'http://www.unidata.ucar.edu/software/udunits/'
+description = """UDUNITS supports conversion of unit specifications between formatted and binary forms,
+ arithmetic manipulation of units, and conversion of values between compatible scales of measurement."""
+
+toolchain = {'name': 'cpeGNU', 'version': '21.02'}
+toolchainopts = {'opt': True, 'pic': True}
+
+sources = [SOURCELOWER_TAR_GZ]
+source_urls = ['https://artifacts.unidata.ucar.edu/repository/downloads-udunits']
+
+sanity_check_paths = {
+    'files': [
+        'bin/udunits2',
+        'include/converter.h',
+        'include/udunits2.h',
+        'include/udunits.h',
+        'lib/libudunits2.a',
+        'lib/libudunits2.so',
+    ],
+    'dirs': ['share'],
+}
+
+parallel = 1
+
+moduleclass = 'phys'

--- a/jenkins-builds/1.3.2-21.02-pilatus
+++ b/jenkins-builds/1.3.2-21.02-pilatus
@@ -14,6 +14,7 @@
  jupyterlab-2.2.8-cpeGNU-21.02.eb
  LAMMPS-29Oct20-cpeGNU-21.02.eb
  matplotlib-3.3.4-cpeGNU-21.02.eb
+ NCO-4.9.7-cpeGNU-21.01.eb
  QuantumESPRESSO-6.7.0-cpeGNU-21.02.eb
  GSL-2.6-cpeIntel-21.02.eb
  NAMD-2.14-cpeIntel-21.02.eb


### PR DESCRIPTION
I provide the recipe of the latest stable release of NCO and its dependencies with Cray PE 21.02 on Pilatus.