### PR TITLE
[daint-mc] Materials were missing from install dir

### DIFF
--- a/easybuild/easyconfigs/p/ParaView/ParaView-5.9.0-CrayGNU-20.11-OSMesa-python3.eb
+++ b/easybuild/easyconfigs/p/ParaView/ParaView-5.9.0-CrayGNU-20.11-OSMesa-python3.eb
@@ -35,7 +35,7 @@ maxparallel = 24
 modtclfooter = """
     prepend-path LD_LIBRARY_PATH /opt/python/%(pyver)s/lib
 """
-postinstallcmds = ['export GALLIUM_DRIVER=swr;']
+postinstallcmds = ['export GALLIUM_DRIVER=swr; mkdir -p %(installdir)s/share/paraview-5.9 && cd %(installdir)s/share/paraview-5.9 && git clone https://gitlab.kitware.com/paraview/materials']
 
 sanity_check_paths = {
     'files': ['bin/pvbatch', 'bin/pvserver'],


### PR DESCRIPTION
== COMPLETED: Installation ended successfully (took 25 min 35 sec)
== Results of the build can be found in the log file(s) /scratch/snx3000/jfavre/daint/software/ParaView/5.9.0-CrayGNU-20.11-OSMesa-python3/easybuild/easybuild-ParaView-5.9.0-20210323.203118.log
