### PR TITLE
[eiger pilatus] Fix cscs Lua modulefile to avoid Lmod warning

### DIFF
--- a/easybuild/module/EasyBuild-custom/cscs.lua
+++ b/easybuild/module/EasyBuild-custom/cscs.lua
@@ -70,20 +70,21 @@ elseif system == "pilatus" then
 else
 	LmodError("System ", system, " is currently unsupported\n")
 end
-setenv("EASYBUILD_MODULE_NAMING_SCHEME","HierarchicalMNS")
-setenv("EASYBUILD_MODULE_SYNTAX","Lua")
-setenv("EASYBUILD_MODULES_TOOL","Lmod")
-setenv("EASYBUILD_OPTARCH",os.getenv("CRAY_CPU_TARGET"))
-setenv("EASYBUILD_RECURSIVE_MODULE_UNLOAD","0")
+setenv("EASYBUILD_MODULE_NAMING_SCHEME", "HierarchicalMNS")
+setenv("EASYBUILD_MODULE_SYNTAX", "Lua")
+setenv("EASYBUILD_MODULES_TOOL", "Lmod")
+setenv("EASYBUILD_OPTARCH", os.getenv("CRAY_CPU_TARGET"))
+setenv("EASYBUILD_RECURSIVE_MODULE_UNLOAD", "0")
 
---[[ 
- EASYBUILD_PREFIX defines the following variable:
- * EASYBUILD_INSTALLPATH
---]]
+-- EASYBUILD_PREFIX
 if not os.getenv("EASYBUILD_PREFIX") then
 	setenv("EASYBUILD_PREFIX", pathJoin(os.getenv("HOME"),"easybuild", system))
 end
-setenv("EASYBUILD_INSTALLPATH", os.getenv("EASYBUILD_PREFIX"))
+-- EASYBUILD_INSTALLPATH
+if not os.getenv("EASYBUILD_INSTALLPATH") then
+        local eb_installpath=os.getenv("EASYBUILD_PREFIX") or pathJoin(os.getenv("HOME"),"easybuild", system)
+        setenv("EASYBUILD_INSTALLPATH", eb_installpath)
+end
 
 -- add folder with already installed modules to the MODULEPATH
 prepend_path("MODULEPATH", pathJoin(os.getenv("EASYBUILD_INSTALLPATH"), "modules/all"))

--- a/easybuild/module/EasyBuild-custom/cscs.lua
+++ b/easybuild/module/EasyBuild-custom/cscs.lua
@@ -57,7 +57,7 @@ if not os.getenv("EASYBUILD_SOURCEPATH") then
 	if subprocess("test -w " .. eb_source_dir .. " ; echo $?") < "1" then
 		setenv("EASYBUILD_SOURCEPATH", eb_source_dir)
 	else
-		setenv("EASYBUILD_SOURCEPATH", pathJoin(os.getenv("HOME"),"sources"))
+		setenv("EASYBUILD_SOURCEPATH", pathJoin(os.getenv("HOME"), "sources"))
 	end
 end
 
@@ -78,11 +78,11 @@ setenv("EASYBUILD_RECURSIVE_MODULE_UNLOAD", "0")
 
 -- EASYBUILD_PREFIX
 if not os.getenv("EASYBUILD_PREFIX") then
-	setenv("EASYBUILD_PREFIX", pathJoin(os.getenv("HOME"),"easybuild", system))
+	setenv("EASYBUILD_PREFIX", pathJoin(os.getenv("HOME"), "easybuild", system))
 end
 -- EASYBUILD_INSTALLPATH
 if not os.getenv("EASYBUILD_INSTALLPATH") then
-        local eb_installpath=os.getenv("EASYBUILD_PREFIX") or pathJoin(os.getenv("HOME"),"easybuild", system)
+        local eb_installpath=os.getenv("EASYBUILD_PREFIX") or pathJoin(os.getenv("HOME"), "easybuild", system)
         setenv("EASYBUILD_INSTALLPATH", eb_installpath)
 end
 


### PR DESCRIPTION
The change to `cscs.lua` will fix the Lmod warning shown on Eiger and Pilatus for `EASYBUILD_INSTALLPATH` when `EASYBUILD_PREFIX` is not defined before loading the custom module:
```
Lmod Warning:  Syntax error in file:
/apps/pilatus/UES/modulefiles/EasyBuild-custom/cscs.lua
 with command: setenv, one or more arguments are not strings.
```

The new modulefile will also keep different prefix and installpath values if they are exported before loading `EasyBuild-custom/cscs`, without overwriting the installpath with the chosen prefix: this is relevant on Eiger and Pilatus with the hierarchical module naming scheme, if a user wants to build new local modules on top of the ones provided by CSCS staff.