### PR TITLE
Use '-[cdt version]' as a suffix

### DIFF
--- a/spack/reframe/spack.py
+++ b/spack/reframe/spack.py
@@ -259,7 +259,7 @@ class spack_config_check(rfm.RunOnlyRegressionTest):
             # cdt compilers have modules, if not they are considered os compilers
             modules.append(cdt_name + '/' + cdt_version)
             modules.append(compiler_type + '/' + version)
-            spec['spec'] += '.' + cdt_version
+            spec['spec'] += '-' + cdt_version
 
             ret.update({
                 spec['spec'] : spec

--- a/spack/reframe/src/spack_util/spacklib.py
+++ b/spack/reframe/src/spack_util/spacklib.py
@@ -305,7 +305,7 @@ def generate_compiler_list_for_testing(cdt_types, allowed_compilers):
         _, cdt_version = get_cdt_info_from_modulerc_file(modulerc_file)
         for compiler in allowed_compilers:
             try:
-                compilers.append(compiler + "@" + get_default_package_versions_from_modulerc(compiler, modulerc_file) + '.' + cdt_version)
+                compilers.append(compiler + "@" + get_default_package_versions_from_modulerc(compiler, modulerc_file) + '-' + cdt_version)
             except:
                 pass
 


### PR DESCRIPTION
The cdt is not part of the package version, so instead use [package version]-[cdt version] as a way to make compilers & externals use the cdt
