### PR TITLE
[daint dom eiger pilatus tsa] Workarounds for spack config generator

### DIFF
--- a/spack/reframe/spack.py
+++ b/spack/reframe/spack.py
@@ -127,9 +127,9 @@ class spack_config_check(rfm.RunOnlyRegressionTest):
         self.modules_file_path = os.path.join(spack_etc_dir, 'modules.yaml')
         # self.keep_files = [spack_etc_dir]
 
-        # This is a workaround for the lack of --scope in spack external find in 0.15.x versions
-        if self.legacy_spack:
-            self.variables['HOME'] = spack_etc_dir
+        # Note: in this way the real home folder of the user running the
+        #       script is not used, resulting in a "clean" configuration environment.
+        self.variables['HOME'] = spack_etc_dir
 
     @deferrable
     def assert_config(self):
@@ -450,7 +450,13 @@ class spack_pkg_check(rfm.RunOnlyRegressionTest):
         self.postrun_cmds = [
             f'spack -C {self.stagedir}/config/{self.spack_version} install {self.spack_pkg}'
         ]
-        self.variables = target.variables
+
+        # Note: re-setting the home dir so that each test, which runs in parallel,
+        #       has its own bootstrap store, which is stored in the home dir.
+        self.variables['HOME'] = self.stagedir
+
+        # Note: deep copy of the environment variable, instead of updating the base one
+        self.variables = target.variables.copy()
         self.variables['REFRAME_STAGE_DIR'] = self.stagedir
 
 

--- a/spack/reframe/spack.py
+++ b/spack/reframe/spack.py
@@ -451,14 +451,13 @@ class spack_pkg_check(rfm.RunOnlyRegressionTest):
             f'spack -C {self.stagedir}/config/{self.spack_version} install {self.spack_pkg}'
         ]
 
-        # Note: re-setting the home dir so that each test, which runs in parallel,
-        #       has its own bootstrap store, which is stored in the home dir.
-        self.variables['HOME'] = self.stagedir
-
         # Note: deep copy of the environment variable, instead of updating the base one
         self.variables = target.variables.copy()
         self.variables['REFRAME_STAGE_DIR'] = self.stagedir
 
+        # Note: re-setting the home dir so that each test, which runs in parallel,
+        #       has its own bootstrap store, which is stored in the home dir.
+        self.variables['HOME'] = self.stagedir
 
 @rfm.simple_test
 class spack_push_config_check(rfm.RunOnlyRegressionTest):


### PR DESCRIPTION
Thanks @haampie and @ekouts for the support!

It's a bit hacky, let me know how can we improve it.

EDIT:
Main points:
1. home folder: set the home folder to the stage dir, so that user configurations stored in `$HOME/.spack` do not kick in
2. bootstrap store: it is stored in home folder, that would be otherwise shared by all tests running in parallel, that seems problematic. if we don't want to re-bootstrap, we can opt for running pkg tests sequentially.
3. fix problem with stage dir #2474: the config_check test was shared by all the tests in parallel that were competing for setting the same variable in the shared environment.