### PR TITLE
Remove legacy spack

### DIFF
--- a/spack/reframe/spack.py
+++ b/spack/reframe/spack.py
@@ -87,7 +87,7 @@ class spack_config_check(rfm.RunOnlyRegressionTest):
             if spacklib.parse_version(self.spack_version) >= spacklib.parse_version('0.16.0'):
                 self.postrun_cmds += ['spack external find --scope site/cray']
             elif spacklib.parse_version(self.spack_version) < spacklib.parse_version('0.15.0'):
-                raise ValueError(f'Sparck version {self.spack_version} is not supported')
+                raise ValueError(f'Spack version {self.spack_version} is not supported')
             else:
                 self.legacy_spack = True
                 self.postrun_cmds += [
@@ -423,7 +423,6 @@ class spack_pkg_check(rfm.RunOnlyRegressionTest):
     valid_prog_environs = ['builtin']
     valid_systems = ['daint:login', 'dom:login']
     executable = 'spack'
-    executable_opts = ['spec', '-IlN']
     num_tasks = 1
     num_tasks_per_node = 1
     exclusive = True
@@ -434,20 +433,25 @@ class spack_pkg_check(rfm.RunOnlyRegressionTest):
     def __init__(self):
         self.dep_name = f'spack_config_check_{util.toalphanum(self.spack_version)}'
         self.depends_on(self.dep_name, how=udeps.by_env)
-
         self.sanity_patterns = sn.all([
             sn.assert_not_found(r'ERROR', self.stderr),
             sn.assert_not_found(r'Error', self.stderr),
             sn.assert_not_found(r'missing', self.stderr),
             sn.assert_not_found(r'command not found', self.stderr),
         ])
-        self.executable_opts += [self.spack_pkg]
-        self.postrun_cmds = [f'spack install {self.spack_pkg}']
 
     @run_after('setup')
     def config_spack(self):
         target = self.getdep(self.dep_name, 'builtin')
+        self.executable_opts = [
+            '-C', f'{self.stagedir}/config/{self.spack_version}',
+            'spec', '-IlN', self.spack_pkg
+        ]
+        self.postrun_cmds = [
+            f'spack -C {self.stagedir}/config/{self.spack_version} install {self.spack_pkg}'
+        ]
         self.variables = target.variables
+        self.variables['REFRAME_STAGE_DIR'] = self.stagedir
 
 
 @rfm.simple_test

--- a/spack/reframe/spack.py
+++ b/spack/reframe/spack.py
@@ -259,7 +259,7 @@ class spack_config_check(rfm.RunOnlyRegressionTest):
             # cdt compilers have modules, if not they are considered os compilers
             modules.append(cdt_name + '/' + cdt_version)
             modules.append(compiler_type + '/' + version)
-            spec['spec'] += '.' + cdt_version
+            spec['spec'] += '-' + cdt_version
 
             ret.update({
                 spec['spec'] : spec

--- a/spack/reframe/spack.py
+++ b/spack/reframe/spack.py
@@ -22,7 +22,7 @@ from reframe.core.exceptions import SanityError
 spacklib = util.import_module_from_file(os.path.join(os.path.dirname(__file__), 'src', 'spack_util', 'spacklib.py'))
 spackconfig = util.import_module_from_file(os.path.join(os.path.dirname(__file__), 'src', 'spack_util', 'spack_config.py'))
 
-SPACK_VERSIONS = ['develop', '0.15.4', '0.16.1']
+SPACK_VERSIONS = ['develop', '0.15.4', '0.16.2']
 
 # TODO find a mechanism to include intel in the list
 base_cuda_compilers = ['gcc', 'cce']

--- a/spack/reframe/src/config/0.15.4/config.yaml
+++ b/spack/reframe/src/config/0.15.4/config.yaml
@@ -1,0 +1,9 @@
+config:
+  'build_stage:':
+  - $REFRAME_STAGE_DIR/stage
+  install_tree: $REFRAME_STAGE_DIR/install
+  module_roots:
+    tcl: $REFRAME_STAGE_DIR/modules
+    lmod: $REFRAME_STAGE_DIR/lmod
+  source_cache: $REFRAME_STAGE_DIR/sources
+  misc_cache: $REFRAME_STAGE_DIR/cache

--- a/spack/reframe/src/config/0.16.2/config.yaml
+++ b/spack/reframe/src/config/0.16.2/config.yaml
@@ -1,0 +1,10 @@
+config:
+  'build_stage:':
+  - $REFRAME_STAGE_DIR/stage
+  install_tree:
+    root: $REFRAME_STAGE_DIR/install
+  module_roots:
+    tcl: $REFRAME_STAGE_DIR/modules
+    lmod: $REFRAME_STAGE_DIR/lmod
+  source_cache: $REFRAME_STAGE_DIR/sources
+  misc_cache: $REFRAME_STAGE_DIR/cache

--- a/spack/reframe/src/config/develop/config.yaml
+++ b/spack/reframe/src/config/develop/config.yaml
@@ -1,0 +1,10 @@
+config:
+  'build_stage:':
+  - $REFRAME_STAGE_DIR/stage
+  install_tree:
+    root: $REFRAME_STAGE_DIR/install
+  module_roots:
+    tcl: $REFRAME_STAGE_DIR/modules
+    lmod: $REFRAME_STAGE_DIR/lmod
+  source_cache: $REFRAME_STAGE_DIR/sources
+  misc_cache: $REFRAME_STAGE_DIR/cache

--- a/spack/reframe/src/spack_util/spacklib.py
+++ b/spack/reframe/src/spack_util/spacklib.py
@@ -305,7 +305,7 @@ def generate_compiler_list_for_testing(cdt_types, allowed_compilers):
         _, cdt_version = get_cdt_info_from_modulerc_file(modulerc_file)
         for compiler in allowed_compilers:
             try:
-                compilers.append(compiler + "@" + get_default_package_versions_from_modulerc(compiler, modulerc_file) + '.' + cdt_version)
+                compilers.append(compiler + "@" + get_default_package_versions_from_modulerc(compiler, modulerc_file) + '-' + cdt_version)
             except:
                 pass
 


### PR DESCRIPTION
This does a bit more than the PR title:

- Remove 0.15.x config files and code, it's been a year since 0.15 and it'll not take very long until 0.17 :crossed_fingers:. Most people tend to use spack's develop branch anyways. The main reason for this is that the script actually works, since 0.15 does not support parallel builds (so, multiple processes calling spack install, like reframe does).
- Use `-[cdt version]` as a suffix, so that we have a more visual `[cray compiler/package version]-[cdt version]` separation.

