### PR TITLE
[dom daint] Remove JULIA_PKG_SERVER

### DIFF
--- a/easybuild/easyconfigs/j/Julia/Julia-1.6.0-CrayGNU-20.11-cuda.eb
+++ b/easybuild/easyconfigs/j/Julia/Julia-1.6.0-CrayGNU-20.11-cuda.eb
@@ -34,8 +34,7 @@ modextravars = {
     'JULIA_MPIEXEC_ARGS': "-C gpu",
     'JULIA_MPI_BINARY': 'system',
     'JULIA_MPI_PATH': '$::env(CRAY_MPICH_DIR)',
-    'JULIA_MPI_TEST_ARRAYTYPE': 'CuArray',
-    'JULIA_PKG_SERVER': '',
+    'JULIA_MPI_TEST_ARRAYTYPE': 'CuArray'
 }
 
 moduleclass = 'lang'

--- a/easybuild/easyconfigs/j/Julia/Julia-1.6.0-CrayGNU-20.11.eb
+++ b/easybuild/easyconfigs/j/Julia/Julia-1.6.0-CrayGNU-20.11.eb
@@ -23,8 +23,7 @@ modextravars = {
     'JULIA_MPIEXEC': 'srun',
     'JULIA_MPIEXEC_ARGS': "-C mc",
     'JULIA_MPI_BINARY': 'system',
-    'JULIA_MPI_PATH': '$::env(CRAY_MPICH_DIR)',
-    'JULIA_PKG_SERVER': '',
+    'JULIA_MPI_PATH': '$::env(CRAY_MPICH_DIR)'
 }
 
 moduleclass = 'lang'


### PR DESCRIPTION
It was added to work around some weird issue where curl would complain about incomplete downloads, but in the end it happened with & without this variable.

Turns out it is useful to unset it, because then the julia package registry gets updated by just a download into ~/.julia/... when you run Pkg.update(), whereas when this variable is set to empty git clone the registry into ~/.julia/..., which curently fails because git tries to mmap something and that fails on the $HOME filesystem.
