### PR TITLE
[daint dom] Fix MATLAB

### DIFF
--- a/easybuild/easyblocks/matlab.py
+++ b/easybuild/easyblocks/matlab.py
@@ -1,0 +1,214 @@
+##
+# Copyright 2009-2021 Ghent University
+#
+# This file is part of EasyBuild,
+# originally created by the HPC team of Ghent University (http://ugent.be/hpc/en),
+# with support of Ghent University (http://ugent.be/hpc),
+# the Flemish Supercomputer Centre (VSC) (https://www.vscentrum.be),
+# Flemish Research Foundation (FWO) (http://www.fwo.be/en)
+# and the Department of Economy, Science and Innovation (EWI) (http://www.ewi-vlaanderen.be/en).
+#
+# https://github.com/easybuilders/easybuild
+#
+# EasyBuild is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation v2.
+#
+# EasyBuild is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with EasyBuild.  If not, see <http://www.gnu.org/licenses/>.
+##
+"""
+EasyBuild support for installing MATLAB, implemented as an easyblock
+
+@author: Stijn De Weirdt (Ghent University)
+@author: Dries Verdegem (Ghent University)
+@author: Kenneth Hoste (Ghent University)
+@author: Pieter De Baets (Ghent University)
+@author: Jens Timmerman (Ghent University)
+@author: Fotis Georgatos (Uni.Lu, NTUA)
+"""
+import re
+import os
+import stat
+import tempfile
+
+from distutils.version import LooseVersion
+
+from easybuild.easyblocks.generic.packedbinary import PackedBinary
+from easybuild.framework.easyconfig import CUSTOM
+from easybuild.tools.build_log import EasyBuildError
+from easybuild.tools.filetools import adjust_permissions, change_dir, copy_file, read_file, write_file
+from easybuild.tools.py2vs3 import string_type
+from easybuild.tools.run import run_cmd
+
+
+class EB_MATLAB(PackedBinary):
+    """Support for installing MATLAB."""
+
+    def __init__(self, *args, **kwargs):
+        """Add extra config options specific to MATLAB."""
+        super(EB_MATLAB, self).__init__(*args, **kwargs)
+        self.comp_fam = None
+        self.configfile = os.path.join(self.builddir, 'my_installer_input.txt')
+
+        # version starts with 'R' for MATLAB: strip this off for LooseVersion instances in Python 3
+        self.looseversion = LooseVersion(self.version.lstrip('R'))
+
+    @staticmethod
+    def extra_options():
+        extra_vars = {
+            'java_options': ['-Xmx256m', "$_JAVA_OPTIONS value set for install and in module file.", CUSTOM],
+            'key': [None, "Installation key(s), make one install for each key. Single key or a list of keys", CUSTOM],
+        }
+        return PackedBinary.extra_options(extra_vars)
+
+    def configure_step(self):
+        """Configure MATLAB installation: create license file."""
+
+        licfile = self.cfg['license_file']
+        if licfile is None:
+            licserv = self.cfg['license_server']
+            if licserv is None:
+                licserv = os.getenv('EB_MATLAB_LICENSE_SERVER', 'license.example.com')
+            licport = self.cfg['license_server_port']
+            if licport is None:
+                licport = os.getenv('EB_MATLAB_LICENSE_SERVER_PORT', '00000')
+            # create license file
+            lictxt = '\n'.join([
+                "SERVER %s 000000000000 %s" % (licserv, licport),
+                "USE_SERVER",
+            ])
+
+            licfile = os.path.join(self.builddir, 'matlab.lic')
+            write_file(licfile, lictxt)
+
+        try:
+            copy_file(os.path.join(self.cfg['start_dir'], 'installer_input.txt'), self.configfile)
+            adjust_permissions(self.configfile, stat.S_IWUSR)
+
+            # read file in binary mode to avoid UTF-8 encoding issues when using Python 3,
+            # due to non-UTF-8 characters...
+            config = read_file(self.configfile, mode='rb')
+
+            # use raw byte strings (must be 'br', not 'rb'),
+            # required when using Python 3 because file was read in binary mode
+            regdest = re.compile(br"^# destinationFolder=.*", re.M)
+            regagree = re.compile(br"^# agreeToLicense=.*", re.M)
+            regmode = re.compile(br"^# mode=.*", re.M)
+            reglicpath = re.compile(br"^# licensePath=.*", re.M)
+
+            # must use byte-strings here when using Python 3, see above
+            config = regdest.sub(b"destinationFolder=%s" % self.installdir.encode('utf-8'), config)
+            config = regagree.sub(b"agreeToLicense=Yes", config)
+            config = regmode.sub(b"mode=silent", config)
+            config = reglicpath.sub(b"licensePath=%s" % licfile.encode('utf-8'), config)
+
+            write_file(self.configfile, config)
+
+        except IOError as err:
+            raise EasyBuildError("Failed to create installation config file %s: %s", self.configfile, err)
+
+        self.log.debug('configuration file written to %s:\n %s', self.configfile, config)
+
+    def install_step(self):
+        """MATLAB install procedure using 'install' command."""
+
+        src = os.path.join(self.cfg['start_dir'], 'install')
+
+        # make sure install script is executable
+        adjust_permissions(src, stat.S_IXUSR)
+
+        if self.looseversion >= LooseVersion('2016b'):
+            jdir = os.path.join(self.cfg['start_dir'], 'sys', 'java', 'jre', 'glnxa64', 'jre', 'bin')
+            for perm_dir in [os.path.join(self.cfg['start_dir'], 'bin', 'glnxa64'), jdir]:
+                adjust_permissions(perm_dir, stat.S_IXUSR)
+
+        # make sure $DISPLAY is not defined, which may lead to (hard to trace) problems
+        # this is a workaround for not being able to specify --nodisplay to the install scripts
+        if 'DISPLAY' in os.environ:
+            os.environ.pop('DISPLAY')
+
+        if '_JAVA_OPTIONS' not in self.cfg['preinstallopts']:
+            java_opts = 'export _JAVA_OPTIONS="%s" && ' % self.cfg['java_options']
+            self.cfg['preinstallopts'] = java_opts + self.cfg['preinstallopts']
+        if self.looseversion >= LooseVersion('2016b'):
+            change_dir(self.builddir)
+
+        # Build the cmd string
+        cmdlist = [
+            self.cfg['preinstallopts'],
+            src,
+            '-inputFile',
+            self.configfile,
+        ]
+        if self.looseversion < LooseVersion('2020a'):
+            # MATLAB installers < 2020a ignore $TMPDIR (always use /tmp) and might need a large tmpdir
+            tmpdir = tempfile.mkdtemp()
+            cmdlist.extend([
+                '-v',
+                '-tmpdir',
+                tmpdir,
+            ])
+        cmdlist.append(self.cfg['installopts'])
+        cmd = ' '.join(cmdlist)
+
+        keys = self.cfg['key']
+        if keys is None:
+            keys = os.getenv('EB_MATLAB_KEY', '00000-00000-00000-00000-00000-00000-00000-00000-00000-00000')
+        if isinstance(keys, string_type):
+            keys = keys.split(',')
+
+        # Compile the installation key regex outside of the loop
+        regkey = re.compile(br"^(# )?fileInstallationKey=.*", re.M)
+
+        # Run an install for each key
+        for i, key in enumerate(keys):
+
+            self.log.info('Installing MATLAB with key %s of %s', i + 1, len(keys))
+
+            try:
+                config = read_file(self.configfile, mode='rb')
+                config = regkey.sub(b"fileInstallationKey=%s" % key.encode('utf-8'), config)
+                write_file(self.configfile, config)
+
+            except IOError as err:
+                raise EasyBuildError("Failed to update config file %s: %s", self.configfile, err)
+
+            (out, _) = run_cmd(cmd, log_all=True, simple=False)
+
+            # check installer output for known signs of trouble
+            patterns = [
+                "Error: You have entered an invalid File Installation Key",
+            ]
+
+            for pattern in patterns:
+                regex = re.compile(pattern, re.I)
+                if regex.search(out):
+                    raise EasyBuildError("Found error pattern '%s' in output of installation command '%s': %s",
+                                         regex.pattern, cmd, out)
+
+    def sanity_check_step(self):
+        """Custom sanity check for MATLAB."""
+        custom_paths = {
+            'files': ["bin/matlab", "bin/glnxa64/MATLAB", "toolbox/local/classpath.txt"],
+            'dirs': ["java/jar"],
+        }
+        super(EB_MATLAB, self).sanity_check_step(custom_paths=custom_paths)
+
+    def make_module_extra(self):
+        """Extend PATH and set proper _JAVA_OPTIONS (e.g., -Xmx)."""
+        txt = super(EB_MATLAB, self).make_module_extra()
+
+        # make MATLAB runtime available
+        if self.looseversion >= LooseVersion('2017a'):
+            for ldlibdir in ['runtime', 'bin', os.path.join('sys', 'os')]:
+                libdir = os.path.join(ldlibdir, 'glnxa64')
+                txt += self.module_generator.prepend_paths('LD_LIBRARY_PATH', libdir)
+        if self.cfg['java_options']:
+            txt += self.module_generator.set_environment('_JAVA_OPTIONS', self.cfg['java_options'])
+        return txt

--- a/easybuild/easyconfigs/m/MATLAB/MATLAB-R2021a.eb
+++ b/easybuild/easyconfigs/m/MATLAB/MATLAB-R2021a.eb
@@ -14,15 +14,12 @@ sources = ['/apps/common/UES/easybuild/sources/m/%s/%s.tar' % (name, version)]
 java_options = '-Xmx2048m'
 
 # read local license file
-import os as local_os
 local_licensefile = '/apps/common/UES/easybuild/sources/m/MATLAB/' + '%s-%s.txt' % (name, version)
-local_filehandle = local_os.open(local_licensefile, local_os.O_RDONLY)
-local_bytext = local_os.read(local_filehandle, 1000)
-local_text = local_bytext.decode('utf-8')
-# FIXME: the open() function raises the error below only with EasyBuild 4.4.0 and newer, not with 4.3.4
+# FIXME: without using "local_filehandle = None" an error occurs with EasyBuild 4.4.0 and newer, not with 4.3.4
 # Failed to copy 'local_filehandle' easyconfig parameter: cannot serialize '_io.TextIOWrapper' object
-# with open(local_licensefile, 'r') as local_filehandle:
-#    local_text = local_filehandle.read()
+with open(local_licensefile, 'r') as local_filehandle:
+    local_text = local_filehandle.read()
+local_filehandle = None
 
 # read key, license_server and license_server_port
 import re as local_re

--- a/easybuild/easyconfigs/m/MATLAB/MATLAB-R2021a.eb
+++ b/easybuild/easyconfigs/m/MATLAB/MATLAB-R2021a.eb
@@ -1,0 +1,33 @@
+# contributed by Luca Marsella (CSCS)
+name = 'MATLAB'
+version = 'R2021a'
+
+homepage = 'http://www.mathworks.com/products/matlab'
+description = """MATLAB is a high-level language and interactive environment
+ that enables you to perform computationally intensive tasks faster than with
+ traditional programming languages such as C, C++, and Fortran."""
+
+toolchain = SYSTEM
+
+sources = ['/apps/common/UES/easybuild/sources/m/%s/%s.tar' % (name, version)]
+
+java_options = '-Xmx2048m'
+
+# read local license file
+import os as local_os
+local_licensefile = '/apps/common/UES/easybuild/sources/m/MATLAB/' + '%s-%s.txt' % (name, version)
+local_filehandle = local_os.open(local_licensefile, local_os.O_RDONLY)
+local_bytext = local_os.read(local_filehandle, 1000)
+local_text = local_bytext.decode('utf-8')
+# FIXME: the open() function raises the error below only with EasyBuild 4.4.0 and newer, not with 4.3.4
+# Failed to copy 'local_filehandle' easyconfig parameter: cannot serialize '_io.TextIOWrapper' object
+# with open(local_licensefile, 'r') as local_filehandle:
+#    local_text = local_filehandle.read()
+
+# read key, license_server and license_server_port
+import re as local_re
+key = local_re.search("key = \'(.+)\'", local_text).group(1)
+license_server = local_re.search("license_server = \'(.+)\'", local_text).group(1)
+license_server_port = local_re.search("license_server_port = \'(.+)\'", local_text).group(1)
+
+moduleclass = 'math'

--- a/jenkins-builds/7.0.UP02-20.11-daint-gpu
+++ b/jenkins-builds/7.0.UP02-20.11-daint-gpu
@@ -44,7 +44,7 @@
  LAMMPS-29Oct20-CrayGNU-20.11-cuda.eb                   --set-default-module
  Lmod-7.8.2.eb                                          --set-default-module --hidden
  magma-2.5.4-CrayIntel-20.11-cuda.eb                    --set-default-module
- MATLAB-R2019a.eb                                       --set-default-module
+ MATLAB-R2021a.eb                                       --set-default-module
  NAMD-2.14-CrayIntel-20.11-cuda.eb                      --set-default-module
  NCL-6.4.0.eb                                           --set-default-module
  NCO-4.8.1-CrayGNU-20.11.eb                             --set-default-module

--- a/jenkins-builds/7.0.UP02-20.11-daint-mc
+++ b/jenkins-builds/7.0.UP02-20.11-daint-mc
@@ -42,7 +42,7 @@
  jupyterlab-2.0.2-CrayGNU-20.11-batchspawner.eb
  LAMMPS-29Oct20-CrayGNU-20.11.eb                        --set-default-module
  Lmod-7.8.2.eb                                          --set-default-module --hidden
- MATLAB-R2019a.eb                                       --set-default-module
+ MATLAB-R2021a.eb                                       --set-default-module
  NAMD-2.13-CrayIntel-20.11.eb                           --set-default-module
  NAMD-2.14-CrayIntel-20.11.eb
  NCL-6.4.0.eb                                           --set-default-module

--- a/jenkins-builds/7.0.UP02-20.11-dom-gpu
+++ b/jenkins-builds/7.0.UP02-20.11-dom-gpu
@@ -39,7 +39,7 @@
  LAMMPS-29Oct20-CrayGNU-20.11-cuda.eb                   --set-default-module
  Lmod-7.8.2.eb                                          --set-default-module --hidden
  magma-2.5.4-CrayIntel-20.11-cuda.eb                    --set-default-module
- MATLAB-R2019a.eb                                       --set-default-module
+ MATLAB-R2021a.eb                                       --set-default-module
  NAMD-2.14-CrayIntel-20.11-cuda.eb                      --set-default-module
  NCL-6.4.0.eb                                           --set-default-module
  NCO-4.8.1-CrayGNU-20.11.eb                             --set-default-module

--- a/jenkins-builds/7.0.UP02-20.11-dom-mc
+++ b/jenkins-builds/7.0.UP02-20.11-dom-mc
@@ -37,7 +37,7 @@
  jupyterlab-2.0.2-CrayGNU-20.11-batchspawner.eb
  LAMMPS-29Oct20-CrayGNU-20.11.eb                        --set-default-module
  Lmod-7.8.2.eb                                          --set-default-module --hidden
- MATLAB-R2019a.eb                                       --set-default-module
+ MATLAB-R2021a.eb                                       --set-default-module
  NAMD-2.14-CrayIntel-20.11.eb                           --set-default-module
  NCL-6.4.0.eb                                           --set-default-module
  NCO-4.8.1-CrayGNU-20.11.eb                             --set-default-module

--- a/jenkins-builds/7.0.UP02-21.02-dom-gpu
+++ b/jenkins-builds/7.0.UP02-21.02-dom-gpu
@@ -38,7 +38,7 @@
  LAMMPS-29Oct20-CrayGNU-21.02-cuda.eb                   --set-default-module
  Lmod-7.8.2.eb                                          --set-default-module --hidden
  magma-2.5.4-CrayIntel-21.02-cuda.eb                    --set-default-module
- MATLAB-R2019a.eb                                       --set-default-module
+ MATLAB-R2021a.eb                                       --set-default-module
  NAMD-2.14-CrayIntel-21.02-cuda.eb                      --set-default-module
  NCL-6.4.0.eb                                           --set-default-module
  NCO-4.8.1-CrayGNU-21.02.eb                             --set-default-module

--- a/jenkins-builds/7.0.UP02-21.02-dom-mc
+++ b/jenkins-builds/7.0.UP02-21.02-dom-mc
@@ -37,7 +37,7 @@
  jupyterlab-2.0.2-CrayGNU-21.02-batchspawner.eb
  LAMMPS-29Oct20-CrayGNU-21.02.eb                        --set-default-module
  Lmod-7.8.2.eb                                          --set-default-module --hidden
- MATLAB-R2019a.eb                                       --set-default-module
+ MATLAB-R2021a.eb                                       --set-default-module
  NAMD-2.13-CrayIntel-21.02.eb                           --set-default-module
  NAMD-2.14-CrayIntel-21.02.eb
  NCL-6.4.0.eb                                           --set-default-module


### PR DESCRIPTION
I provide a fix for [UES-1617](https://jira.cscs.ch/browse/UES-1617) and [UES-1619](https://jira.cscs.ch/browse/UES-1619), replacing MATLAB `R2019a` with the latest `R2021a` in the production lists of Dom and Piz Daint:
- LooseVersion in the easyblock `matlab.py` is fixed with Python3 following [a similar issue](https://github.com/easybuilders/easybuild-easyblocks/issues/1792)
- I added a `FIXME` in the easyconfig file `MATLAB-R2021a.eb` since the `open()` function raises an error only with EasyBuild 4.4.0 and newer, not with 4.3.4 (`Failed to copy 'local_filehandle' easyconfig parameter: cannot serialize '_io.TextIOWrapper' object`)