### PR TITLE
[daint,dom] Update expat-2.2.10-CrayGNU-20.11.eb

### DIFF
--- a/easybuild/easyconfigs/e/expat/expat-2.2.10-CrayGNU-20.11.eb
+++ b/easybuild/easyconfigs/e/expat/expat-2.2.10-CrayGNU-20.11.eb
@@ -1,4 +1,4 @@
-# contributed by Luca Marsella (CSCS)#
+# contributed by Luca Marsella (CSCS)
 easyblock = 'ConfigureMake'
 
 name = 'expat'
@@ -11,7 +11,8 @@ description = """Expat is an XML parser library written in C. It is a stream-ori
 toolchain = {'name': 'CrayGNU', 'version': '20.11'}
 toolchainopts = {'pic': True}
 
-source_urls = ['http://downloads.sourceforge.net/project/%(name)s/%(name)s/%(version)s']
+#source_urls = ['http://downloads.sourceforge.net/project/%(name)s/%(name)s/%(version)s']
+source_urls = ['https://github.com/libexpat/libexpat/releases/download/R_2_2_10/%(name)s-/%(version)s']
 sources = [SOURCELOWER_TAR_XZ]
 
 

--- a/easybuild/easyconfigs/e/expat/expat-2.2.10-CrayGNU-20.11.eb
+++ b/easybuild/easyconfigs/e/expat/expat-2.2.10-CrayGNU-20.11.eb
@@ -12,6 +12,6 @@ toolchain = {'name': 'CrayGNU', 'version': '20.11'}
 toolchainopts = {'pic': True}
 
 source_urls = ['https://github.com/libexpat/libexpat/releases/download/R_2_2_10/']
-sources = ['%(name)s-%(version)s.tar.xz']
+sources = [SOURCE_TAR_BZ2]
 
 moduleclass = 'tools'

--- a/easybuild/easyconfigs/e/expat/expat-2.2.10-CrayGNU-20.11.eb
+++ b/easybuild/easyconfigs/e/expat/expat-2.2.10-CrayGNU-20.11.eb
@@ -1,4 +1,4 @@
-# contributed by Luca Marsella (CSCS)
+# contributed by Luca Marsella (CSCS)#
 easyblock = 'ConfigureMake'
 
 name = 'expat'

--- a/easybuild/easyconfigs/e/expat/expat-2.2.10-CrayGNU-20.11.eb
+++ b/easybuild/easyconfigs/e/expat/expat-2.2.10-CrayGNU-20.11.eb
@@ -11,9 +11,7 @@ description = """Expat is an XML parser library written in C. It is a stream-ori
 toolchain = {'name': 'CrayGNU', 'version': '20.11'}
 toolchainopts = {'pic': True}
 
-#source_urls = ['http://downloads.sourceforge.net/project/%(name)s/%(name)s/%(version)s']
-source_urls = ['https://github.com/libexpat/libexpat/releases/download/R_2_2_10/%(name)s-/%(version)s']
-sources = [SOURCELOWER_TAR_XZ]
-
+source_urls = ['https://github.com/libexpat/libexpat/releases/download/R_2_2_10/']
+sources = ['%(name)s-%(version)s.tar.xz']
 
 moduleclass = 'tools'


### PR DESCRIPTION
Source is no longer hosted on sourceforge. Fixes SD-53430.
This builds, but please feel free to modify the variable usage convention according to current preferences (e.g. SOURCELOWER_TAR_XZ...)