### PR TITLE
[dom-mc] CP2K 7.1 and 8.1 with CrayPAT 20.11

### DIFF
--- a/easybuild/easyconfigs/c/CP2K/CP2K-7.1-CrayGNU-20.11-pat.eb
+++ b/easybuild/easyconfigs/c/CP2K/CP2K-7.1-CrayGNU-20.11-pat.eb
@@ -3,6 +3,7 @@ easyblock = 'MakeCp'
 
 name = 'CP2K'
 version = '7.1'
+versionsuffix = '-pat'
 
 homepage = 'http://www.cp2k.org/'
 description = """
@@ -19,13 +20,17 @@ toolchainopts = {'usempi': True, 'openmp': True}
 
 source_urls = ['https://github.com/%(namelower)s/%(namelower)s/releases/download/v%(version)s.0']
 sources = [SOURCELOWER_TAR_BZ2]
-patches = [('%(name)s-%(version)s-%(toolchain_name)s.psmp', '%(builddir)s/%(namelower)s-%(version)s/arch')]
+patches = [
+    ('%(name)s-%(version)s-%(toolchain_name)s.psmp', '%(builddir)s/%(namelower)s-%(version)s/arch'),
+]
 
 builddependencies = [
     ('cray-fftw', EXTERNAL_MODULE),
     ('cray-libsci', EXTERNAL_MODULE),
     ('Bison', '3.3.2'),
     ('flex', '2.6.4'),
+    ('perftools-base', EXTERNAL_MODULE),
+    ('perftools-lite', EXTERNAL_MODULE)
 ]
 dependencies = [
     ('ELPA', '2019.11.001'),

--- a/easybuild/easyconfigs/c/CP2K/CP2K-8.1-CrayGNU-20.11-pat.eb
+++ b/easybuild/easyconfigs/c/CP2K/CP2K-8.1-CrayGNU-20.11-pat.eb
@@ -2,7 +2,8 @@
 easyblock = 'MakeCp'
 
 name = 'CP2K'
-version = '7.1'
+version = '8.1'
+versionsuffix = '-pat'
 
 homepage = 'http://www.cp2k.org/'
 description = """
@@ -19,16 +20,20 @@ toolchainopts = {'usempi': True, 'openmp': True}
 
 source_urls = ['https://github.com/%(namelower)s/%(namelower)s/releases/download/v%(version)s.0']
 sources = [SOURCELOWER_TAR_BZ2]
-patches = [('%(name)s-%(version)s-%(toolchain_name)s.psmp', '%(builddir)s/%(namelower)s-%(version)s/arch')]
+patches = [
+    ('%(name)s-%(version)s-%(toolchain_name)s.psmp', '%(builddir)s/%(namelower)s-%(version)s/arch'),
+]
 
 builddependencies = [
     ('cray-fftw', EXTERNAL_MODULE),
     ('cray-libsci', EXTERNAL_MODULE),
     ('Bison', '3.3.2'),
     ('flex', '2.6.4'),
+    ('perftools-base', EXTERNAL_MODULE),
+    ('perftools-lite', EXTERNAL_MODULE)
 ]
 dependencies = [
-    ('ELPA', '2019.11.001'),
+    ('ELPA', '2020.11.001'),
     ('Libint-CP2K', '2.6.0'),
     ('libxc', '4.3.4'),
 ]


### PR DESCRIPTION
The default module in production will still be CP2K 7.1 due to a performance issue with the gpu release of CP2K 8.1: for the sake consistency, I keep the same default also with the mc release. I provide a minor fix for production recipe of CP2K 7.1 as well.