### PR TITLE
[daint-gpu] SpFFT 0.9.10 isn't compatible with cuda 11, upgrade it

### DIFF
--- a/easybuild/easyconfigs/s/SIRIUS/SIRIUS-6.5.7-CrayGNU-20.11-cuda.eb
+++ b/easybuild/easyconfigs/s/SIRIUS/SIRIUS-6.5.7-CrayGNU-20.11-cuda.eb
@@ -23,7 +23,7 @@ dependencies = [
     ('cray-hdf5', EXTERNAL_MODULE),
     ('GSL', '2.5'),
     ('libxc', '4.3.4'),
-    ('SpFFT', '0.9.10', '-cuda-mkl'),
+    ('SpFFT', '1.0.1', '-cuda-mkl'),
     ('spglib', '1.16.0'),
 ]
 

--- a/easybuild/easyconfigs/s/SpFFT/SpFFT-1.0.1-CrayGNU-20.11-cuda-mkl.eb
+++ b/easybuild/easyconfigs/s/SpFFT/SpFFT-1.0.1-CrayGNU-20.11-cuda-mkl.eb
@@ -1,0 +1,34 @@
+easyblock = 'CMakeMake'
+
+name = 'SpFFT'
+version = '1.0.1'
+versionsuffix = '-cuda-mkl'
+
+homepage = 'https://github.com/eth-cscs/SpFFT'
+description = "Sparse 3D FFT library with MPI, OpenMP, CUDA and ROCm support"
+
+toolchain = {'name': 'CrayGNU', 'version': '20.11'}
+toolchainopts = {'opt': True, 'usempi': True, 'pic': True, 'verbose': False, 'openmp': True}
+
+source_urls = ['https://github.com/eth-cscs/%(name)s/archive']
+sources = ['v%(version)s.tar.gz']
+
+builddependencies = [
+    ('CMake', '3.14.5', '', True),
+]
+dependencies = [
+    ('cudatoolkit', EXTERNAL_MODULE),
+    ('intel/19.1.1.217', EXTERNAL_MODULE),
+]
+
+configopts = "-DCMAKE_BUILD_TYPE=RELEASE -DSPFFT_GPU_BACKEND=CUDA -DSPFFT_SINGLE_PRECISION=ON -DSPFFT_MPI=ON -DSPFFT_OMP=ON"
+
+prebuildopts = []
+
+
+sanity_check_paths = {
+    'files': ['lib/libspfft.so', 'include/%(namelower)s/config.h', 'include/%(namelower)s/%(namelower)s.hpp'],
+    'dirs': [],
+}
+
+moduleclass = 'lib'


### PR DESCRIPTION
SpFFT 0.9.10 doesn't work with Cuda 11. 

The official QE-SIRIUS installation, `QuantumESPRESSO-SIRIUS/6.5-rc4-CrayGNU-20.11-cuda`, on daint is broken at the moment and should be reinstalled after merging this PR.
