### PR TITLE
[pilatus] Add FFmpeg to 21.07 software stack

### DIFF
--- a/jenkins-builds/1.4.0-21.07-eiger
+++ b/jenkins-builds/1.4.0-21.07-eiger
@@ -13,6 +13,7 @@
  Boost-1.75.0-cpeGNU-21.07-python3.eb --set-default-module
  CDO-1.9.10-cpeGNU-21.07.eb
  CP2K-8.1-cpeGNU-21.07.eb
+ FFmpeg-4.4-cpeGNU-21.07.eb
  GREASY-19.03-cscs-cpeGNU-21.07.eb
  GROMACS-2020.5-cpeGNU-21.07.eb
  GSL-2.6-cpeGNU-21.07.eb


### PR DESCRIPTION
Add `FFmpeg` 21.07 in production with PE 21.07 (currently on Pilatus only): this pull request depends on #2410.