### PR TITLE
[daint dom eiger pilatus tsa] Make reframe conflict with cray-python

### DIFF
--- a/easybuild/easyconfigs/r/reframe/reframe-3.8.1.eb
+++ b/easybuild/easyconfigs/r/reframe/reframe-3.8.1.eb
@@ -49,3 +49,7 @@ sanity_check_paths = {
 
 sanity_check_commands = ['reframe -V', 'python3 -m pytest --version']
 moduleclass = 'devel'
+
+# reframe uses system python, dependencies use extensions that link to that
+# so reframe is bound to system python.
+conflict cray-python


### PR DESCRIPTION
System python (3.6) is used to build reframe's deps on Daint, which means that extensions link against system libpython, which is incompatible with cray-python (3.8)
