### PR TITLE
[eiger pilatus] Add NCL 6.6.2 in production

### DIFF
--- a/jenkins-builds/1.4.0-21.04-eiger
+++ b/jenkins-builds/1.4.0-21.04-eiger
@@ -4,6 +4,7 @@
  hub-2.14.2.eb                        --set-default-module
  hwloc-2.4.1.eb                       --set-default-module
  jupyter-utils-0.1.eb                 --set-default-module
+ NCL-6.6.2.eb                         --set-default-module
  reframe-3.6.0.eb                     --set-default-module
  GSL-2.6-cpeAMD-21.04.eb
  GSL-2.6-cpeCray-21.04.eb

--- a/jenkins-builds/1.4.0-21.04-pilatus
+++ b/jenkins-builds/1.4.0-21.04-pilatus
@@ -4,6 +4,7 @@
  hub-2.14.2.eb                        --set-default-module
  hwloc-2.4.1.eb                       --set-default-module
  jupyter-utils-0.1.eb                 --set-default-module
+ NCL-6.6.2.eb                         --set-default-module
  reframe-3.6.0.eb                     --set-default-module
  GSL-2.6-cpeAMD-21.04.eb
  GSL-2.6-cpeCray-21.04.eb


### PR DESCRIPTION
I add the latest release of NCL on Eiger and Pilatus production lists to address [SD-51081](https://jira.cscs.ch/browse/SD-51081).