### PR TITLE
[daint-gpu] version bump to v1.9.4 alpha 54 (October 7, 2021)

### DIFF
--- a/easybuild/easyconfigs/v/VMD/VMD-1.9.4.eb
+++ b/easybuild/easyconfigs/v/VMD/VMD-1.9.4.eb
@@ -4,7 +4,7 @@ easyblock = "CmdCp"
 
 name = 'VMD'
 version = '1.9.4'
-versionsuffix = 'a51'
+versionsuffix = 'a54'
 
 homepage = 'http://www.ks.uiuc.edu/Research/vmd/'
 description = """


### PR DESCRIPTION
VMD is being updated from VMD 1.9.4 alpha 51 (Dec 21, 2020) to VMD 1.9.4 alpha 54 (October 7, 2021)

== COMPLETED: Installation ended successfully (took 46 secs)
== Results of the build can be found in the log file(s) /scratch/snx3000/jfavre/daint/software/VMD/1.9.4a54/easybuild/easybuild-VMD-1.9.4-20211011.180351.log
== Build succeeded for 1 out of 1

testing in a live VNC desktop was done. See https://jira.cscs.ch/browse/AVAILAPPS-9