### PR TITLE
[daint] provide X265 encoding

### DIFF
--- a/easybuild/easyconfigs/f/FFmpeg/FFmpeg-4.4-CrayGNU-20.11.eb
+++ b/easybuild/easyconfigs/f/FFmpeg/FFmpeg-4.4-CrayGNU-20.11.eb
@@ -16,10 +16,11 @@ dependencies = [
     ('NASM', '2.15.05'),
     ('theora', '1.2.0alpha1'),
     ('x264', '20191217'),
+    ('x265', '3.2.1'),
 ]
 
 configopts = '--enable-pic --enable-shared --enable-gpl --disable-x86asm --enable-version3 --enable-nonfree --enable-libtheora --cc="$CC" --cxx="$CXX" '
-configopts += ' --enable-libx264 '
+configopts += ' --enable-libx264 --enable-libx265 '
 
 
 sanity_check_paths = {

--- a/easybuild/easyconfigs/x/x265/x265-3.2.1-CrayGNU-20.11.eb
+++ b/easybuild/easyconfigs/x/x265/x265-3.2.1-CrayGNU-20.11.eb
@@ -1,0 +1,32 @@
+# contributed by Jean Favre 
+easyblock = 'CMakeMake'
+
+name = 'x265'
+version = '3.2.1'
+
+homepage = 'http://www.videolan.org/developers/x264.html'
+description = """x265 is a free software library and application for encoding video streams into the H.265/MPEG-H
+  HEVC compression format, and is released under the terms of the GNU GPL. """
+
+toolchain = {'name': 'CrayGNU', 'version': '20.11'}
+
+source_urls = [
+    'https://download.videolan.org/pub/videolan/x265/'
+]
+sources = ['x265_%(version)s.tar.gz']
+
+builddependencies = [
+    ('CMake', '3.14.5', '', True),
+    ('NASM', '2.15.05')
+]
+
+preconfigopts = "unset CC && unset CFLAGS && "
+
+srcdir = "source"
+
+sanity_check_paths = {
+    'files': ['bin/%(namelower)s', 'include/x265_config.h', 'include/x265.h', 'lib/libx265.so'],
+    'dirs': [],
+}
+
+moduleclass = 'vis'


### PR DESCRIPTION
== COMPLETED: Installation ended successfully (took 1 min 23 sec)
== Results of the build can be found in the log file(s) /scratch/snx3000/jfavre/daint/software/x265/3.2.1-CrayGNU-20.11/easybuild/easybuild-x265-3.2.1-20210618.170117.log

== COMPLETED: Installation ended successfully (took 2 min 1 sec)
== Results of the build can be found in the log file(s) /scratch/snx3000/jfavre/daint/software/FFmpeg/4.4-CrayGNU-20.11/easybuild/easybuild-FFmpeg-4.4-20210618.170431.log
== Build succeeded for 1 out of 1

a video can be encoded in this manner:
ffmpeg -i animation_%06d.jpg  -c:v libx265  -vf format=yuv420p  -tag:v hvc1 test_265.mp4