### PR TITLE
[dom daint] Deploy h5py 3.2.1 on dom/daint

### DIFF
--- a/jenkins-builds/7.0.UP02-20.11-daint-gpu
+++ b/jenkins-builds/7.0.UP02-20.11-daint-gpu
@@ -27,6 +27,8 @@
  hub-2.14.2.eb                                          --set-default-module
  h5py-2.10.0-CrayGNU-20.11-python3-parallel.eb          --set-default-module
  h5py-2.10.0-CrayGNU-20.11-python3-serial.eb
+ h5py-3.2.1-CrayGNU-20.11-python3-parallel.eb
+ h5py-3.2.1-CrayGNU-20.11-python3-serial.eb
  hwloc-2.4.1.eb                                         --set-default-module
  IDL-8.5.1.eb                                           --set-default-module
  IDL-8.7.2-CSCS.eb

--- a/jenkins-builds/7.0.UP02-20.11-daint-mc
+++ b/jenkins-builds/7.0.UP02-20.11-daint-mc
@@ -26,6 +26,8 @@
  hub-2.14.2.eb                                          --set-default-module
  h5py-2.10.0-CrayGNU-20.11-python3-parallel.eb          --set-default-module
  h5py-2.10.0-CrayGNU-20.11-python3-serial.eb
+ h5py-3.2.1-CrayGNU-20.11-python3-parallel.eb
+ h5py-3.2.1-CrayGNU-20.11-python3-serial.eb
  hwloc-2.4.1.eb                                         --set-default-module
  IDL-8.5.1.eb                                           --set-default-module
  IDL-8.7.2-CSCS.eb

--- a/jenkins-builds/7.0.UP02-20.11-dom-gpu
+++ b/jenkins-builds/7.0.UP02-20.11-dom-gpu
@@ -24,6 +24,8 @@
  hub-2.14.2.eb                                          --set-default-module
  h5py-2.10.0-CrayGNU-20.11-python3-parallel.eb          --set-default-module
  h5py-2.10.0-CrayGNU-20.11-python3-serial.eb
+ h5py-3.2.1-CrayGNU-20.11-python3-parallel.eb
+ h5py-3.2.1-CrayGNU-20.11-python3-serial.eb
  hwloc-2.4.1.eb                                         --set-default-module
  IDL-8.5.1.eb                                           --set-default-module
  IDL-8.7.2-CSCS.eb

--- a/jenkins-builds/7.0.UP02-20.11-dom-gpu
+++ b/jenkins-builds/7.0.UP02-20.11-dom-gpu
@@ -22,9 +22,7 @@
  HPX-1.5.0-CrayGNU-20.11-APEX-cuda.eb
  HPX-1.5.0-CrayGNU-20.11-nonetworking-cuda.eb
  hub-2.14.2.eb                                          --set-default-module
- h5py-2.10.0-CrayGNU-20.11-python3-parallel.eb          --set-default-module
- h5py-2.10.0-CrayGNU-20.11-python3-serial.eb
- h5py-3.2.1-CrayGNU-20.11-python3-parallel.eb
+ h5py-3.2.1-CrayGNU-20.11-python3-parallel.eb           --set-default-module
  h5py-3.2.1-CrayGNU-20.11-python3-serial.eb
  hwloc-2.4.1.eb                                         --set-default-module
  IDL-8.5.1.eb                                           --set-default-module

--- a/jenkins-builds/7.0.UP02-20.11-dom-mc
+++ b/jenkins-builds/7.0.UP02-20.11-dom-mc
@@ -23,6 +23,8 @@
  hub-2.14.2.eb                                          --set-default-module
  h5py-2.10.0-CrayGNU-20.11-python3-parallel.eb          --set-default-module
  h5py-2.10.0-CrayGNU-20.11-python3-serial.eb
+ h5py-3.2.1-CrayGNU-20.11-python3-parallel.eb
+ h5py-3.2.1-CrayGNU-20.11-python3-serial.eb
  hwloc-2.4.1.eb                                         --set-default-module
  IDL-8.5.1.eb                                           --set-default-module
  IDL-8.7.2-CSCS.eb

--- a/jenkins-builds/7.0.UP02-20.11-dom-mc
+++ b/jenkins-builds/7.0.UP02-20.11-dom-mc
@@ -21,9 +21,7 @@
  HPX-1.5.0-CrayGNU-20.11-APEX.eb
  HPX-1.5.0-CrayGNU-20.11-nonetworking.eb
  hub-2.14.2.eb                                          --set-default-module
- h5py-2.10.0-CrayGNU-20.11-python3-parallel.eb          --set-default-module
- h5py-2.10.0-CrayGNU-20.11-python3-serial.eb
- h5py-3.2.1-CrayGNU-20.11-python3-parallel.eb
+ h5py-3.2.1-CrayGNU-20.11-python3-parallel.eb           --set-default-module
  h5py-3.2.1-CrayGNU-20.11-python3-serial.eb
  hwloc-2.4.1.eb                                         --set-default-module
  IDL-8.5.1.eb                                           --set-default-module


### PR DESCRIPTION
I am not deploynd as default yet since this is also introduces a major release difference.