### PR TITLE
[daint-mc] major Mesa upgrade for cpu-based rendering for ParaView

### DIFF
--- a/easybuild/easyconfigs/l/LLVM/LLVM-9.0.1-CrayGNU-20.11.eb
+++ b/easybuild/easyconfigs/l/LLVM/LLVM-9.0.1-CrayGNU-20.11.eb
@@ -1,0 +1,35 @@
+# contributed by Jean M. Favre (CSCS)
+easyblock = 'CMakeMake'
+
+name = 'LLVM'
+version = '9.0.1'
+
+homepage = 'http://llvm.org/'
+description = """The LLVM Core libraries provide a modern source- and
+target-independent optimizer, along with code generation support for many
+popular CPUs (as well as some less common ones!) These libraries are built
+around a well specified code representation known as the LLVM intermediate
+representation ("LLVM IR"). The LLVM Core libraries are well documented, and it
+is particularly easy to invent your own language (or port an existing compiler)
+to use LLVM as an optimizer and code generator."""
+
+toolchain = {'name': 'CrayGNU', 'version': '20.11'}
+toolchainopts = {'dynamic': True}
+
+source_urls = ['https://github.com/%(namelower)s/%(namelower)s-project/releases/download/%(namelower)sorg-%(version)s']
+sources = ['%(namelower)s-%(version)s.src.tar.xz']
+
+builddependencies = [
+    ('CMake', '3.14.5', '', True),
+]
+
+# required to install extra tools in bin/
+configopts = " -DLLVM_INSTALL_UTILS=ON -DLLVM_TARGETS_TO_BUILD=X86  -DLLVM_TARGETS_TO_BUILD=X86  -DLLVM_ENABLE_RTTI:BOOL=ON  -DLLVM_BUILD_LLVM_DYLIB:BOOL=ON  -DLLVM_ENABLE_ZLIB=ON  -DCMAKE_BUILD_TYPE=Release  -DBUILD_SHARED_LIBS=ON "
+
+
+sanity_check_paths = {
+    'files': ['bin/%(namelower)s-ar', 'bin/FileCheck'],
+    'dirs': ['include/%(namelower)s', 'include/%(namelower)s-c'],
+}
+
+moduleclass = 'compiler'

--- a/easybuild/easyconfigs/m/Mesa/Mesa-21.2.1-CrayGNU-20.11.eb
+++ b/easybuild/easyconfigs/m/Mesa/Mesa-21.2.1-CrayGNU-20.11.eb
@@ -1,0 +1,46 @@
+# contributed by Jean M. Favre (CSCS)
+
+# This configuration file builds Mesa for software rendering, not hardware rendering.
+# This means using at least SSE4.2. It uses the following:
+# - llvmpipe: the high-performance Gallium LLVM driver
+# - swr: Intel's OpenSWR
+# It will try to use the llvmpipe by default. To select swr instead, set the following:
+# GALLIUM_DRIVER=swr
+# see also https://gallium.readthedocs.io/en/latest/drivers/openswr/usage.html
+#
+
+easyblock = 'MesonNinja'
+
+name = 'Mesa'
+version = '21.2.1'
+
+homepage = 'http://www.mesa3d.org/'
+description = """Mesa is an open-source implementation of the OpenGL specification -
+ a system for rendering interactive 3D graphics."""
+
+toolchain = {'name': 'CrayGNU', 'version': '20.11'}
+
+source_urls = ['https://archive.%(namelower)s3d.org/']
+sources = [SOURCELOWER_TAR_XZ]
+
+builddependencies = [
+    ('Meson', '0.59.1', '-python%(pymajver)s'),
+    ('Ninja', '1.10.2', '-python%(pymajver)s'),
+    ('Mako', '1.1.2', '-python%(pymajver)s')
+]
+dependencies = [
+    ('LLVM', '9.0.1'),
+    ('cray-python', EXTERNAL_MODULE),
+]
+
+configopts = " -Dplatforms=x11 -Dosmesa=true -Dllvm=true "
+configopts += "-Dgles1=disabled -Dgles2=disabled -Degl=disabled -Dgbm=disabled -Ddri3=disabled "
+configopts += "-Dgallium-vdpau=disabled -Dgallium-va=disabled -Dgallium-xvmc=disabled "
+configopts += "-Dvulkan-drivers='' -Dglx=gallium-xlib -Ddri-drivers='' -Dgallium-drivers=swr,swrast "
+
+sanity_check_paths = {
+    'files': ['include/GL/glcorearb.h', 'include/GL/glext.h', 'include/GL/gl.h', 'include/GL/glx.h', 'include/GL/osmesa.h', 'lib64/libGL.so', 'lib64/libOSMesa.so', 'lib64/libswrAVX.so', 'lib64/libswrAVX2.so'],
+    'dirs': ['include/GL'],
+}
+
+moduleclass = 'vis'

--- a/easybuild/easyconfigs/m/Meson/Meson-0.59.1-CrayGNU-20.11-python3.eb
+++ b/easybuild/easyconfigs/m/Meson/Meson-0.59.1-CrayGNU-20.11-python3.eb
@@ -1,0 +1,32 @@
+# contributed by Jean M. Favre (CSCS)
+#
+easyblock = 'PythonPackage'
+
+name = 'Meson'
+version = '0.59.1'
+versionsuffix = '-python%(pymajver)s'
+
+homepage = 'https://mesonbuild.com'
+description = """Meson is a cross-platform build system designed to be both as
+fast and as user friendly as possible."""
+
+toolchain = {'name': 'CrayGNU', 'version': '20.11'}
+
+source_urls = ['https://github.com/mesonbuild/meson/releases/download/%(version)s/']
+sources = [SOURCELOWER_TAR_GZ]
+
+dependencies = [
+    ('cray-python', EXTERNAL_MODULE),
+    ('Ninja', '1.10.2', '-python%(pymajver)s')
+]
+
+download_dep_fail = True
+
+options = {'modulename': 'mesonbuild'}
+
+sanity_check_paths = {
+    'files': ['bin/meson'],
+    'dirs': [],
+}
+
+moduleclass = 'tools'

--- a/easybuild/easyconfigs/n/Ninja/Ninja-1.10.2-CrayGNU-20.11-python3.eb
+++ b/easybuild/easyconfigs/n/Ninja/Ninja-1.10.2-CrayGNU-20.11-python3.eb
@@ -1,0 +1,28 @@
+# contributed by Jean M. Favre (CSCS)
+#
+easyblock = 'CmdCp'
+
+name = 'Ninja'
+version = '1.10.2'
+versionsuffix = '-python%(pymajver)s'
+
+homepage = 'https://ninja-build.org/'
+description = "Ninja is a small build system with a focus on speed."
+
+toolchain = {'name': 'CrayGNU', 'version': '20.11'}
+
+source_urls = ['https://github.com/ninja-build/ninja/archive/']
+sources = ['v%(version)s.tar.gz']
+
+builddependencies = [("cray-python", EXTERNAL_MODULE)]
+
+cmds_map = [('.*', "./configure.py --bootstrap")]
+
+files_to_copy = [(['ninja'], 'bin')]
+
+sanity_check_paths = {
+    'files': ['bin/ninja'],
+    'dirs': [],
+}
+
+moduleclass = 'tools'


### PR DESCRIPTION
the old driver had:

################ Remote Render Server ############
Vendor:   VMware, Inc.
Version:  3.3 (Core Profile) Mesa 18.3.3
Renderer: llvmpipe (LLVM 8.0, 256 bits)
##################################################

the new driver has:
################ Remote Render Server ############
Vendor:   Mesa/X.org
Version:  4.5 (Core Profile) Mesa 21.2.1
Renderer: llvmpipe (LLVM 9.0.1, 256 bits)
##################################################

== COMPLETED: Installation ended successfully (took 2 mins 59 secs)
== Results of the build can be found in the log file(s) /scratch/snx3000/jfavre/daint/software/Mesa/21.2.1-CrayGNU-20.11/easybuild/easybuild-Mesa-21.2.1-20210910.091009.log

