### PR TITLE
[daint-mc] Add OpenFOAM v2106 for CrayGNU 20.11

### DIFF
--- a/easybuild/easyconfigs/c/CGAL/CGAL-4.14.3-CrayGNU-20.11.eb
+++ b/easybuild/easyconfigs/c/CGAL/CGAL-4.14.3-CrayGNU-20.11.eb
@@ -1,0 +1,30 @@
+#
+easyblock = 'CMakeMake'
+
+name = 'CGAL'
+version = "4.14.3"
+
+homepage = 'http://www.cgal.org/'
+description = """
+    The goal of the CGAL Open Source Project is to provide easy access to
+    efficient and reliable geometric algorithms in the form of a C++ library.
+"""
+
+toolchain = {'name': 'CrayGNU', 'version': '20.11'}
+toolchainopts = {'strict': True}
+
+source_urls = ['https://github.com/%(name)s/%(namelower)s/releases/download/releases%2FCGAL-%(version)s']
+sources = [SOURCE_TAR_XZ]
+
+builddependencies = [
+    ('CMake', '3.14.5', '', True),
+]
+dependencies = [
+    ('zlib', '1.2.11'),
+    ('Boost', '1.75.0'),
+]
+
+configopts = "-DCMAKE_BUILD_TYPE=Release -DBoost_DIR=${EBROOTBOOST} -DWITH_ZLIB=ON -DWITH_MPFR=ON -DWITH_GMP=ON -DWITH_BLAS=ON -DWITH_CGAL_Qt5=OFF "
+
+
+moduleclass = 'numlib'

--- a/easybuild/easyconfigs/o/OpenFOAM/OpenFOAM-v2106-CrayGNU-20.11.eb
+++ b/easybuild/easyconfigs/o/OpenFOAM/OpenFOAM-v2106-CrayGNU-20.11.eb
@@ -1,0 +1,46 @@
+# mkra (CSCS), 2018
+easyblock = 'Binary'
+
+name = 'OpenFOAM'
+version = 'v2106'
+
+homepage = 'http://www.openfoam.org/'
+description = """
+    OpenFOAM is a free, open source CFD software package. OpenFOAM has an 
+    extensive range of features to solve anything from complex fluid flows
+    involving chemical reactions, turbulence and heat transfer, to solid 
+    dynamics and electromagnetics.
+"""
+
+toolchain = {'name': 'CrayGNU', 'version': '20.11'}
+toolchainopts = {'cstd': 'c++11'}
+
+source_urls = ['https://dl.%(namelower)s.com/source/%(version)s']
+sources = [SOURCE_TGZ]
+patches = ['patch.%(name)s-%(version)s']
+
+builddependencies = [
+    ('CMake', '3.14.5', '', True),
+]
+dependencies = [
+    ('cray-tpsl-64', EXTERNAL_MODULE),
+    ('cray-fftw', EXTERNAL_MODULE),
+    ('CGAL', '4.14.3'),
+]
+
+unpack_options = '--strip-components=1'
+extract_sources = 'True'
+buildininstalldir = 'True'
+
+install_cmd = "source etc/bashrc && ./Allwmake -j 6 "
+
+sanity_check_paths = {
+    'files': [],
+    'dirs': ['platforms/linux64GccDPInt32Opt/bin', 'platforms/linux64GccDPInt32Opt/lib'],
+}
+
+modtclfooter = """
+    setenv FOAM_BASH "%(installdir)s/etc/bashrc"
+"""
+
+moduleclass = 'cae'

--- a/easybuild/easyconfigs/o/OpenFOAM/patch.OpenFOAM-v2106
+++ b/easybuild/easyconfigs/o/OpenFOAM/patch.OpenFOAM-v2106
@@ -1,0 +1,108 @@
+diff -Nru OpenFOAM-v2106.ORIG/etc/bashrc OpenFOAM-v2106/etc/bashrc
+--- OpenFOAM-v2106.ORIG/etc/bashrc	2021-06-28 10:15:09.000000000 +0200
++++ OpenFOAM-v2106/etc/bashrc	2021-08-19 09:57:50.000000000 +0200
+@@ -93,8 +93,11 @@
+ #   HPMPI | CRAY-MPICH | FJMPI | QSMPI | SGIMPI | INTELMPI | USERMPI
+ # Specify SYSTEMOPENMPI1, SYSTEMOPENMPI2 for internal tracking (if desired)
+ # Can also use INTELMPI-xyz etc and define your own wmake rule
+-export WM_MPLIB=SYSTEMOPENMPI
+-
++export WM_MPLIB=SYSTEMMPI
++export MPI_ROOT=${MPICH_DIR}
++export MPI_ARCH_FLAGS=" "
++export MPI_ARCH_LIBS=" "
++export MPI_ARCH_INC=" "
+ 
+ #------------------------------------------------------------------------------
+ # (advanced / legacy)
+diff -Nru OpenFOAM-v2106.ORIG/etc/config.sh/CGAL OpenFOAM-v2106/etc/config.sh/CGAL
+--- OpenFOAM-v2106.ORIG/etc/config.sh/CGAL	2021-06-28 10:15:09.000000000 +0200
++++ OpenFOAM-v2106/etc/config.sh/CGAL	2021-08-19 15:47:22.000000000 +0200
+@@ -43,11 +43,11 @@
+ #------------------------------------------------------------------------------
+ # USER EDITABLE PART: Changes made here may be lost with the next upgrade
+ 
+-boost_version=boost_1_66_0
+-cgal_version=CGAL-4.12.2
++boost_version=${EBVERSIONBOOST}
++cgal_version=${EBVERSIONCGAL}
+ 
+-export BOOST_ARCH_PATH="$WM_THIRD_PARTY_DIR/platforms/$WM_ARCH$WM_COMPILER/$boost_version"
+-export CGAL_ARCH_PATH="$WM_THIRD_PARTY_DIR/platforms/$WM_ARCH$WM_COMPILER/$cgal_version"
++export BOOST_ARCH_PATH=${EBROOTBOOST}
++export CGAL_ARCH_PATH=${EBROOTCGAL}
+ 
+ # export GMP_ARCH_PATH=...
+ # export MPFR_ARCH_PATH=...
+diff -Nru OpenFOAM-v2106.ORIG/etc/config.sh/FFTW OpenFOAM-v2106/etc/config.sh/FFTW
+--- OpenFOAM-v2106.ORIG/etc/config.sh/FFTW	2021-06-28 10:15:09.000000000 +0200
++++ OpenFOAM-v2106/etc/config.sh/FFTW	2021-08-19 11:23:04.000000000 +0200
+@@ -35,8 +35,8 @@
+ #------------------------------------------------------------------------------
+ # USER EDITABLE PART: Changes made here may be lost with the next upgrade
+ 
+-fftw_version=fftw-3.3.7
+-export FFTW_ARCH_PATH=$WM_THIRD_PARTY_DIR/platforms/$WM_ARCH$WM_COMPILER/$fftw_version
++fftw_version=fftw-3.3.8.8
++export FFTW_ARCH_PATH=${FFTW_DIR}/../.
+ 
+ # END OF (NORMAL) USER EDITABLE PART
+ #------------------------------------------------------------------------------
+diff -Nru OpenFOAM-v2106.ORIG/etc/config.sh/metis OpenFOAM-v2106/etc/config.sh/metis
+--- OpenFOAM-v2106.ORIG/etc/config.sh/metis	2021-06-28 10:15:09.000000000 +0200
++++ OpenFOAM-v2106/etc/config.sh/metis	2021-08-19 11:24:18.000000000 +0200
+@@ -35,7 +35,7 @@
+ # USER EDITABLE PART: Changes made here may be lost with the next upgrade
+ 
+ METIS_VERSION=metis-5.1.0
+-export METIS_ARCH_PATH=$WM_THIRD_PARTY_DIR/platforms/$WM_ARCH$WM_COMPILER$WM_PRECISION_OPTION$WM_LABEL_OPTION/$METIS_VERSION
++export METIS_ARCH_PATH=${CRAY_TPSL_64_DIR}
+ 
+ # END OF (NORMAL) USER EDITABLE PART
+ #------------------------------------------------------------------------------
+diff -Nru OpenFOAM-v2106.ORIG/etc/config.sh/paraview OpenFOAM-v2106/etc/config.sh/paraview
+--- OpenFOAM-v2106.ORIG/etc/config.sh/paraview	2021-06-28 10:15:09.000000000 +0200
++++ OpenFOAM-v2106/etc/config.sh/paraview	2021-08-19 11:25:41.000000000 +0200
+@@ -57,7 +57,7 @@
+ #------------------------------------------------------------------------------
+ # USER EDITABLE PART: Changes made here may be lost with the next upgrade
+ 
+-ParaView_VERSION=5.9.1
++ParaView_VERSION=none
+ ParaView_QT=qt-system
+ 
+ # END OF (NORMAL) USER EDITABLE PART
+diff -Nru OpenFOAM-v2106.ORIG/etc/config.sh/scotch OpenFOAM-v2106/etc/config.sh/scotch
+--- OpenFOAM-v2106.ORIG/etc/config.sh/scotch	2021-06-28 10:15:09.000000000 +0200
++++ OpenFOAM-v2106/etc/config.sh/scotch	2021-08-19 10:11:46.000000000 +0200
+@@ -33,8 +33,8 @@
+ #------------------------------------------------------------------------------
+ # USER EDITABLE PART: Changes made here may be lost with the next upgrade
+ 
+-SCOTCH_VERSION=scotch_6.1.0
+-export SCOTCH_ARCH_PATH=$WM_THIRD_PARTY_DIR/platforms/$WM_ARCH$WM_COMPILER$WM_PRECISION_OPTION$WM_LABEL_OPTION/$SCOTCH_VERSION
++SCOTCH_VERSION=scotch_6.0.8
++export SCOTCH_ARCH_PATH=${CRAY_TPSL_64_DIR}
+ 
+ # END OF (NORMAL) USER EDITABLE PART
+ #------------------------------------------------------------------------------
+diff -Nru OpenFOAM-v2106.ORIG/wmake/rules/linux64Gcc/c OpenFOAM-v2106/wmake/rules/linux64Gcc/c
+--- OpenFOAM-v2106.ORIG/wmake/rules/linux64Gcc/c	2021-06-28 10:15:09.000000000 +0200
++++ OpenFOAM-v2106/wmake/rules/linux64Gcc/c	2021-08-19 11:26:27.000000000 +0200
+@@ -1,5 +1,6 @@
+ include $(GENERAL_RULES)/Gcc/c
+ 
++cc          = cc
+ cARCH       = -m64
+ 
+ # Compile option is non-mandatory, but must be non-empty
+diff -Nru OpenFOAM-v2106.ORIG/wmake/rules/linux64Gcc/c++ OpenFOAM-v2106/wmake/rules/linux64Gcc/c++
+--- OpenFOAM-v2106.ORIG/wmake/rules/linux64Gcc/c++	2021-06-28 10:15:09.000000000 +0200
++++ OpenFOAM-v2106/wmake/rules/linux64Gcc/c++	2021-08-19 11:26:41.000000000 +0200
+@@ -1,5 +1,6 @@
+ include $(GENERAL_RULES)/Gcc/c++
+ 
++CC          = CC
+ c++ARCH     = -m64 -pthread
+ 
+ include $(DEFAULT_RULES)/c++$(WM_COMPILE_OPTION)


### PR DESCRIPTION
Updated source URL as well as dependencies using cray-tpsl instead of Scotch built using EB.