### PR TITLE
[daint] adding libx264 encoding options

### DIFF
--- a/easybuild/easyconfigs/f/FFmpeg/FFmpeg-4.4-CrayGNU-20.11.eb
+++ b/easybuild/easyconfigs/f/FFmpeg/FFmpeg-4.4-CrayGNU-20.11.eb
@@ -15,9 +15,11 @@ sources = [SOURCELOWER_TAR_BZ2]
 dependencies = [
     ('NASM', '2.15.05'),
     ('theora', '1.2.0alpha1'),
+    ('x264', '20191217'),
 ]
 
 configopts = '--enable-pic --enable-shared --enable-gpl --disable-x86asm --enable-version3 --enable-nonfree --enable-libtheora --cc="$CC" --cxx="$CXX" '
+configopts += ' --enable-libx264 '
 
 
 sanity_check_paths = {

--- a/easybuild/easyconfigs/x/x264/x264-20191217-CrayGNU-20.11.eb
+++ b/easybuild/easyconfigs/x/x264/x264-20191217-CrayGNU-20.11.eb
@@ -1,0 +1,31 @@
+# contributed by Jean Favre 
+easyblock = 'ConfigureMake'
+
+name = 'x264'
+version = '20191217'
+
+homepage = 'http://www.videolan.org/developers/x264.html'
+description = """x264 is a free software library and application for encoding video streams into the H.264/MPEG-4
+ AVC compression format, and is released under the terms of the GNU GPL."""
+
+toolchain = {'name': 'CrayGNU', 'version': '20.11'}
+
+source_urls = [
+    'https://download.videolan.org/pub/videolan/x264/snapshots/'
+]
+sources = ['x264-snapshot-%(version)s-2245-stable.tar.bz2']
+
+preconfigopts = "unset CC && unset CFLAGS &&"
+
+dependencies = [
+    ('NASM', '2.15.05')
+]
+
+configopts = '--enable-static --enable-pic  '
+
+sanity_check_paths = {
+    'files': ['bin/%(namelower)s', 'include/x264_config.h', 'include/x264.h', 'lib/libx264.a'],
+    'dirs': [],
+}
+
+moduleclass = 'vis'


### PR DESCRIPTION
== COMPLETED: Installation ended successfully (took 20 sec)
== Results of the build can be found in the log file(s) /scratch/snx3000/jfavre/daint/software/x264/20191217-CrayGNU-20.11/easybuild/easybuild-x264-20191217-20210616.161055.log

== COMPLETED: Installation ended successfully (took 1 min 52 sec)
== Results of the build can be found in the log file(s) /scratch/snx3000/jfavre/daint/software/FFmpeg/4.4-CrayGNU-20.11/easybuild/easybuild-FFmpeg-4.4-20210616.161717.log
