### PR TITLE
[eiger pilatus] Fix EB custom modulefile for Lmod

### DIFF
--- a/easybuild/module/EasyBuild-custom/cscs
+++ b/easybuild/module/EasyBuild-custom/cscs
@@ -9,12 +9,12 @@ Production EasyBuild @ CSCS
 
 More information
 ================
- - Homepage: https://github.com/eth-cscs/production/wiki/User-instructions-for-EasyBuild
+ - Homepage: https://github.com/eth-cscs/production/wiki
     }
 }
 
 module-whatis {Description: Production EasyBuild @ CSCS }
-module-whatis {Homepage: https://github.com/eth-cscs/production/wiki/User-instructions-for-EasyBuild}
+module-whatis {Homepage: https://github.com/eth-cscs/production/wiki}
 
 set root /apps/common/UES/jenkins/easybuild/software/EasyBuild-custom/cscs
 
@@ -27,7 +27,6 @@ setenv	EBDEVELEASYBUILDMINCUSTOM		"$root/easybuild/EasyBuild-custom-cscs-easybui
 # COMMON SETUP #
 ################
 # Local variables
-set ebmodule               /apps/common/UES/easybuild/software/EasyBuild/latest
 set eb_config_dir          /apps/common/UES/jenkins/production/easybuild
 #
 # EB_CUSTOM_REPOSITORY
@@ -71,6 +70,7 @@ if { [ string match *esch* $::env(HOSTNAME) ] } {
 } else {
  set system [regsub {[0-9]+} $::env(HOSTNAME) ""]
 }
+
 # system specific setup
 if { [ string match *daint* $system ] } {
     setenv EASYBUILD_EXTERNAL_MODULES_METADATA $::env(EB_CUSTOM_REPOSITORY)/cray_external_modules_metadata-20.11.cfg
@@ -83,14 +83,14 @@ if { [ string match *daint* $system ] } {
 } elseif { [ string match *eiger* $system ] } {
     setenv EASYBUILD_MODULE_SYNTAX              Lua
     setenv EASYBUILD_MODULES_TOOL               Lmod
-    setenv EASYBUILD_EXTERNAL_MODULES_METADATA $::env(EB_CUSTOM_REPOSITORY)/alps-external_modules_metadata-21.04.cfg
+    setenv EASYBUILD_EXTERNAL_MODULES_METADATA $::env(EB_CUSTOM_REPOSITORY)/cpe_external_modules_metadata-21.04.cfg
     setenv EASYBUILD_OPTARCH                    $::env(CRAY_CPU_TARGET)
     setenv EASYBUILD_MODULE_NAMING_SCHEME       HierarchicalMNS
     setenv EASYBUILD_RECURSIVE_MODULE_UNLOAD    0
 } elseif { [ string match *pilatus* $system ] } {
     setenv EASYBUILD_MODULE_SYNTAX              Lua
     setenv EASYBUILD_MODULES_TOOL               Lmod
-    setenv EASYBUILD_EXTERNAL_MODULES_METADATA $::env(EB_CUSTOM_REPOSITORY)/alps-external_modules_metadata-21.04.cfg
+    setenv EASYBUILD_EXTERNAL_MODULES_METADATA $::env(EB_CUSTOM_REPOSITORY)/cpe_external_modules_metadata-21.05.cfg
     setenv EASYBUILD_OPTARCH                    $::env(CRAY_CPU_TARGET)
     setenv EASYBUILD_MODULE_NAMING_SCHEME       HierarchicalMNS
     setenv EASYBUILD_RECURSIVE_MODULE_UNLOAD    0
@@ -132,23 +132,17 @@ if { ! [ info exists ::env(EASYBUILD_PREFIX) ] } {
     } else {
         setenv EASYBUILD_PREFIX                 $::env(HOME)/easybuild/$system
     }
-} else {
-    setenv EASYBUILD_PREFIX                     $::env(EASYBUILD_PREFIX)
 }
 setenv EASYBUILD_INSTALLPATH                    $::env(EASYBUILD_PREFIX)
 
 #
 # If not set, EASYBUILD_BUILDPATH and EASYBUILD_TMPDIR will point to $XDG_RUNTIME_DIR/easybuild
 #
-if { [ info exists ::env(EASYBUILD_TMPDIR) ] } {
-    setenv EASYBUILD_TMPDIR                     $::env(EASYBUILD_TMPDIR)
-} else {
+if { ! [ info exists ::env(EASYBUILD_TMPDIR) ] } {
     setenv EASYBUILD_TMPDIR                     $::env(XDG_RUNTIME_DIR)/easybuild/tmp
 }
 
-if { [ info exists ::env(EASYBUILD_BUILDPATH) ] } {
-    setenv EASYBUILD_BUILDPATH                  $::env(EASYBUILD_BUILDPATH)
-} else {
+if { ! [ info exists ::env(EASYBUILD_BUILDPATH) ] } {
     setenv EASYBUILD_BUILDPATH                  $::env(XDG_RUNTIME_DIR)/easybuild/build
 }
 #
@@ -167,13 +161,5 @@ if { ! [ info exists ::env(EASYBUILD_SOURCEPATH) ] } {
 # Adding easybuild installed software to the list of modules
 prepend-path MODULEPATH                         $::env(EASYBUILD_INSTALLPATH)/modules/all
 # Loading easybuild module
-if { [module-info mode] == "load" } {
-        module use /apps/common/UES/easybuild/modules/all
-}
-
+prepend-path MODULEPATH                         /apps/common/UES/easybuild/modules/all
 module load EasyBuild
-
-if { [module-info mode] == "remove" || [module-info mode] == "unload" } {
-        module unuse /apps/common/UES/easybuild/modules/all
-}
-# Built with EasyBuild version 3.6.2

--- a/easybuild/module/EasyBuild-custom/cscs.lua
+++ b/easybuild/module/EasyBuild-custom/cscs.lua
@@ -1,0 +1,89 @@
+help([[
+
+Description
+===========
+Production EasyBuild @ CSCS
+
+More information
+================
+ - Homepage: https://github.com/eth-cscs/production/wiki
+]])
+
+whatis([===[Description: Production EasyBuild @ CSCS  ]===])
+whatis([===[Homepage: https://github.com/eth-cscs/production/wiki]===])
+conflict("EasyBuild-custom")
+
+-- EasyBuild-custom SETUP 
+local eb_config_dir="/apps/common/UES/jenkins/production/easybuild"
+local eb_module_dir="/apps/common/UES/easybuild"
+local eb_root_dir="/apps/common/UES/jenkins/easybuild/software/EasyBuild-custom/cscs"
+local eb_runtime_dir=os.getenv("SCRATCH") or pathJoin("/tmp", os.getenv("USER"))
+local eb_source_dir="/apps/common/UES/easybuild/sources"
+setenv("EBROOTEASYBUILDMINCUSTOM", eb_root_dir)
+setenv("EBVERSIONEASYBUILDMINCUSTOM", "cscs")
+setenv("EBDEVELEASYBUILDMINCUSTOM", pathJoin(eb_root_dir, "/easybuild/EasyBuild-custom-cscs-easybuild-devel"))
+
+--[[ 
+ EB_CUSTOM_REPOSITORY defines the following variables:
+ * XDG_CONFIG_DIRS
+ * EASYBUILD_ROBOT_PATHS
+ * EASYBUILD_INCLUDE_EASYBLOCKS
+ * EASYBUILD_EXTERNAL_MODULES_METADATA (see section SYSTEM SPECIFIC)
+--]]
+local eb_custom_repository=os.getenv("EB_CUSTOM_REPOSITORY") or eb_config_dir
+setenv("XDG_CONFIG_DIRS", eb_custom_repository)
+setenv("EASYBUILD_ROBOT_PATHS", pathJoin(eb_custom_repository, "easyconfigs/:"))
+setenv("EASYBUILD_INCLUDE_EASYBLOCKS", pathJoin(eb_custom_repository, "easyblocks/*.py"))
+
+--[[ 
+ XDG_RUNTIME_DIR defines the following variables:
+ * EASYBUILD_BUILDPATH
+ * EASYBUILD_TMPDIR
+--]]
+local xdg_runtime_dir=os.getenv("XDG_RUNTIME_DIR") or eb_runtime_dir
+if not os.getenv("EASYBUILD_BUILDPATH") then
+	setenv("EASYBUILD_BUILDPATH", pathJoin(xdg_runtime_dir, "build"))
+end
+if not os.getenv("EASYBUILD_TMPDIR") then
+	setenv("EASYBUILD_TMPDIR", pathJoin(xdg_runtime_dir, "tmp"))
+end
+
+-- EASYBUILD_SOURCEPATH: use eb_source_dir if writable, otherwise $HOME/sources
+if not os.getenv("EASYBUILD_SOURCEPATH") then
+	if subprocess("test -w " .. eb_source_dir .. " ; echo $?") < "1" then
+		setenv("EASYBUILD_SOURCEPATH", eb_source_dir)
+	else
+		setenv("EASYBUILD_SOURCEPATH", pathJoin(os.getenv("HOME"),"sources"))
+	end
+end
+
+-- SYSTEM SPECIFIC (Cray with Lmod)
+local system=os.getenv("LMOD_SYSTEM_NAME")
+if system == "eiger" then
+	setenv("EASYBUILD_EXTERNAL_MODULES_METADATA", pathJoin(eb_custom_repository, "cpe_external_modules_metadata-21.04.cfg"))
+elseif system == "pilatus" then
+	setenv("EASYBUILD_EXTERNAL_MODULES_METADATA", pathJoin(eb_custom_repository, "cpe_external_modules_metadata-21.05.cfg"))
+else
+	LmodError("System ", system, " is currently unsupported\n")
+end
+setenv("EASYBUILD_MODULE_NAMING_SCHEME","HierarchicalMNS")
+setenv("EASYBUILD_MODULE_SYNTAX","Lua")
+setenv("EASYBUILD_MODULES_TOOL","Lmod")
+setenv("EASYBUILD_OPTARCH",os.getenv("CRAY_CPU_TARGET"))
+setenv("EASYBUILD_RECURSIVE_MODULE_UNLOAD","0")
+
+--[[ 
+ EASYBUILD_PREFIX defines the following variable:
+ * EASYBUILD_INSTALLPATH
+--]]
+if not os.getenv("EASYBUILD_PREFIX") then
+	setenv("EASYBUILD_PREFIX", pathJoin(os.getenv("HOME"),"easybuild", system))
+end
+setenv("EASYBUILD_INSTALLPATH", os.getenv("EASYBUILD_PREFIX"))
+
+-- add folder with already installed modules to the MODULEPATH
+prepend_path("MODULEPATH", pathJoin(os.getenv("EASYBUILD_INSTALLPATH"), "modules/all"))
+
+-- add EasyBuild module folder to MODULEPATH and load EasyBuild
+prepend_path("MODULEPATH", pathJoin(eb_module_dir, "modules/all"))
+load("EasyBuild")


### PR DESCRIPTION
I have realized that the EasyBuild-custom modulefile does not export correctly `EASYBUILD_PREFIX` for user `jenscscs` on Eiger and Pilatus (Cray with Lmod): the reason could be an issue with the script `tcl2lua.tcl` invoked by Lmod to convert Tcl to Lua syntax.

I have tried to fix the Tcl modulefile enclosed to this pull request removing the following line, which should not be necessary:
```
setenv EASYBUILD_PREFIX                     $::env(EASYBUILD_PREFIX)
```
However, the modified Tcl modulefile does not still work for user `jenscscs` on the systems with Lmod, therefore I provide the corresponding Lua modulefile which will only be loaded on systems with Lmod: the other systems will still load the Tcl modulefile.