### PR TITLE
[daint-gpu, dom-gpu] upgrade ovito for use by PSI users

### DIFF
--- a/easybuild/easyconfigs/o/ovito/ovito-3.5.4-CrayGNU-20.11.eb
+++ b/easybuild/easyconfigs/o/ovito/ovito-3.5.4-CrayGNU-20.11.eb
@@ -1,0 +1,21 @@
+# contributed by Jean Favre (CSCS)
+easyblock = 'Tarball'
+
+name = 'ovito'
+version = '3.5.4'
+
+homepage = 'https://www.ovito.org'
+description = """OVITO is a scientific visualization and analysis software for
+atomistic and particle simulation data"""
+
+toolchain = {'name': 'CrayGNU', 'version': '20.11'}
+
+source_urls = ['https://www.%(name)s.org/download/3106/']
+sources = ['%(name)s-basic-%(version)s-%(arch)s.tar.xz']
+
+sanity_check_paths = {
+    'files': ['bin/%(name)s'],
+    'dirs': ['share', 'lib'],
+}
+
+moduleclass = 'devel'

--- a/jenkins-builds/7.0.UP02-20.11-daint-gpu
+++ b/jenkins-builds/7.0.UP02-20.11-daint-gpu
@@ -48,7 +48,7 @@
  netcdf-python-1.5.4-CrayGNU-20.11-python3.eb           --set-default-module
  numpy-1.17.2-CrayGNU-20.11.eb                          --set-default-module
  OOOPS-1.0.eb
- ovito-3.5.2-CrayGNU-20.11.eb                           --set-default-module
+ ovito-3.5.4-CrayGNU-20.11.eb                           --set-default-module
  ParaView-5.9.0-CrayGNU-20.11-EGL-python3.eb            --set-default-module
  ParaView-5.9.1-CrayGNU-20.11-EGL-python3.eb
  PLUMED-2.6.1-CrayGNU-20.11.eb                          --set-default-module

--- a/jenkins-builds/7.0.UP02-20.11-dom-gpu
+++ b/jenkins-builds/7.0.UP02-20.11-dom-gpu
@@ -43,7 +43,7 @@
  netcdf-python-1.5.4-CrayGNU-20.11-python3.eb           --set-default-module
  numpy-1.17.2-CrayGNU-20.11.eb                          --set-default-module
  OOOPS-1.0.eb
- ovito-3.5.2-CrayGNU-20.11.eb                           --set-default-module
+ ovito-3.5.4-CrayGNU-20.11.eb                           --set-default-module
  ParaView-5.9.1-CrayGNU-20.11-EGL-python3.eb            --set-default-module
  PLUMED-2.6.1-CrayGNU-20.11.eb                          --set-default-module
  pycuda-2018.1.1-CrayGNU-20.11-python3-cuda.eb          --set-default-module


### PR DESCRIPTION
== COMPLETED: Installation ended successfully (took 21 secs)
== Results of the build can be found in the log file(s) /scratch/snx3000/jfavre/daint/software/ovito/3.5.4-CrayGNU-20.11/easybuild/easybuild-ovito-3.5.4-20211015.125808.log
== Build succeeded for 1 out of 1


was tested succesfully in a VNC desktop according to https://user.cscs.ch/computing/visualisation/ovito/