### PR TITLE
[daint] Bump default version of Julia to 1.6.0

### DIFF
--- a/jenkins-builds/7.0.UP02-20.11-daint-gpu
+++ b/jenkins-builds/7.0.UP02-20.11-daint-gpu
@@ -34,10 +34,10 @@
  IDL-8.7.2-CSCS.eb
  ipcmagic-0.1-CrayGNU-20.11.eb                          --set-default-module
  ipcmagic-1.0.1-CrayGNU-20.11.eb 
- Julia-1.6.0-CrayGNU-20.11-cuda.eb                      
- Julia-1.5.0-CrayGNU-20.11-cuda.eb                      --set-default-module
- JuliaExtensions-1.6.0-CrayGNU-20.11-cuda.eb            
- JuliaExtensions-1.5.0-CrayGNU-20.11-cuda.eb            --set-default-module
+ Julia-1.6.0-CrayGNU-20.11-cuda.eb                      --set-default-module
+ Julia-1.5.0-CrayGNU-20.11-cuda.eb
+ JuliaExtensions-1.6.0-CrayGNU-20.11-cuda.eb            --set-default-module
+ JuliaExtensions-1.5.0-CrayGNU-20.11-cuda.eb
  jupyterlab-1.1.1-CrayGNU-20.11-batchspawner.eb         --set-default-module
  jupyterlab-1.2.16-CrayGNU-20.11-batchspawner-cuda.eb
  jupyterlab-2.0.2-CrayGNU-20.11-batchspawner-cuda.eb

--- a/jenkins-builds/7.0.UP02-20.11-daint-mc
+++ b/jenkins-builds/7.0.UP02-20.11-daint-mc
@@ -33,10 +33,10 @@
  IDL-8.7.2-CSCS.eb
  ipcmagic-0.1-CrayGNU-20.11.eb                          --set-default-module
  ipcmagic-1.0.1-CrayGNU-20.11.eb 
- Julia-1.6.0-CrayGNU-20.11.eb                           
- Julia-1.5.0-CrayGNU-20.11.eb                           --set-default-module
- JuliaExtensions-1.6.0-CrayGNU-20.11.eb                 
- JuliaExtensions-1.5.0-CrayGNU-20.11.eb                 --set-default-module
+ Julia-1.6.0-CrayGNU-20.11.eb                           --set-default-module
+ Julia-1.5.0-CrayGNU-20.11.eb
+ JuliaExtensions-1.6.0-CrayGNU-20.11.eb                 --set-default-module
+ JuliaExtensions-1.5.0-CrayGNU-20.11.eb
  jupyter-utils-0.1.eb                                   --set-default-module
  jupyterlab-1.1.1-CrayGNU-20.11-batchspawner.eb         --set-default-module
  jupyterlab-1.2.16-CrayGNU-20.11-batchspawner.eb


### PR DESCRIPTION
1.6.0 is working just fine, and is a quite a bit faster compared to 1.5.x in terms of package manager, package precompilation, and compiler latency; so it'd be good to default to 1.6.0

Pinging @lucamar, @omlins, @gppezzi 