### PR TITLE
[daint dom eiger pilatus tsa] Include custom MNS and toolchains

### DIFF
--- a/easybuild/module/EasyBuild-custom/cscs
+++ b/easybuild/module/EasyBuild-custom/cscs
@@ -47,7 +47,6 @@ setenv EASYBUILD_ROBOT_PATHS                    $::env(EB_CUSTOM_REPOSITORY)/eas
 setenv EASYBUILD_INCLUDE_EASYBLOCKS             $::env(EB_CUSTOM_REPOSITORY)/easyblocks/*.py
 setenv EASYBUILD_INCLUDE_MODULE_NAMING_SCHEMES  $::env(EB_CUSTOM_REPOSITORY)/tools/module_naming_scheme/*.py
 setenv EASYBUILD_INCLUDE_TOOLCHAINS             $::env(EB_CUSTOM_REPOSITORY)/toolchains/*.py,$::env(EB_CUSTOM_REPOSITORY)/toolchains/compiler/*.py
-
 #
 # Checking if we have the command modulecmd
 # If so, then module is a c version

--- a/easybuild/module/EasyBuild-custom/cscs
+++ b/easybuild/module/EasyBuild-custom/cscs
@@ -35,6 +35,8 @@ set eb_config_dir          /apps/common/UES/jenkins/production/easybuild
 # XDG_CONFIG_DIRS
 # EASYBUILD_ROBOT_PATHS
 # EASYBUILD_INCLUDE_EASYBLOCKS
+# EASYBUILD_INCLUDE_MODULE_NAMING_SCHEMES
+# EASYBUILD_INCLUDE_TOOLCHAINS
 # EASYBUILD_EXTERNAL_MODULES_METADATA (if on cray)
 #
 if { ! [ info exists ::env(EB_CUSTOM_REPOSITORY) ] } {
@@ -43,6 +45,9 @@ if { ! [ info exists ::env(EB_CUSTOM_REPOSITORY) ] } {
 setenv XDG_CONFIG_DIRS                          $::env(EB_CUSTOM_REPOSITORY)
 setenv EASYBUILD_ROBOT_PATHS                    $::env(EB_CUSTOM_REPOSITORY)/easyconfigs/:
 setenv EASYBUILD_INCLUDE_EASYBLOCKS             $::env(EB_CUSTOM_REPOSITORY)/easyblocks/*.py
+setenv EASYBUILD_INCLUDE_MODULE_NAMING_SCHEMES  $::env(EB_CUSTOM_REPOSITORY)/tools/module_naming_scheme/*.py
+setenv EASYBUILD_INCLUDE_TOOLCHAINS             $::env(EB_CUSTOM_REPOSITORY)/toolchains/*.py,$::env(EB_CUSTOM_REPOSITORY)/toolchains/compiler/*.py
+
 #
 # Checking if we have the command modulecmd
 # If so, then module is a c version

--- a/easybuild/module/EasyBuild-custom/cscs.lua
+++ b/easybuild/module/EasyBuild-custom/cscs.lua
@@ -28,12 +28,16 @@ setenv("EBDEVELEASYBUILDMINCUSTOM", pathJoin(eb_root_dir, "/easybuild/EasyBuild-
  * XDG_CONFIG_DIRS
  * EASYBUILD_ROBOT_PATHS
  * EASYBUILD_INCLUDE_EASYBLOCKS
+ * EASYBUILD_INCLUDE_MODULE_NAMING_SCHEMES
+ * EASYBUILD_INCLUDE_TOOLCHAINS
  * EASYBUILD_EXTERNAL_MODULES_METADATA (see section SYSTEM SPECIFIC)
 --]]
 local eb_custom_repository=os.getenv("EB_CUSTOM_REPOSITORY") or eb_config_dir
 setenv("XDG_CONFIG_DIRS", eb_custom_repository)
 setenv("EASYBUILD_ROBOT_PATHS", pathJoin(eb_custom_repository, "easyconfigs/:"))
 setenv("EASYBUILD_INCLUDE_EASYBLOCKS", pathJoin(eb_custom_repository, "easyblocks/*.py"))
+setenv("EASYBUILD_INCLUDE_MODULE_NAMING_SCHEMES", pathJoin(eb_custom_repository, "tools/module_naming_scheme/*.py"))
+setenv("EASYBUILD_INCLUDE_TOOLCHAINS", pathJoin(eb_custom_repository, "toolchains/*.py,", eb_custom_repository, "toolchains/compiler/*.py"))
 
 --[[ 
  XDG_RUNTIME_DIR defines the following variables:


### PR DESCRIPTION
I have implemented the change following the instructions on the [EasyBuild documentation](https://docs.easybuild.io/en/latest/Including_additional_Python_modules.html), since we have a custom module naming scheme and custom toolchains: using the include variables, we can avoid to copy manually the python scripts, therefore I have adapted [our Confluence page](https://confluence.cscs.ch/display/GENERAL/EasyBuild+at+CSCS) accordingly. 

You can check that the new custom modulefiles add the correct python scripts switching to the latest non-default `EasyBuild/4.4.0` (I have removed the custom python scripts from the standard installation folder) with the commands:
```
git clone git@github.com:lucamar/production.git
cd production
git checkout eb-custom
module use $PWD/easybuild/module
module load EasyBuild-custom-cscs
module switch EasyBuild EasyBuild/4.4.0

eb --avail-module-naming-schemes | grep -i lower
	LowercaseModuleNamingScheme

eb --list-toolchains | grep cpe
	cpeAMD: PrgEnv-aocc
	cpeCray: PrgEnv-cray
	cpeGNU: PrgEnv-gnu
	cpeIntel: PrgEnv-intel
```