### PR TITLE
[daint-gpu] Add latest QE/SIRIUS

### DIFF
--- a/easybuild/easyconfigs/g/GSL/GSL-2.6-CrayGNU-20.11.eb
+++ b/easybuild/easyconfigs/g/GSL/GSL-2.6-CrayGNU-20.11.eb
@@ -1,0 +1,29 @@
+# contributed by Luca Marsella (CSCS)
+easyblock = 'ConfigureMake'
+
+name = 'GSL'
+version = '2.6'
+
+homepage = 'http://www.gnu.org/software/gsl/'
+description = """
+    The GNU Scientific Library (GSL) is a numerical library for C and C++
+    programmers. The library provides a wide range of mathematical routines
+    such as random number generators, special functions and least-squares
+    fitting.
+"""
+
+toolchain = {'name': 'CrayGNU', 'version': '20.11'}
+toolchainopts = {'opt': True, 'optarch': True, 'unroll': True, 'pic': True}
+
+source_urls = [GNU_SOURCE]
+sources = [SOURCELOWER_TAR_GZ]
+
+configopts = '--with-pic'
+
+
+sanity_check_paths = {
+    'files': ['lib/libgsl.so', 'lib/libgsl.a'],
+    'dirs': ['include'],
+}
+
+moduleclass = 'numlib'

--- a/easybuild/easyconfigs/l/libxc/libxc-5.1.2-CrayGNU-20.11.eb
+++ b/easybuild/easyconfigs/l/libxc/libxc-5.1.2-CrayGNU-20.11.eb
@@ -1,0 +1,36 @@
+# contributed by Simon Pintarelli, Anton Kozhevnikov and Luca Marsella (CSCS)
+easyblock = 'CMakeMake'
+
+name = 'libxc'
+version = '5.1.2'
+
+homepage = 'http://www.tddft.org/programs/octopus/wiki/index.php/Libxc'
+description = """Libxc is a library of exchange-correlation functionals for density-functional theory.
+ The aim is to provide a portable, well tested and reliable set of exchange and correlation functionals."""
+
+toolchain = {'name': 'CrayGNU', 'version': '20.11'}
+toolchainopts = {'opt': True}
+
+source_urls = ['https://www.tddft.org/programs/%(name)s/down.php?file=%(version)s']
+sources = [SOURCE_TAR_GZ]
+#checksums = ['a8ee37ddc5079339854bd313272856c9d41a27802472ee9ae44b58ee9a298337']
+
+builddependencies = [
+    ('CMake', '3.14.5', '', True),
+]
+
+configopts = [
+    " -DENABLE_FORTRAN=ON -DENABLE_FORTRAN03=ON -DCMAKE_INSTALL_LIBDIR=lib ",
+    " -DENABLE_FORTRAN=ON -DENABLE_FORTRAN03=ON -DCMAKE_INSTALL_LIBDIR=lib  -DBUILD_SHARED_LIBS=ON ",
+]
+
+# add func_reference.c to CMakeLists.txt https://gitlab.com/libxc/libxc/-/issues/91
+#prebuildopts = ' sed -i "/func_info.c/a func_reference.c" %(builddir)s/%(name)s-%(version)s/CMakeLists.txt && '
+
+
+sanity_check_paths = {
+    'files': ['lib/%(name)s.a', 'lib/%(name)s.so', 'lib/libxcf03.a', 'lib/libxcf03.so', 'lib/libxcf90.a', 'lib/libxcf90.so'],
+    'dirs': ['include'],
+}
+
+moduleclass = 'chem'

--- a/easybuild/easyconfigs/q/QuantumESPRESSO/QuantumESPRESSO-SIRIUS-6.7-rc1-CrayGNU-20.11-cuda.eb
+++ b/easybuild/easyconfigs/q/QuantumESPRESSO/QuantumESPRESSO-SIRIUS-6.7-rc1-CrayGNU-20.11-cuda.eb
@@ -1,0 +1,39 @@
+# created by Anton Kozhevnikov (CSCS)
+# modified by Simon Pintarelli (CSCS)
+easyblock = 'CMakeMake'
+
+name = 'QuantumESPRESSO-SIRIUS'
+version = '6.7-rc1'
+versionsuffix = '-cuda'
+
+homepage = 'https://github.com/electronic-structure/q-e-sirius/'
+description = " SIRIUS-enabled version of Quantum ESPRESSO "
+
+toolchain = {'name': 'CrayGNU', 'version': '20.11'}
+toolchainopts = {'opt': True, 'usempi': True, 'pic': True, 'verbose': False, 'openmp': True}
+
+sources = ['https://github.com/electronic-structure/q-e-sirius/archive/v%(version)s-sirius.tar.gz']
+
+builddependencies = [
+    ('CMake', '3.14.5', '', True),
+    ('cudatoolkit', EXTERNAL_MODULE),
+    ('intel/19.1.1.217', EXTERNAL_MODULE)
+]
+
+dependencies = [
+    ('SIRIUS', '7.2.0', '-cuda')
+]
+
+preconfigopts = "module unload cray-libsci && module load gcc/9.3.0 && module list &&  CC=cc FC=ftn CPP=cpp MPIF90=ftn "
+configopts = "-DQE_ENABLE_OPENMP=1 -DQE_ENABLE_SIRIUS=1 -DQE_ENABLE_SCALAPACK=1"
+
+prebuildopts = "module unload cray-libsci && module unload cray-libsci_acc && module load gcc/9.3.0 && module list &&"
+
+buildopts = 'pw'
+
+sanity_check_paths = {
+    'files': ['bin/pw.x'],
+    'dirs': [''],
+}
+
+moduleclass = 'chem'

--- a/easybuild/easyconfigs/s/SIRIUS/SIRIUS-7.2.0-CrayGNU-20.11-cuda.eb
+++ b/easybuild/easyconfigs/s/SIRIUS/SIRIUS-7.2.0-CrayGNU-20.11-cuda.eb
@@ -1,0 +1,38 @@
+# created by Anton Kozhevnikov (CSCS)
+easyblock = 'CMakeMake'
+
+name = 'SIRIUS'
+version = '7.2.0'
+versionsuffix = '-cuda'
+
+homepage = 'https://electronic-structure.github.io/SIRIUS/'
+description = "Domain specific library for electronic structure calculations."
+
+toolchain = {'name': 'CrayGNU', 'version': '20.11'}
+toolchainopts = {'opt': True, 'usempi': True, 'pic': True, 'verbose': False, 'openmp': True}
+
+source_urls = ['https://github.com/electronic-structure/%(name)s/archive/']
+sources = ['v%(version)s.tar.gz']
+
+builddependencies = [
+    ('CMake', '3.14.5', '', True),
+    ('cudatoolkit', EXTERNAL_MODULE),
+    ('intel/19.1.1.217', EXTERNAL_MODULE)
+]
+
+dependencies = [
+    ('cray-hdf5', EXTERNAL_MODULE),
+    ('GSL', '2.6'),
+    ('libxc', '5.1.2'),
+    ('SpFFT', '1.0.1', '-cuda-mkl'),
+    ('spglib', '1.16.0'),
+    ('SPLA', '1.3.0', '-cuda-mkl')
+]
+
+configopts = "-DUSE_CUDA=1 -DBUILD_TESTS=0 -DUSE_MAGMA=0 -DUSE_MKL=1 -DUSE_SCALAPACK=0 -DUSE_ELPA=0 -DGPU_MODEL='P100' -DSpFFT_DIR=$EBROOTSPFFT/lib64/cmake/SpFFT"
+
+prebuildopts = "module unload cray-libsci && module unload cray-libsci_acc && module load gcc/9.3.0 && module list &&"
+
+modextrapaths = {'CPATH': ['include/%(namelower)s']}
+
+moduleclass = 'chem'

--- a/easybuild/easyconfigs/s/SPLA/SPLA-1.3.0-CrayGNU-20.11-cuda-mkl.eb
+++ b/easybuild/easyconfigs/s/SPLA/SPLA-1.3.0-CrayGNU-20.11-cuda-mkl.eb
@@ -1,0 +1,34 @@
+easyblock = 'CMakeMake'
+
+name = 'SPLA'
+version = '1.3.0'
+versionsuffix = '-cuda-mkl'
+
+homepage = 'https://github.com/eth-cscs/spla'
+description = """Specialized Parallel Linear Algebra"""
+
+toolchain = {'name': 'CrayGNU', 'version': '20.11'}
+toolchainopts = {'usempi': True, 'openmp': True, 'pic': True, 'verbose': False, 'opt': True}
+
+source_urls = ['https://github.com/eth-cscs/spla/archive']
+sources = ['v%(version)s.tar.gz']
+
+builddependencies = [('CMake', '3.14.5', '', True)]
+
+dependencies = [
+  ('cudatoolkit', EXTERNAL_MODULE),
+  ('intel/19.1.1.217', EXTERNAL_MODULE),
+]
+
+separate_build_dir = True
+
+prebuildopts = [ ]
+
+configopts = "-DCMAKE_BUILD_TYPE=RELEASE -DSPLA_GPU_BACKEND=CUDA -DSPLA_OMP=ON -DSPLA_BLAS_MKL=ON"
+
+moduleclass = 'lib'
+
+sanity_check_paths = {
+    'files': ['lib/libspla.so', 'include/spla/config.h', 'include/spla/spla.hpp'],
+    'dirs': []
+}

--- a/easybuild/easyconfigs/s/SpFFT/SpFFT-1.0.1-CrayGNU-20.11-cuda-mkl.eb
+++ b/easybuild/easyconfigs/s/SpFFT/SpFFT-1.0.1-CrayGNU-20.11-cuda-mkl.eb
@@ -1,0 +1,34 @@
+easyblock = 'CMakeMake'
+
+name = 'SpFFT'
+version = '1.0.1'
+versionsuffix = '-cuda-mkl'
+
+homepage = 'https://github.com/eth-cscs/SpFFT'
+description = """Sparse 3D FFT library with MPI, OpenMP, CUDA and ROCm support"""
+
+toolchain = {'name': 'CrayGNU', 'version': '20.11'}
+toolchainopts = {'usempi': True, 'openmp': True, 'pic': True, 'verbose': False, 'opt': True}
+
+source_urls = ['https://github.com/eth-cscs/SpFFT/archive']
+sources = ['v%(version)s.tar.gz']
+
+builddependencies = [('CMake', '3.14.5', '', True)]
+
+dependencies = [
+  ('cudatoolkit', EXTERNAL_MODULE),
+  ('intel/19.1.1.217', EXTERNAL_MODULE),
+]
+
+separate_build_dir = True
+
+prebuildopts = [ ]
+
+configopts = "-DCMAKE_BUILD_TYPE=RELEASE -DSPFFT_GPU_BACKEND=CUDA -DSPFFT_SINGLE_PRECISION=ON -DSPFFT_MPI=ON -DSPFFT_OMP=ON"
+
+moduleclass = 'lib'
+
+sanity_check_paths = {
+    'files': ['lib/libspfft.so', 'include/spfft/config.h', 'include/spfft/spfft.hpp'],
+    'dirs': []
+}


### PR DESCRIPTION
This should be a solution to fix 
https://github.com/eth-cscs/production/pull/2228 
and 
https://github.com/eth-cscs/production/pull/2199
We just update to the latest version of the code. However, there is a problem. QE now uses CMake in combination with git submodules (for example, `qe_git_submodule_update(external/fox)`). This means that it can be easily installed from the git repository and not so easily from the tar.gz release if the submodules are available as external packages (I'm not sure it will even work). So the QE EB recipe must be changed to fetch the source from our git development branch. I know it's a path towards a rolling release model, but that should also be supported in our way of deploying software.