### PR TITLE
[daint] Update 7.0.UP02-20.11-daint-gpu

### DIFF
--- a/jenkins-builds/7.0.UP02-20.11-daint-gpu
+++ b/jenkins-builds/7.0.UP02-20.11-daint-gpu
@@ -34,10 +34,8 @@
  IDL-8.7.2-CSCS.eb
  ipcmagic-0.1-CrayGNU-20.11.eb                          --set-default-module
  ipcmagic-1.0.1-CrayGNU-20.11.eb 
- Julia-1.6.0-CrayGNU-20.11-cuda.eb                      --set-default-module
- Julia-1.5.0-CrayGNU-20.11-cuda.eb                      
- JuliaExtensions-1.6.0-CrayGNU-20.11-cuda.eb            --set-default-module
- JuliaExtensions-1.5.0-CrayGNU-20.11-cuda.eb            
+ Julia-1.6.0-CrayGNU-20.11-cuda.eb                      --set-default-module                   
+ JuliaExtensions-1.6.0-CrayGNU-20.11-cuda.eb            --set-default-module 
  jupyterlab-1.1.1-CrayGNU-20.11-batchspawner.eb         --set-default-module
  jupyterlab-1.2.16-CrayGNU-20.11-batchspawner-cuda.eb
  jupyterlab-2.0.2-CrayGNU-20.11-batchspawner-cuda.eb

--- a/jenkins-builds/7.0.UP02-20.11-daint-gpu
+++ b/jenkins-builds/7.0.UP02-20.11-daint-gpu
@@ -34,10 +34,10 @@
  IDL-8.7.2-CSCS.eb
  ipcmagic-0.1-CrayGNU-20.11.eb                          --set-default-module
  ipcmagic-1.0.1-CrayGNU-20.11.eb 
- Julia-1.6.0-CrayGNU-20.11-cuda.eb                      
- Julia-1.5.0-CrayGNU-20.11-cuda.eb                      --set-default-module
- JuliaExtensions-1.6.0-CrayGNU-20.11-cuda.eb            
- JuliaExtensions-1.5.0-CrayGNU-20.11-cuda.eb            --set-default-module
+ Julia-1.6.0-CrayGNU-20.11-cuda.eb                      --set-default-module
+ Julia-1.5.0-CrayGNU-20.11-cuda.eb                      
+ JuliaExtensions-1.6.0-CrayGNU-20.11-cuda.eb            --set-default-module
+ JuliaExtensions-1.5.0-CrayGNU-20.11-cuda.eb            
  jupyterlab-1.1.1-CrayGNU-20.11-batchspawner.eb         --set-default-module
  jupyterlab-1.2.16-CrayGNU-20.11-batchspawner-cuda.eb
  jupyterlab-2.0.2-CrayGNU-20.11-batchspawner-cuda.eb

--- a/jenkins-builds/7.0.UP02-20.11-daint-mc
+++ b/jenkins-builds/7.0.UP02-20.11-daint-mc
@@ -33,10 +33,10 @@
  IDL-8.7.2-CSCS.eb
  ipcmagic-0.1-CrayGNU-20.11.eb                          --set-default-module
  ipcmagic-1.0.1-CrayGNU-20.11.eb 
- Julia-1.6.0-CrayGNU-20.11.eb                           
- Julia-1.5.0-CrayGNU-20.11.eb                           --set-default-module
- JuliaExtensions-1.6.0-CrayGNU-20.11.eb                 
- JuliaExtensions-1.5.0-CrayGNU-20.11.eb                 --set-default-module
+ Julia-1.6.0-CrayGNU-20.11.eb                           --set-default-module
+ Julia-1.5.0-CrayGNU-20.11.eb                           
+ JuliaExtensions-1.6.0-CrayGNU-20.11.eb                 --set-default-module
+ JuliaExtensions-1.5.0-CrayGNU-20.11.eb                 
  jupyter-utils-0.1.eb                                   --set-default-module
  jupyterlab-1.1.1-CrayGNU-20.11-batchspawner.eb         --set-default-module
  jupyterlab-1.2.16-CrayGNU-20.11-batchspawner.eb

--- a/jenkins-builds/7.0.UP02-20.11-daint-mc
+++ b/jenkins-builds/7.0.UP02-20.11-daint-mc
@@ -33,10 +33,8 @@
  IDL-8.7.2-CSCS.eb
  ipcmagic-0.1-CrayGNU-20.11.eb                          --set-default-module
  ipcmagic-1.0.1-CrayGNU-20.11.eb 
- Julia-1.6.0-CrayGNU-20.11.eb                           --set-default-module
- Julia-1.5.0-CrayGNU-20.11.eb                           
+ Julia-1.6.0-CrayGNU-20.11.eb                           --set-default-module                           
  JuliaExtensions-1.6.0-CrayGNU-20.11.eb                 --set-default-module
- JuliaExtensions-1.5.0-CrayGNU-20.11.eb                 
  jupyter-utils-0.1.eb                                   --set-default-module
  jupyterlab-1.1.1-CrayGNU-20.11-batchspawner.eb         --set-default-module
  jupyterlab-1.2.16-CrayGNU-20.11-batchspawner.eb

--- a/jenkins-builds/7.0.UP02-20.11-dom-gpu
+++ b/jenkins-builds/7.0.UP02-20.11-dom-gpu
@@ -28,10 +28,8 @@
  IDL-8.5.1.eb                                           --set-default-module
  IDL-8.7.2-CSCS.eb
  ipcmagic-1.0.1-CrayGNU-20.11.eb                        --set-default-module
- Julia-1.6.0-CrayGNU-20.11-cuda.eb                      --set-default-module
- Julia-1.5.0-CrayGNU-20.11-cuda.eb                      
- JuliaExtensions-1.6.0-CrayGNU-20.11-cuda.eb            --set-default-module
- JuliaExtensions-1.5.0-CrayGNU-20.11-cuda.eb            
+ Julia-1.6.0-CrayGNU-20.11.eb                           --set-default-module
+ JuliaExtensions-1.6.0-CrayGNU-20.11.eb                 --set-default-module
  jupyterlab-1.1.1-CrayGNU-20.11-batchspawner.eb         --set-default-module
  jupyterlab-1.2.16-CrayGNU-20.11-batchspawner-cuda.eb
  jupyterlab-2.0.2-CrayGNU-20.11-batchspawner-cuda.eb

--- a/jenkins-builds/7.0.UP02-20.11-dom-mc
+++ b/jenkins-builds/7.0.UP02-20.11-dom-mc
@@ -28,9 +28,7 @@
  IDL-8.7.2-CSCS.eb
  ipcmagic-1.0.1-CrayGNU-20.11.eb                       --set-default-module
  Julia-1.6.0-CrayGNU-20.11.eb                           --set-default-module
- Julia-1.5.0-CrayGNU-20.11.eb                           
  JuliaExtensions-1.6.0-CrayGNU-20.11.eb                 --set-default-module
- JuliaExtensions-1.5.0-CrayGNU-20.11.eb                 
  jupyter-utils-0.1.eb                                   --set-default-module
  jupyterlab-1.1.1-CrayGNU-20.11-batchspawner.eb         --set-default-module
  jupyterlab-1.2.16-CrayGNU-20.11-batchspawner.eb


### PR DESCRIPTION
This changes the default Julia to 1.6 which offers a bunch of enhancements, and very little regression.. if any! JupyterLab kernel is already at 1.6, so this will align termianl and jupyter behaviour nicely.