### PR TITLE
update libfabric version on eiger

### DIFF
--- a/spack/eiger/packages.yaml
+++ b/spack/eiger/packages.yaml
@@ -101,7 +101,7 @@ packages:
     - spec: cray-mpich@8.1.4
       modules:
       - cray-mpich/8.1.4
-      - libfabric/1.11.0.4.67
+      - libfabric/1.11.0.4.71
   jemalloc:
     externals:
     - spec: jemalloc@5.1.0.4


### PR DESCRIPTION
`libfabric/1.11.0.4.67` doesn't exist anymore