### PR TITLE
[eiger] jupyterlab-2.2.10-cpeGNU-21.08.eb

### DIFF
--- a/easybuild/easyconfigs/j/jupyterlab/jupyterlab-2.2.10-cpeGNU-21.08.eb
+++ b/easybuild/easyconfigs/j/jupyterlab/jupyterlab-2.2.10-cpeGNU-21.08.eb
@@ -161,7 +161,7 @@ exts_list = [
     ('cycler', '0.10.0'),
     ('kiwisolver', '1.2.0'),
     ('matplotlib', '3.4.3', {'use_pip': True, 'source_tmpl': '%(name)s-%(version)s-cp%(pymajver)s%(pyminver)s-cp%(pymajver)s%(pyminver)s-manylinux1_x86_64.whl', 'unpack_sources': False}),
-    ('ipywidgets', '7.6.5', {'use_pip': True, 'source_tmpl': '%(name)s-%(version)s-py2-py3-none-any.whl', 'unpack_sources': False}),
+    ('ipywidgets', '7.6.5', {'use_pip': True, 'source_tmpl': '%(name)s-%(version)s-py2.py3-none-any.whl', 'unpack_sources': False}),
     ('jupyterlab_widgets', '1.0.2', {'use_pip': True, 'source_tmpl': '%(name)s-%(version)s-py3-none-any.whl', 'unpack_sources': False}),
     ('ipympl', '0.8.0', {'use_pip': True, 'source_tmpl': '%(name)s-%(version)s-py2.py3-none-any.whl', 'unpack_sources': False}),
 


### PR DESCRIPTION
upgrading widgets infrastructure to support custom kernels that use current pip install defaults. otherwise widgets will fail to render in jupyterlab
This fixes SD-53474
Compatibility table is shown here: https://github.com/matplotlib/ipympl