### PR TITLE
[dom] Fix CMake on Dom

### DIFF
--- a/easybuild/easyconfigs/c/CMake/CMake-3.14.5.eb
+++ b/easybuild/easyconfigs/c/CMake/CMake-3.14.5.eb
@@ -1,3 +1,4 @@
+# contributed by Luca Marsella (CSCS)
 easyblock = 'ConfigureMake'
 
 name = 'CMake'
@@ -11,6 +12,10 @@ toolchain = SYSTEM
 
 source_urls = ['http://www.cmake.org/files/v%(version_major_minor)s']
 sources = [SOURCELOWER_TAR_GZ]
+
+# use system cURL to avoid the undefined reference to `DH_get_nid@OPENSSL_1_1_0i' 
+# when building cURL on dom101 (see https://jira.cscs.ch/browse/SD-52103)
+configopts = ' --system-curl '
 
 sanity_check_paths = {
     'files': ["bin/%s" % x for x in ['cmake', 'cpack', 'ctest']],


### PR DESCRIPTION
Use the configure option `--system-curl` to use system cURL to avoid the undefined reference to 'DH_get_nid@OPENSSL_1_1_0i' when building cURL on dom101, as explained in [SD-52103](https://jira.cscs.ch/browse/SD-52103).