### PR TITLE
[dom] Drop xalt when loading julia, since it hijacks libcurl.so and is incompatible

### DIFF
--- a/easybuild/easyconfigs/j/Julia/Julia-1.6.0-CrayGNU-20.11-cuda.eb
+++ b/easybuild/easyconfigs/j/Julia/Julia-1.6.0-CrayGNU-20.11-cuda.eb
@@ -37,6 +37,13 @@ modextravars = {
     'JULIA_MPI_TEST_ARRAYTYPE': 'CuArray',
 }
 
-modtclfooter = "module unload cray-libsci_acc"
-
 moduleclass = 'lang'
+
+# Julia 1.6.0+ uses Downloads.jl with a vendored libcurl.so that's dlopen'ed.
+# See https://julialang.org/blog/2021/03/julia-1.6-highlights/#downloads_networkingoptions
+# xalt hijacks libcurl.so by setting LD_LIBRARY_PATH, which should be avoided,
+# as it is incompatible with the API Julia expects.
+modtclfooter = """
+module unload cray-libsci_acc
+module unload xalt
+"""

--- a/easybuild/easyconfigs/j/Julia/Julia-1.6.0-CrayGNU-20.11.eb
+++ b/easybuild/easyconfigs/j/Julia/Julia-1.6.0-CrayGNU-20.11.eb
@@ -27,3 +27,11 @@ modextravars = {
 }
 
 moduleclass = 'lang'
+
+# Julia 1.6.0+ uses Downloads.jl with a vendored libcurl.so that's dlopen'ed.
+# See https://julialang.org/blog/2021/03/julia-1.6-highlights/#downloads_networkingoptions
+# xalt hijacks libcurl.so by setting LD_LIBRARY_PATH, which should be avoided,
+# as it is incompatible with the API Julia expects.
+modtclfooter = """
+module unload xalt
+"""


### PR DESCRIPTION
xalt hijacks libcurl.so through LD_LIBRARY_PATH as julia tries to open a vendored version of the library.

This results in warning messages when using Downloads.jl (which is used by the package manager).

Julia has good reasons to vendor libcurl: https://julialang.org/blog/2021/03/julia-1.6-highlights/#downloads_networkingoptions

So we should drop xalt here.

Pinging @lucamar, @omlins, @gppezzi 