### PR TITLE
[eiger] Fix Amber and NCO with PE 21.03

### DIFF
--- a/easybuild/easyconfigs/a/Amber/Amber-20-15-9-cpeIntel-21.03.eb
+++ b/easybuild/easyconfigs/a/Amber/Amber-20-15-9-cpeIntel-21.03.eb
@@ -17,21 +17,21 @@ sources = [
     '/apps/common/UES/easybuild/sources/a/%(name)s/AmberTools20.tar.bz2',
 ]
 
-builddependencies = [
-    ('cray-hdf5', EXTERNAL_MODULE),
-    # ('cray-netcdf', EXTERNAL_MODULE),
-]
+# cray-hdf5 and cray-netcdf are not available with PrgEnv-intel with cpe/21.04
+#builddependencies = [
+#     ('cray-hdf5', EXTERNAL_MODULE),
+#     ('cray-netcdf', EXTERNAL_MODULE),
+#]
+
 dependencies = [
     ('bzip2', '1.0.8'),
-    ('zlib', '1.2.11'),
+    ('zlib', '1.2.11')
 ]
 
-# single make process since parallel builds might fail
-# when uncommenting the next line make sure to change all make -j to make -j1
+# single make process since parallel builds might fail:
+# if you uncomment the next line, change every "make -j" to "make -j1"
 # maxparallel = 1
 
-# prebuildopts  = "module unload cray-libsci && module unload cray-libsci_acc && module load gcc/8.3.0 && "
-# prebuildopts  = "module swap gcc gcc/9.3.0 && "
 prebuildopts = "cd .. && mv amber20_src/* . && export AMBER_SOURCE=%(builddir)s && export AMBER_PREFIX=%(installdir)s && export AMBER_HOME=%(installdir)s && ./update_amber --update-to=AmberTools.15,%(name)s.9 && ./configure       -noX11 --skip-python intel <<< N && find . -name 'config.h' -exec sed -i -e 's/-h msglevel_2//g' '{}' \\; && find . -name 'config.h' -exec sed -i -e 's/-h gnu//g' '{}' \\; && find . -name 'external.config.h' -exec sed -i -e 's/-h msglevel_2//g' '{}' \\; && find . -name 'external.config.h' -exec sed -i -e 's/-h gnu//g' '{}' \\; && make -j && make install && ./configure       -noX11 -openmp --skip-python intel <<< N && find . -name 'config.h' -exec sed -i -e 's/-h msglevel_2//g' '{}' \\; && find . -name 'config.h' -exec sed -i -e 's/-h gnu//g' '{}' \\; && find . -name 'external.config.h' -exec sed -i -e 's/-h msglevel_2//g' '{}' \\; && find . -name 'external.config.h' -exec sed -i -e 's/-h gnu//g' '{}' \\; && make -j && make install && ./configure -mpi  -noX11 -openmp --skip-python intel <<< N && find . -name 'config.h' -exec sed -i -e 's/-h msglevel_2//g' '{}' \\; && find . -name 'config.h' -exec sed -i -e 's/-h gnu//g' '{}' \\; && find . -name 'external.config.h' -exec sed -i -e 's/-h msglevel_2//g' '{}' \\; && find . -name 'external.config.h' -exec sed -i -e 's/-h gnu//g' '{}' \\; && make -j && make install && ./configure -mpi  -noX11         --skip-python intel <<< N && find . -name 'config.h' -exec sed -i -e 's/-h msglevel_2//g' '{}' \\; && find . -name 'config.h' -exec sed -i -e 's/-h gnu//g' '{}' \\; && find . -name 'external.config.h' -exec sed -i -e 's/-h msglevel_2//g' '{}' \\; && find . -name 'external.config.h' -exec sed -i -e 's/-h gnu//g' '{}' \\; && make -j && make install && "
 buildopts = 'install'
 

--- a/easybuild/easyconfigs/j/JasPer/JasPer-2.0.32-cpeGNU-21.03.eb
+++ b/easybuild/easyconfigs/j/JasPer/JasPer-2.0.32-cpeGNU-21.03.eb
@@ -1,0 +1,30 @@
+# Contributed by Jean-Guillaume Piccinali, Samuel Omlin and Luca Marsella (CSCS)
+easyblock = 'CMakeMake'
+
+name = 'JasPer'
+version = '2.0.32'
+
+homepage = 'http://www.ece.uvic.ca/~frodo/jasper/'
+description = """The JasPer Project is an open-source initiative to provide a free
+ software-based reference implementation of the codec specified in the JPEG-2000 Part-1 standard."""
+
+toolchain = {'name': 'cpeGNU', 'version': '21.03'}
+toolchainopts = {'pic': True}
+
+source_urls = ['https://github.com/%(namelower)s-software/%(namelower)s/archive/']
+sources = ['version-%(version)s.tar.gz']
+
+builddependencies = [
+    ('CMake', '3.20.1', '', True),
+]
+
+configopts = '-DJAS_ENABLE_DOC=FALSE'
+
+separate_build_dir = 'True'
+
+sanity_check_paths = {
+    'files': ['bin/%(namelower)s', 'lib64/libjasper.so'],
+    'dirs': ['include'],
+}
+
+moduleclass = 'vis'

--- a/easybuild/easyconfigs/n/NCO/NCO-4.9.8-cpeGNU-21.03.eb
+++ b/easybuild/easyconfigs/n/NCO/NCO-4.9.8-cpeGNU-21.03.eb
@@ -2,12 +2,12 @@
 easyblock = 'ConfigureMake'
 
 name = 'NCO'
-version = '4.9.7'
+version = '4.9.8'
 
 homepage = 'http://nco.sourceforge.net/'
 description = "The NCO toolkit manipulates and analyzes data stored in netCDF-accessible formats, including DAP, HDF4, and HDF5."
 
-toolchain = {'name': 'cpeGNU', 'version': '21.02'}
+toolchain = {'name': 'cpeGNU', 'version': '21.03'}
 toolchainopts = {'opt': True, 'pic': True}
 
 sources = ['https://github.com/%(namelower)s/%(namelower)s/archive/%(version)s.tar.gz']
@@ -16,7 +16,7 @@ dependencies = [
     ('ANTLR', '2.7.7', '-python3'),
     ('cray-hdf5', EXTERNAL_MODULE),
     ('cray-netcdf', EXTERNAL_MODULE),
-    ('JasPer', '2.0.25'),
+    ('JasPer', '2.0.32'),
     ('UDUNITS', '2.2.28')
 ]
 


### PR DESCRIPTION
Remove `cray-hdf5` from Amber since it's not provided by `cpeIntel 21.04` and fix NCO filename (tested in https://jenkins.cscs.ch/blue/organizations/jenkins/UpdateEB/detail/UpdateEB/2/pipeline/, therefore it will be merged immediately).