### PR TITLE
[daint] Update Boost recipes to 20.11 toolchains

### DIFF
--- a/easybuild/easyconfigs/b/Boost/Boost-1.75.0-CrayCCE-20.11.eb
+++ b/easybuild/easyconfigs/b/Boost/Boost-1.75.0-CrayCCE-20.11.eb
@@ -1,0 +1,29 @@
+# contributed by Luca Marsella (CSCS)
+name = 'Boost'
+version = "1.75.0"
+
+homepage = 'http://www.boost.org/'
+description = """
+    Boost provides free peer-reviewed portable C++ source libraries.
+"""
+
+toolchain = {'name': 'CrayCCE', 'version': '20.11'}
+toolchainopts = {'usempi': True, 'pic': True, 'verbose': False}
+
+source_urls = [SOURCEFORGE_SOURCE]
+sources = ['%(namelower)s_1_75_0.tar.gz']
+
+dependencies = [
+    ('bzip2', '1.0.8'),
+    ('zlib', '1.2.11'),
+]
+
+configopts = '--without-libraries=python'
+
+toolset = 'clang'
+
+boost_mpi = True
+
+modextravars = {'BOOST_ROOT': '%(installdir)s'}
+
+moduleclass = 'devel'

--- a/easybuild/easyconfigs/b/Boost/Boost-1.75.0-CrayIntel-20.11.eb
+++ b/easybuild/easyconfigs/b/Boost/Boost-1.75.0-CrayIntel-20.11.eb
@@ -1,0 +1,28 @@
+# contributed by Luca Marsella (CSCS)
+name = 'Boost'
+version = '1.75.0'
+
+homepage = 'http://www.boost.org/'
+description = """
+    Boost provides free peer-reviewed portable C++ source libraries.
+"""
+
+toolchain = {'name': 'CrayIntel', 'version': '20.11'}
+toolchainopts = {'pic': True, 'usempi': True, 'verbose': False}
+
+sources = ['%%(namelower)s_%s.tar.bz2' % '_'.join(version.split('.'))]
+source_urls = ['https://dl.bintray.com/boostorg/release/%(version)s/source/']
+
+dependencies = [
+    ('bzip2', '1.0.6'),
+    ('zlib', '1.2.11'),
+]
+
+configopts = '--without-libraries=python'
+boost_mpi = True
+
+modextravars = {
+    'BOOST_ROOT' : "%(installdir)s",
+}
+
+moduleclass = 'devel'

--- a/easybuild/easyconfigs/b/bzip2/bzip2-1.0.8-CrayCCE-20.11.eb
+++ b/easybuild/easyconfigs/b/bzip2/bzip2-1.0.8-CrayCCE-20.11.eb
@@ -1,0 +1,37 @@
+# contributed by Luca Marsella (CSCS), Samuel Omlin (CSCS)
+name = 'bzip2'
+version = '1.0.8'
+
+homepage = 'http://www.bzip.org/'
+description = """
+    bzip2 is a freely available, patent free, high-quality data compressor. It
+    typically compresses files to within 10% to 15% of the best available
+    techniques (the PPM family of statistical compressors), whilst being around
+    twice as fast at compression and six times faster at decompression.
+"""
+
+toolchain = {'name': 'CrayCCE', 'version': '20.11'}
+toolchainopts = {'pic': True}
+
+source_urls = ['https://sourceware.org/pub/%(namelower)s/']
+sources = [SOURCE_TAR_GZ]
+
+# create pkgconfig file
+postinstallcmds = [
+    "mkdir %(installdir)s/lib/pkgconfig",
+    """echo -e "prefix=%(installdir)s
+libdir=\${prefix}/lib
+includedir=\${prefix}/include
+
+Name: %(name)s
+Description: %(name)s compression library
+Version: %(version)s
+
+Requires:
+Libs: -L\${libdir} -lbz2
+Cflags: -I\${includedir}" > %(installdir)s/lib/pkgconfig/%(name)s.pc""",
+]
+
+# prepend PKG_CONFIG_PATH: EasyBuild does this automatically
+# modextrapaths = {'PKG_CONFIG_PATH': ['lib/pkgconfig']}
+moduleclass = 'lib'

--- a/easybuild/easyconfigs/b/bzip2/bzip2-1.0.8-CrayIntel-20.11.eb
+++ b/easybuild/easyconfigs/b/bzip2/bzip2-1.0.8-CrayIntel-20.11.eb
@@ -1,0 +1,37 @@
+# contributed by Luca Marsella (CSCS), Samuel Omlin (CSCS)
+name = 'bzip2'
+version = '1.0.8'
+
+homepage = 'http://www.bzip.org/'
+description = """
+    bzip2 is a freely available, patent free, high-quality data compressor. It
+    typically compresses files to within 10% to 15% of the best available
+    techniques (the PPM family of statistical compressors), whilst being around
+    twice as fast at compression and six times faster at decompression.
+"""
+
+toolchain = {'name': 'CrayIntel', 'version': '20.11'}
+toolchainopts = {'pic': True}
+
+source_urls = ['https://sourceware.org/pub/%(namelower)s/']
+sources = [SOURCE_TAR_GZ]
+
+# create pkgconfig file
+postinstallcmds = [
+    "mkdir %(installdir)s/lib/pkgconfig",
+    """echo -e "prefix=%(installdir)s
+libdir=\${prefix}/lib
+includedir=\${prefix}/include
+
+Name: %(name)s
+Description: %(name)s compression library
+Version: %(version)s
+
+Requires:
+Libs: -L\${libdir} -lbz2
+Cflags: -I\${includedir}" > %(installdir)s/lib/pkgconfig/%(name)s.pc""",
+]
+
+# prepend PKG_CONFIG_PATH: EasyBuild does this automatically
+# modextrapaths = {'PKG_CONFIG_PATH': ['lib/pkgconfig']}
+moduleclass = 'lib'

--- a/easybuild/easyconfigs/z/zlib/zlib-1.2.11-CrayCCE-20.11.eb
+++ b/easybuild/easyconfigs/z/zlib/zlib-1.2.11-CrayCCE-20.11.eb
@@ -1,0 +1,26 @@
+# contributed by Luca Marsella (CSCS)
+easyblock = 'ConfigureMake'
+
+name = 'zlib'
+version = '1.2.11'
+
+homepage = 'http://www.zlib.net/'
+description = """
+    zlib is designed to be a free, general-purpose, legally unencumbered --
+    that is, not covered by any patents -- lossless data-compression library
+    for use on virtually any computer hardware and operating system.
+"""
+
+toolchain = {'name': 'CrayCCE', 'version': '20.11'}
+toolchainopts = {'pic': True, 'dynamic': True}
+
+source_urls = [('http://sourceforge.net/projects/libpng/files/%(name)s/%(version)s', 'download')]
+sources = [SOURCELOWER_TAR_GZ]
+
+
+sanity_check_paths = {
+    'files': ['include/zconf.h', 'include/%(name)s.h', 'lib/libz.a', 'lib/libz.so'],
+    'dirs': [],
+}
+
+moduleclass = 'lib'

--- a/jenkins-builds/7.0.UP02-20.11-daint-gpu
+++ b/jenkins-builds/7.0.UP02-20.11-daint-gpu
@@ -1,6 +1,9 @@
  Amber-20-11-7-CrayIntel-20.11-cuda.eb                  --set-default-module
  Boost-1.70.0-CrayGNU-20.11-python3.eb                  --set-default-module
  Boost-1.70.0-CrayGNU-20.11.eb
+ Boost-1.75.0-CrayCCE-20.11.eb
+ Boost-1.75.0-CrayGNU-20.11.eb
+ Boost-1.75.0-CrayIntel-20.11.eb
  Buildah-1.14.9.eb
  CDO-1.9.5-CrayGNU-20.11.eb                             --set-default-module
  CDO-1.9.5-CrayIntel-20.11.eb

--- a/jenkins-builds/7.0.UP02-20.11-daint-mc
+++ b/jenkins-builds/7.0.UP02-20.11-daint-mc
@@ -1,6 +1,9 @@
  Amber-20-11-7-CrayIntel-20.11.eb                       --set-default-module
  Boost-1.70.0-CrayGNU-20.11-python3.eb                  --set-default-module
  Boost-1.70.0-CrayGNU-20.11.eb
+ Boost-1.75.0-CrayCCE-20.11.eb
+ Boost-1.75.0-CrayGNU-20.11.eb
+ Boost-1.75.0-CrayIntel-20.11.eb
  Buildah-1.14.9.eb                                      --set-default-module
  CDO-1.9.5-CrayGNU-20.11.eb                             --set-default-module
  CDO-1.9.5-CrayIntel-20.11.eb


### PR DESCRIPTION
Also add them to production lists.

I haven't tested the CrayCCE recipe (I'm assuming the two others will work just fine). Hoping to have CI tell me if I've done something wrong.