### PR TITLE
[daint] Update Spack config for version 0.16.1 on daint

### DIFF
--- a/spack/0.16.1/daint/config.yaml
+++ b/spack/0.16.1/daint/config.yaml
@@ -1,8 +1,8 @@
 config:
   build_jobs: 8
   build_stage:
-  - ${XDG_RUNTIME_DIR}/${RANDOM}
-  - $spack/.spack/var/stage/${RANDOM}
+  - ${XDG_RUNTIME_DIR}
+  - $spack/.spack/var/stage
   db_lock_timeout: 20
   misc_cache: $spack/.spack/var/cache/misc
   source_cache: $spack/.spack/var/cache/source

--- a/spack/0.16.1/daint/packages.yaml
+++ b/spack/0.16.1/daint/packages.yaml
@@ -46,7 +46,7 @@ packages:
       spec: automake@1.15.1
   bash:
     externals:
-    - prefix: /usr/local
+    - prefix: /
       spec: bash@4.4.23
   bison:
     externals:
@@ -60,7 +60,7 @@ packages:
     variants: +ipo+scalapack+cuda cuda_arch=60 build_type=Release
   cpio:
     externals:
-    - prefix: /usr
+    - prefix: /
       spec: cpio@2.12
   cray-fftw:
     buildable: false
@@ -253,7 +253,7 @@ packages:
         compilers:
           c: /usr/bin/gcc-7
           cxx: /usr/bin/g++
-          fortran: /usr/bin/gfortran
+          fortran: /usr/bin/gfortran-7
       prefix: /usr
       spec: gcc@7.5.0 languages=c,c++,fortran
   ghostscript:
@@ -452,60 +452,216 @@ packages:
     - modules:
       - cray-hdf5-parallel/1.12.0.0
       spec: netcdf@1.12.0.0 +parallel-netcdf+mpi %cce@11.0.0.20.11
-  netcdt-fortran:
+  netcdf-c:
     buildable: true
     externals:
     - modules:
-      - cray-hdf5-parallel/1.12.0.0
-      spec: netcdt-fortran@1.12.0.0 +parallel-netcdf+mpi %gcc@8.1.0.20.08
+      - cray-netcdf-hdf5parallel/4.7.4.0
+      spec: netcdf-c@4.7.4.0 +parallel-netcdf+mpi %gcc@8.1.0.20.08
     - modules:
-      - cray-hdf5-parallel/1.12.0.0
-      spec: netcdt-fortran@1.12.0.0 +parallel-netcdf+mpi %gcc@9.3.0.20.08
+      - cray-netcdf-hdf5parallel/4.7.4.0
+      spec: netcdf-c@4.7.4.0 +parallel-netcdf+mpi %gcc@9.3.0.20.08
     - modules:
-      - cray-hdf5-parallel/1.12.0.0
-      spec: netcdt-fortran@1.12.0.0 +parallel-netcdf+mpi %gcc@8.3.0.20.08
+      - cray-netcdf-hdf5parallel/4.7.4.0
+      spec: netcdf-c@4.7.4.0 +parallel-netcdf+mpi %gcc@8.3.0.20.08
     - modules:
-      - cray-hdf5-parallel/1.12.0.0
-      spec: netcdt-fortran@1.12.0.0 +parallel-netcdf+mpi %intel@19.0.1.144.20.08
+      - cray-netcdf-hdf5parallel/4.7.4.0
+      spec: netcdf-c@4.7.4.0 +parallel-netcdf+mpi %intel@19.0.1.144.20.08
     - modules:
-      - cray-hdf5-parallel/1.12.0.0
-      spec: netcdt-fortran@1.12.0.0 +parallel-netcdf+mpi %intel@19.1.1.217.20.08
+      - cray-netcdf-hdf5parallel/4.7.4.0
+      spec: netcdf-c@4.7.4.0 +parallel-netcdf+mpi %intel@19.1.1.217.20.08
     - modules:
-      - cray-hdf5-parallel/1.12.0.0
-      spec: netcdt-fortran@1.12.0.0 +parallel-netcdf+mpi %pgi@20.1.0.20.08
+      - cray-netcdf-hdf5parallel/4.7.4.0
+      spec: netcdf-c@4.7.4.0 +parallel-netcdf+mpi %pgi@20.1.0.20.08
     - modules:
-      - cray-hdf5-parallel/1.12.0.0
-      spec: netcdt-fortran@1.12.0.0 +parallel-netcdf+mpi %pgi@20.1.1.20.08
+      - cray-netcdf-hdf5parallel/4.7.4.0
+      spec: netcdf-c@4.7.4.0 +parallel-netcdf+mpi %pgi@20.1.1.20.08
     - modules:
-      - cray-hdf5-parallel/1.12.0.0
-      spec: netcdt-fortran@1.12.0.0 +parallel-netcdf+mpi %cce@10.0.2.20.08
+      - cray-netcdf-hdf5parallel/4.7.4.0
+      spec: netcdf-c@4.7.4.0 +parallel-netcdf+mpi %cce@10.0.2.20.08
     - modules:
-      - cray-hdf5-parallel/1.12.0.0
-      spec: netcdt-fortran@1.12.0.0 +parallel-netcdf+mpi %gcc@8.1.0.20.11
+      - cray-netcdf-hdf5parallel/4.7.4.0
+      spec: netcdf-c@4.7.4.0 +parallel-netcdf+mpi %gcc@8.1.0.20.11
     - modules:
-      - cray-hdf5-parallel/1.12.0.0
-      spec: netcdt-fortran@1.12.0.0 +parallel-netcdf+mpi %gcc@9.3.0.20.11
+      - cray-netcdf-hdf5parallel/4.7.4.0
+      spec: netcdf-c@4.7.4.0 +parallel-netcdf+mpi %gcc@9.3.0.20.11
     - modules:
-      - cray-hdf5-parallel/1.12.0.0
-      spec: netcdt-fortran@1.12.0.0 +parallel-netcdf+mpi %gcc@8.3.0.20.11
+      - cray-netcdf-hdf5parallel/4.7.4.0
+      spec: netcdf-c@4.7.4.0 +parallel-netcdf+mpi %gcc@8.3.0.20.11
     - modules:
-      - cray-hdf5-parallel/1.12.0.0
-      spec: netcdt-fortran@1.12.0.0 +parallel-netcdf+mpi %gcc@10.1.0.20.11
+      - cray-netcdf-hdf5parallel/4.7.4.0
+      spec: netcdf-c@4.7.4.0 +parallel-netcdf+mpi %gcc@10.1.0.20.11
     - modules:
-      - cray-hdf5-parallel/1.12.0.0
-      spec: netcdt-fortran@1.12.0.0 +parallel-netcdf+mpi %intel@19.0.1.144.20.11
+      - cray-netcdf-hdf5parallel/4.7.4.0
+      spec: netcdf-c@4.7.4.0 +parallel-netcdf+mpi %intel@19.0.1.144.20.11
     - modules:
-      - cray-hdf5-parallel/1.12.0.0
-      spec: netcdt-fortran@1.12.0.0 +parallel-netcdf+mpi %intel@19.1.1.217.20.11
+      - cray-netcdf-hdf5parallel/4.7.4.0
+      spec: netcdf-c@4.7.4.0 +parallel-netcdf+mpi %intel@19.1.1.217.20.11
     - modules:
-      - cray-hdf5-parallel/1.12.0.0
-      spec: netcdt-fortran@1.12.0.0 +parallel-netcdf+mpi %pgi@20.1.0.20.11
+      - cray-netcdf-hdf5parallel/4.7.4.0
+      spec: netcdf-c@4.7.4.0 +parallel-netcdf+mpi %pgi@20.1.0.20.11
     - modules:
-      - cray-hdf5-parallel/1.12.0.0
-      spec: netcdt-fortran@1.12.0.0 +parallel-netcdf+mpi %pgi@20.1.1.20.11
+      - cray-netcdf-hdf5parallel/4.7.4.0
+      spec: netcdf-c@4.7.4.0 +parallel-netcdf+mpi %pgi@20.1.1.20.11
     - modules:
-      - cray-hdf5-parallel/1.12.0.0
-      spec: netcdt-fortran@1.12.0.0 +parallel-netcdf+mpi %cce@11.0.0.20.11
+      - cray-netcdf-hdf5parallel/4.7.4.0
+      spec: netcdf-c@4.7.4.0 +parallel-netcdf+mpi %cce@11.0.0.20.11
+    - modules:
+      - cray-netcdf/4.7.4.0
+      spec: netcdf-c@4.7.4.0 ~parallel-netcdf+mpi %gcc@8.1.0.20.08
+    - modules:
+      - cray-netcdf/4.7.4.0
+      spec: netcdf-c@4.7.4.0 ~parallel-netcdf+mpi %gcc@9.3.0.20.08
+    - modules:
+      - cray-netcdf/4.7.4.0
+      spec: netcdf-c@4.7.4.0 ~parallel-netcdf+mpi %gcc@8.3.0.20.08
+    - modules:
+      - cray-netcdf/4.7.4.0
+      spec: netcdf-c@4.7.4.0 ~parallel-netcdf+mpi %intel@19.0.1.144.20.08
+    - modules:
+      - cray-netcdf/4.7.4.0
+      spec: netcdf-c@4.7.4.0 ~parallel-netcdf+mpi %intel@19.1.1.217.20.08
+    - modules:
+      - cray-netcdf/4.7.4.0
+      spec: netcdf-c@4.7.4.0 ~parallel-netcdf+mpi %pgi@20.1.0.20.08
+    - modules:
+      - cray-netcdf/4.7.4.0
+      spec: netcdf-c@4.7.4.0 ~parallel-netcdf+mpi %pgi@20.1.1.20.08
+    - modules:
+      - cray-netcdf/4.7.4.0
+      spec: netcdf-c@4.7.4.0 ~parallel-netcdf+mpi %cce@10.0.2.20.08
+    - modules:
+      - cray-netcdf/4.7.4.0
+      spec: netcdf-c@4.7.4.0 ~parallel-netcdf+mpi %gcc@8.1.0.20.11
+    - modules:
+      - cray-netcdf/4.7.4.0
+      spec: netcdf-c@4.7.4.0 ~parallel-netcdf+mpi %gcc@9.3.0.20.11
+    - modules:
+      - cray-netcdf/4.7.4.0
+      spec: netcdf-c@4.7.4.0 ~parallel-netcdf+mpi %gcc@8.3.0.20.11
+    - modules:
+      - cray-netcdf/4.7.4.0
+      spec: netcdf-c@4.7.4.0 ~parallel-netcdf+mpi %gcc@10.1.0.20.11
+    - modules:
+      - cray-netcdf/4.7.4.0
+      spec: netcdf-c@4.7.4.0 ~parallel-netcdf+mpi %intel@19.0.1.144.20.11
+    - modules:
+      - cray-netcdf/4.7.4.0
+      spec: netcdf-c@4.7.4.0 ~parallel-netcdf+mpi %intel@19.1.1.217.20.11
+    - modules:
+      - cray-netcdf/4.7.4.0
+      spec: netcdf-c@4.7.4.0 ~parallel-netcdf+mpi %pgi@20.1.0.20.11
+    - modules:
+      - cray-netcdf/4.7.4.0
+      spec: netcdf-c@4.7.4.0 ~parallel-netcdf+mpi %pgi@20.1.1.20.11
+    - modules:
+      - cray-netcdf/4.7.4.0
+      spec: netcdf-c@4.7.4.0 ~parallel-netcdf+mpi %cce@11.0.0.20.11
+  netcdf-fortran:
+    buildable: true
+    externals:
+    - modules:
+      - cray-netcdf-hdf5parallel/4.7.4.0
+      spec: netcdf-fortran@4.7.4.0 +parallel-netcdf+mpi %gcc@8.1.0.20.08
+    - modules:
+      - cray-netcdf-hdf5parallel/4.7.4.0
+      spec: netcdf-fortran@4.7.4.0 +parallel-netcdf+mpi %gcc@9.3.0.20.08
+    - modules:
+      - cray-netcdf-hdf5parallel/4.7.4.0
+      spec: netcdf-fortran@4.7.4.0 +parallel-netcdf+mpi %gcc@8.3.0.20.08
+    - modules:
+      - cray-netcdf-hdf5parallel/4.7.4.0
+      spec: netcdf-fortran@4.7.4.0 +parallel-netcdf+mpi %intel@19.0.1.144.20.08
+    - modules:
+      - cray-netcdf-hdf5parallel/4.7.4.0
+      spec: netcdf-fortran@4.7.4.0 +parallel-netcdf+mpi %intel@19.1.1.217.20.08
+    - modules:
+      - cray-netcdf-hdf5parallel/4.7.4.0
+      spec: netcdf-fortran@4.7.4.0 +parallel-netcdf+mpi %pgi@20.1.0.20.08
+    - modules:
+      - cray-netcdf-hdf5parallel/4.7.4.0
+      spec: netcdf-fortran@4.7.4.0 +parallel-netcdf+mpi %pgi@20.1.1.20.08
+    - modules:
+      - cray-netcdf-hdf5parallel/4.7.4.0
+      spec: netcdf-fortran@4.7.4.0 +parallel-netcdf+mpi %cce@10.0.2.20.08
+    - modules:
+      - cray-netcdf-hdf5parallel/4.7.4.0
+      spec: netcdf-fortran@4.7.4.0 +parallel-netcdf+mpi %gcc@8.1.0.20.11
+    - modules:
+      - cray-netcdf-hdf5parallel/4.7.4.0
+      spec: netcdf-fortran@4.7.4.0 +parallel-netcdf+mpi %gcc@9.3.0.20.11
+    - modules:
+      - cray-netcdf-hdf5parallel/4.7.4.0
+      spec: netcdf-fortran@4.7.4.0 +parallel-netcdf+mpi %gcc@8.3.0.20.11
+    - modules:
+      - cray-netcdf-hdf5parallel/4.7.4.0
+      spec: netcdf-fortran@4.7.4.0 +parallel-netcdf+mpi %gcc@10.1.0.20.11
+    - modules:
+      - cray-netcdf-hdf5parallel/4.7.4.0
+      spec: netcdf-fortran@4.7.4.0 +parallel-netcdf+mpi %intel@19.0.1.144.20.11
+    - modules:
+      - cray-netcdf-hdf5parallel/4.7.4.0
+      spec: netcdf-fortran@4.7.4.0 +parallel-netcdf+mpi %intel@19.1.1.217.20.11
+    - modules:
+      - cray-netcdf-hdf5parallel/4.7.4.0
+      spec: netcdf-fortran@4.7.4.0 +parallel-netcdf+mpi %pgi@20.1.0.20.11
+    - modules:
+      - cray-netcdf-hdf5parallel/4.7.4.0
+      spec: netcdf-fortran@4.7.4.0 +parallel-netcdf+mpi %pgi@20.1.1.20.11
+    - modules:
+      - cray-netcdf-hdf5parallel/4.7.4.0
+      spec: netcdf-fortran@4.7.4.0 +parallel-netcdf+mpi %cce@11.0.0.20.11
+    - modules:
+      - cray-netcdf/4.7.4.0
+      spec: netcdf-fortran@4.7.4.0 ~parallel-netcdf+mpi %gcc@8.1.0.20.08
+    - modules:
+      - cray-netcdf/4.7.4.0
+      spec: netcdf-fortran@4.7.4.0 ~parallel-netcdf+mpi %gcc@9.3.0.20.08
+    - modules:
+      - cray-netcdf/4.7.4.0
+      spec: netcdf-fortran@4.7.4.0 ~parallel-netcdf+mpi %gcc@8.3.0.20.08
+    - modules:
+      - cray-netcdf/4.7.4.0
+      spec: netcdf-fortran@4.7.4.0 ~parallel-netcdf+mpi %intel@19.0.1.144.20.08
+    - modules:
+      - cray-netcdf/4.7.4.0
+      spec: netcdf-fortran@4.7.4.0 ~parallel-netcdf+mpi %intel@19.1.1.217.20.08
+    - modules:
+      - cray-netcdf/4.7.4.0
+      spec: netcdf-fortran@4.7.4.0 ~parallel-netcdf+mpi %pgi@20.1.0.20.08
+    - modules:
+      - cray-netcdf/4.7.4.0
+      spec: netcdf-fortran@4.7.4.0 ~parallel-netcdf+mpi %pgi@20.1.1.20.08
+    - modules:
+      - cray-netcdf/4.7.4.0
+      spec: netcdf-fortran@4.7.4.0 ~parallel-netcdf+mpi %cce@10.0.2.20.08
+    - modules:
+      - cray-netcdf/4.7.4.0
+      spec: netcdf-fortran@4.7.4.0 ~parallel-netcdf+mpi %gcc@8.1.0.20.11
+    - modules:
+      - cray-netcdf/4.7.4.0
+      spec: netcdf-fortran@4.7.4.0 ~parallel-netcdf+mpi %gcc@9.3.0.20.11
+    - modules:
+      - cray-netcdf/4.7.4.0
+      spec: netcdf-fortran@4.7.4.0 ~parallel-netcdf+mpi %gcc@8.3.0.20.11
+    - modules:
+      - cray-netcdf/4.7.4.0
+      spec: netcdf-fortran@4.7.4.0 ~parallel-netcdf+mpi %gcc@10.1.0.20.11
+    - modules:
+      - cray-netcdf/4.7.4.0
+      spec: netcdf-fortran@4.7.4.0 ~parallel-netcdf+mpi %intel@19.0.1.144.20.11
+    - modules:
+      - cray-netcdf/4.7.4.0
+      spec: netcdf-fortran@4.7.4.0 ~parallel-netcdf+mpi %intel@19.1.1.217.20.11
+    - modules:
+      - cray-netcdf/4.7.4.0
+      spec: netcdf-fortran@4.7.4.0 ~parallel-netcdf+mpi %pgi@20.1.0.20.11
+    - modules:
+      - cray-netcdf/4.7.4.0
+      spec: netcdf-fortran@4.7.4.0 ~parallel-netcdf+mpi %pgi@20.1.1.20.11
+    - modules:
+      - cray-netcdf/4.7.4.0
+      spec: netcdf-fortran@4.7.4.0 ~parallel-netcdf+mpi %cce@11.0.0.20.11
   netlib-lapack:
     variants: build_type=Release
   netlib-scalapack:
@@ -570,6 +726,60 @@ packages:
     - modules:
       - papi/6.0.0.4
       spec: papi@6.0.0.4 %cce@11.0.0.20.11
+  parallel-netcdf:
+    buildable: true
+    externals:
+    - modules:
+      - cray-netcdf-hdf5parallel/4.7.4.0
+      spec: parallel-netcdf@4.7.4.0 +cxx+fortran %gcc@8.1.0.20.08
+    - modules:
+      - cray-netcdf-hdf5parallel/4.7.4.0
+      spec: parallel-netcdf@4.7.4.0 +cxx+fortran %gcc@9.3.0.20.08
+    - modules:
+      - cray-netcdf-hdf5parallel/4.7.4.0
+      spec: parallel-netcdf@4.7.4.0 +cxx+fortran %gcc@8.3.0.20.08
+    - modules:
+      - cray-netcdf-hdf5parallel/4.7.4.0
+      spec: parallel-netcdf@4.7.4.0 +cxx+fortran %intel@19.0.1.144.20.08
+    - modules:
+      - cray-netcdf-hdf5parallel/4.7.4.0
+      spec: parallel-netcdf@4.7.4.0 +cxx+fortran %intel@19.1.1.217.20.08
+    - modules:
+      - cray-netcdf-hdf5parallel/4.7.4.0
+      spec: parallel-netcdf@4.7.4.0 +cxx+fortran %pgi@20.1.0.20.08
+    - modules:
+      - cray-netcdf-hdf5parallel/4.7.4.0
+      spec: parallel-netcdf@4.7.4.0 +cxx+fortran %pgi@20.1.1.20.08
+    - modules:
+      - cray-netcdf-hdf5parallel/4.7.4.0
+      spec: parallel-netcdf@4.7.4.0 +cxx+fortran %cce@10.0.2.20.08
+    - modules:
+      - cray-netcdf-hdf5parallel/4.7.4.0
+      spec: parallel-netcdf@4.7.4.0 +cxx+fortran %gcc@8.1.0.20.11
+    - modules:
+      - cray-netcdf-hdf5parallel/4.7.4.0
+      spec: parallel-netcdf@4.7.4.0 +cxx+fortran %gcc@9.3.0.20.11
+    - modules:
+      - cray-netcdf-hdf5parallel/4.7.4.0
+      spec: parallel-netcdf@4.7.4.0 +cxx+fortran %gcc@8.3.0.20.11
+    - modules:
+      - cray-netcdf-hdf5parallel/4.7.4.0
+      spec: parallel-netcdf@4.7.4.0 +cxx+fortran %gcc@10.1.0.20.11
+    - modules:
+      - cray-netcdf-hdf5parallel/4.7.4.0
+      spec: parallel-netcdf@4.7.4.0 +cxx+fortran %intel@19.0.1.144.20.11
+    - modules:
+      - cray-netcdf-hdf5parallel/4.7.4.0
+      spec: parallel-netcdf@4.7.4.0 +cxx+fortran %intel@19.1.1.217.20.11
+    - modules:
+      - cray-netcdf-hdf5parallel/4.7.4.0
+      spec: parallel-netcdf@4.7.4.0 +cxx+fortran %pgi@20.1.0.20.11
+    - modules:
+      - cray-netcdf-hdf5parallel/4.7.4.0
+      spec: parallel-netcdf@4.7.4.0 +cxx+fortran %pgi@20.1.1.20.11
+    - modules:
+      - cray-netcdf-hdf5parallel/4.7.4.0
+      spec: parallel-netcdf@4.7.4.0 +cxx+fortran %cce@11.0.0.20.11
   perl:
     externals:
     - prefix: /usr
@@ -845,7 +1055,7 @@ packages:
       spec: ruby@2.5.8
   tar:
     externals:
-    - prefix: /
+    - prefix: /usr
       spec: tar@1.30
   texinfo:
     externals:


### PR DESCRIPTION
This fixes two issues:
1.  `intel-mkl` package not being able to be installed with the `${RANDOM}` in the build path
2. For some strange reason, the `netcdf` modules have the wrong versions