### PR TITLE
[eiger] Fix PLUMED 2.7.1

### DIFF
--- a/easybuild/easyconfigs/c/cpeGNU/cpeGNU-21.06.eb
+++ b/easybuild/easyconfigs/c/cpeGNU/cpeGNU-21.06.eb
@@ -13,7 +13,7 @@ dependencies = [
    ("cpe/%(version)s", EXTERNAL_MODULE),
    #('PrgEnv-gnu', EXTERNAL_MODULE),
    ('PrgEnv-gnu/8.1.0', EXTERNAL_MODULE),
-   ('gcc/9.3.0', EXTERNAL_MODULE),
+   ('gcc/10.2.0', EXTERNAL_MODULE),
    ('craype-x86-rome', EXTERNAL_MODULE),
    ('libfabric/1.11.0.4.71', EXTERNAL_MODULE),
    ('craype-network-ofi', EXTERNAL_MODULE),

--- a/easybuild/easyconfigs/p/PLUMED/PLUMED-2.7.1-cpeGNU-21.05.eb
+++ b/easybuild/easyconfigs/p/PLUMED/PLUMED-2.7.1-cpeGNU-21.05.eb
@@ -31,11 +31,8 @@ dependencies = [
 
 # The following search options are activated by default in configure:
 # --enable-external-blas --enable-external-lapack --enable-fftw --enable-gsl --enable-mpi --enable-python
-# Therefore set the include and library paths accordingly: Cray wrappers cc, CC and ftn set them automatically
-configopts = ' CC=cc CFLAGS="-craype-verbose -fopenmp $CFLAGS" '
-configopts += ' CXX=CC CXXFLAGS="-craype-verbose -fopenmp $CXXFLAGS" ' 
-configopts += ' MPIEXEC=srun '
-configopts += ' --disable-xdrfile --enable-shared --enable-modules=all --exec-prefix=%(installdir)s '
+preconfigopts = ' CC=gcc CFLAGS="" CXX=g++ CXXFLAGS="" MPIEXEC=srun '
+configopts = ' --disable-xdrfile --enable-shared --enable-modules=all --exec-prefix=%(installdir)s '
 
 sanity_check_paths = {
     'files': ['bin/%(namelower)s', 'lib/libplumedKernel.so', 'lib/libplumed.so'],

--- a/easybuild/easyconfigs/p/PLUMED/PLUMED-2.7.1-cpeGNU-21.05.eb
+++ b/easybuild/easyconfigs/p/PLUMED/PLUMED-2.7.1-cpeGNU-21.05.eb
@@ -32,11 +32,10 @@ dependencies = [
 # The following search options are activated by default in configure:
 # --enable-external-blas --enable-external-lapack --enable-fftw --enable-gsl --enable-mpi --enable-python
 # Therefore set the include and library paths accordingly: Cray wrappers cc, CC and ftn set them automatically
-preconfigopts = ' CC=cc CFLAGS="-fopenmp" && '
-preconfigopts += ' CXX=CC CXXFLAGS="-fopenmp" && ' 
-preconfigopts += ' FC=ftn FCFLAGS="-fopenmp" && ' 
-preconfigopts += ' MPIEXEC=srun && '
-configopts = ' --disable-xdrfile --enable-shared --enable-modules=all --exec-prefix=%(installdir)s '
+configopts = ' CC=cc CFLAGS="-craype-verbose -fopenmp $CFLAGS" '
+configopts += ' CXX=CC CXXFLAGS="-craype-verbose -fopenmp $CXXFLAGS" ' 
+configopts += ' MPIEXEC=srun '
+configopts += ' --disable-xdrfile --enable-shared --enable-modules=all --exec-prefix=%(installdir)s '
 
 sanity_check_paths = {
     'files': ['bin/%(namelower)s', 'lib/libplumedKernel.so', 'lib/libplumed.so'],

--- a/easybuild/easyconfigs/p/PLUMED/PLUMED-2.7.1-cpeGNU-21.05.eb
+++ b/easybuild/easyconfigs/p/PLUMED/PLUMED-2.7.1-cpeGNU-21.05.eb
@@ -32,10 +32,11 @@ dependencies = [
 # The following search options are activated by default in configure:
 # --enable-external-blas --enable-external-lapack --enable-fftw --enable-gsl --enable-mpi --enable-python
 # Therefore set the include and library paths accordingly: Cray wrappers cc, CC and ftn set them automatically
-configopts = ' CC=cc CFLAGS="-craype-verbose -fopenmp $CFLAGS" '
-configopts += ' CXX=CC CXXFLAGS="-craype-verbose -fopenmp $CXXFLAGS" ' 
-configopts += ' MPIEXEC=srun '
-configopts += ' --disable-xdrfile --enable-shared --enable-modules=all --exec-prefix=%(installdir)s '
+preconfigopts = ' CC=cc CFLAGS="-fopenmp" && '
+preconfigopts += ' CXX=CC CXXFLAGS="-fopenmp" && ' 
+preconfigopts += ' FC=ftn FCFLAGS="-fopenmp" && ' 
+preconfigopts += ' MPIEXEC=srun && '
+configopts = ' --disable-xdrfile --enable-shared --enable-modules=all --exec-prefix=%(installdir)s '
 
 sanity_check_paths = {
     'files': ['bin/%(namelower)s', 'lib/libplumedKernel.so', 'lib/libplumed.so'],

--- a/easybuild/easyconfigs/p/PLUMED/PLUMED-2.7.1-cpeGNU-21.06.eb
+++ b/easybuild/easyconfigs/p/PLUMED/PLUMED-2.7.1-cpeGNU-21.06.eb
@@ -31,8 +31,7 @@ dependencies = [
 
 # The following search options are activated by default in configure:
 # --enable-external-blas --enable-external-lapack --enable-fftw --enable-gsl --enable-mpi --enable-python
-# Therefore set the include and library paths accordingly: Cray wrappers cc, CC and ftn set them automatically
-preconfigopts = ' CC=cc CFLAGS="-fopenmp" CXX=CC CXXFLAGS="-fopenmp" FC=ftn FCFLAGS="-fopenmp" MPIEXEC=srun '
+preconfigopts = ' CC=gcc CFLAGS="" CXX=g++ CXXFLAGS="" MPIEXEC=srun '
 configopts = ' --disable-xdrfile --enable-shared --enable-modules=all --exec-prefix=%(installdir)s '
 
 sanity_check_paths = {

--- a/easybuild/easyconfigs/p/PLUMED/PLUMED-2.7.1-cpeGNU-21.06.eb
+++ b/easybuild/easyconfigs/p/PLUMED/PLUMED-2.7.1-cpeGNU-21.06.eb
@@ -21,18 +21,22 @@ sources = ['v%(version)s.tar.gz']
 
 builddependencies = [
     ('cray-fftw', EXTERNAL_MODULE),
-    ('cray-python', EXTERNAL_MODULE),
+    ('cray-python', EXTERNAL_MODULE)
 ]
+
 dependencies = [
     ('zlib', '1.2.11'),
-    ('GSL', '2.7'),
+    ('GSL', '2.7')
 ]
 
 # The following search options are activated by default in configure:
 # --enable-external-blas --enable-external-lapack --enable-fftw --enable-gsl --enable-mpi --enable-python
 # Therefore set the include and library paths accordingly: Cray wrappers cc, CC and ftn set them automatically
-configopts = ' CC=cc CFLAGS="-craype-verbose -fopenmp $CFLAGS"  CXX=CC CXXFLAGS="-craype-verbose -fopenmp $CXXFLAGS"  MPIEXEC=srun  --disable-xdrfile --enable-shared --enable-modules=all --exec-prefix=%(installdir)s '
-
+preconfigopts = ' CC=cc CFLAGS="-fopenmp" && '
+preconfigopts += ' CXX=CC CXXFLAGS="-fopenmp" && ' 
+preconfigopts += ' FC=ftn FCFLAGS="-fopenmp" && ' 
+preconfigopts += ' MPIEXEC=srun && '
+configopts = ' --disable-xdrfile --enable-shared --enable-modules=all --exec-prefix=%(installdir)s '
 
 sanity_check_paths = {
     'files': ['bin/%(namelower)s', 'lib/libplumedKernel.so', 'lib/libplumed.so'],

--- a/easybuild/easyconfigs/p/PLUMED/PLUMED-2.7.1-cpeGNU-21.06.eb
+++ b/easybuild/easyconfigs/p/PLUMED/PLUMED-2.7.1-cpeGNU-21.06.eb
@@ -32,10 +32,7 @@ dependencies = [
 # The following search options are activated by default in configure:
 # --enable-external-blas --enable-external-lapack --enable-fftw --enable-gsl --enable-mpi --enable-python
 # Therefore set the include and library paths accordingly: Cray wrappers cc, CC and ftn set them automatically
-preconfigopts = ' CC=cc CFLAGS="-fopenmp" && '
-preconfigopts += ' CXX=CC CXXFLAGS="-fopenmp" && ' 
-preconfigopts += ' FC=ftn FCFLAGS="-fopenmp" && ' 
-preconfigopts += ' MPIEXEC=srun && '
+preconfigopts = ' CC=cc CFLAGS="-fopenmp" CXX=CC CXXFLAGS="-fopenmp" FC=ftn FCFLAGS="-fopenmp" MPIEXEC=srun '
 configopts = ' --disable-xdrfile --enable-shared --enable-modules=all --exec-prefix=%(installdir)s '
 
 sanity_check_paths = {


### PR DESCRIPTION
I provide a fixed recipe for PLUMED with PE 21.05 and 21.06 that avoids linking the non-threaded release of `cray-libsci` (see [SD-52306](https://jira.cscs.ch/browse/SD-52306)).