### PR TITLE
[pilatus] Add hub to production list

### DIFF
--- a/jenkins-builds/1.3.2-21.02-pilatus
+++ b/jenkins-builds/1.3.2-21.02-pilatus
@@ -1,6 +1,7 @@
  Buildah-1.19.0.eb                    --set-default-module
  CMake-3.19.6.eb                      --set-default-module
  ddt-21.0-linux-x86_64.eb             --set-default-module
+ hub-2.14.2.eb                        --set-default-module
  hwloc-2.4.1.eb                       --set-default-module
  jupyter-utils-0.1.eb                 --set-default-module
  reframe-3.5.0.eb                     --set-default-module


### PR DESCRIPTION
This module is required for the JenkinsfileUpdateEB project for the automation of the Github PRs.