### PR TITLE
[eiger] QuantumESPRESSO with cpeIntel

### DIFF
--- a/easybuild/easyconfigs/l/libxc/libxc-4.3.4-cpeIntel-21.04.eb
+++ b/easybuild/easyconfigs/l/libxc/libxc-4.3.4-cpeIntel-21.04.eb
@@ -1,0 +1,26 @@
+# contributed by Luca Marsella (CSCS)
+easyblock = 'ConfigureMake'
+
+name = 'libxc'
+version = '4.3.4'
+
+homepage = 'http://www.tddft.org/programs/octopus/wiki/index.php/Libxc'
+description = """Libxc is a library of exchange-correlation functionals for density-functional theory.
+ The aim is to provide a portable, well tested and reliable set of exchange and correlation functionals."""
+
+toolchain = {'name': 'cpeIntel', 'version': '21.04'}
+toolchainopts = {'opt': True}
+
+source_urls = ['https://www.tddft.org/programs/%(name)s/down.php?file=%(version)s']
+sources = [SOURCE_TAR_GZ]
+checksums = ['a8ee37ddc5079339854bd313272856c9d41a27802472ee9ae44b58ee9a298337']
+
+configopts = " --enable-shared "
+
+
+sanity_check_paths = {
+    'files': ['lib/%(name)s.a', 'lib/%(name)s.so', 'lib/libxcf03.a', 'lib/libxcf03.so', 'lib/libxcf90.a', 'lib/libxcf90.so'],
+    'dirs': ['include'],
+}
+
+moduleclass = 'chem'

--- a/easybuild/easyconfigs/q/QuantumESPRESSO/QuantumESPRESSO-6.7.0-cpeIntel-21.04.eb
+++ b/easybuild/easyconfigs/q/QuantumESPRESSO/QuantumESPRESSO-6.7.0-cpeIntel-21.04.eb
@@ -1,0 +1,40 @@
+# created by Luca Marsella (CSCS)
+easyblock = 'ConfigureMake'
+
+name = 'QuantumESPRESSO'
+version = '6.7.0'
+
+homepage = 'http://www.quantum-espresso.org/'
+description = """Quantum ESPRESSO is an integrated suite of computer codes
+ for electronic-structure calculations and materials modeling at the nanoscale.
+ It is based on density-functional theory, plane waves, and pseudopotentials
+  (both norm-conserving and ultrasoft)."""
+
+toolchain = {'name': 'cpeIntel', 'version': '21.04'}
+toolchainopts = {'opt': True, 'usempi': True, 'pic': True, 'verbose': False, 'openmp': True}
+
+sources = ['https://github.com/QEF/q-e/archive/qe-%(version)s.tar.gz']
+
+dependencies = [
+    ('libxc', '4.3.4')
+]
+
+preconfigopts = " module unload cray-libsci && module list && "
+configopts = ' CC=cc FC=ifort F77=ifort MPIF90=ftn SCALAPACK_LIBS="-L$MKLROOT/lib/intel64 -lmkl_scalapack_lp64 -lmkl_intel_lp64 -lmkl_intel_thread -lmkl_core -lmkl_blacs_intelmpi_lp64" FFT_LIBS="-L$MKLROOT/lib/intel64 -lmkl_intel_lp64 -lmkl_intel_thread -lmkl_core" LDFLAGS="-L$MKLROOT/lib/intel64 -lpthread -lstdc++ -ldl -qopenmp" FFLAGS="-O3 -g -assume byterecl -traceback -qopenmp" F90FLAGS="$FFLAGS" CFLAGS="-O3" --with-libxc=yes --with-libxc-prefix=$EBROOTLIBXC --with-libxc-include=$EBROOTLIBXC/include --enable-openmp --enable-parallel --with-scalapack '
+
+# use MKL FFT instead of FFTW and add HDF5
+prebuildopts = """
+    sed -i -e '/^DFLAGS/ s/$/ -D__DFTI/' -e '/^IFLAGS/ s#$# -I${MKLROOT}/include -I$(MKLROOT)/include/fftw#' make.inc &&
+    module unload cray-libsci && cat make.inc && """
+buildopts = "all epw"
+
+# single make process: parallel builds fail for target 'epw'
+maxparallel = 1
+
+
+sanity_check_paths = {
+    'files': ['bin/pw.x'],
+    'dirs': [''],
+}
+
+moduleclass = 'chem'

--- a/jenkins-builds/1.4.0-21.04-eiger
+++ b/jenkins-builds/1.4.0-21.04-eiger
@@ -19,9 +19,9 @@
  LAMMPS-29Oct20-cpeGNU-21.04.eb
  matplotlib-3.3.4-cpeGNU-21.04.eb
  NCO-4.9.8-cpeGNU-21.04.eb
- QuantumESPRESSO-6.7.0-cpeGNU-21.04.eb
  Vc-1.4.1-cpeGNU-21.04.eb           
  Amber-20-15-9-cpeIntel-21.04.eb
  GSL-2.6-cpeIntel-21.04.eb
  NAMD-2.14-cpeIntel-21.04.eb
+ QuantumESPRESSO-6.7.0-cpeIntel-21.04.eb
  VASP-6.2.0-cpeIntel-21.04.eb


### PR DESCRIPTION
QuantumESPRESSO and dependencies with the Intel compiler to address the issue with `cray-libsci` reported in [SD-52008](https://jira.cscs.ch/browse/SD-52008): `cray-hdf5` is not available with `PrgEnv-intel`, therefore it has been removed with respect to the build with `cpeGNU`.