### PR TITLE
[eiger] Update jupyterlab-2.2.8-cpeGNU-20.10.eb

### DIFF
--- a/easybuild/easyconfigs/j/jupyterlab/jupyterlab-2.2.8-cpeGNU-20.10.eb
+++ b/easybuild/easyconfigs/j/jupyterlab/jupyterlab-2.2.8-cpeGNU-20.10.eb
@@ -141,7 +141,7 @@ exts_list = [
     ('ruamel.yaml.clib', '0.2.2', {
         'modulename': "ruamel",
         }),
-    ('jupyterhub', '1.1.0'),
+    ('jupyterhub', '1.3.0'),
 
 # widgets: note the lab extensions below
     ('widgetsnbextension', '3.5.1'),


### PR DESCRIPTION
Bump jupyterhub version to 1.3.0 to match upgrade on the VM. No updates required for jupyterhub dependencies.