### PR TITLE
[daint dom] spack: discover intel-mkl available versions

### DIFF
--- a/spack/reframe/spack.py
+++ b/spack/reframe/spack.py
@@ -284,9 +284,8 @@ class spack_config_check(rfm.RunOnlyRegressionTest):
 
             if 'modules' in pkg_data:
                 pkg_versions = spacklib.get_module_available_versions(pkg_data['modules'])
-            else:
-                #TODO verify how to ge the version of prefix only packages like intel-mkl
-                pkg_versions = []
+            elif 'version' in pkg_data:
+                pkg_versions = pkg_data['version']
 
             external_specs = set()
             for pkg_version in pkg_versions:


### PR DESCRIPTION
Look for intel-mkl versions by inspecting `/opt/intel` directory and make them available for `packages.yaml` generation.

It is just a proposal to see if it can be improved and/or extended (e.g. for oneAPI).

Moreover, since `spack_config.py` can be considered a dynamically generated configuration (but without reframe information about the architecture at the moment), it could be useful to make this script "executable" so by running it is possible to get the configuration that will be considered for generating the spack configuration (e.g. useful for debugging purposes).

About the prefix used (see https://spack.readthedocs.io/en/latest/build_systems/intelpackage.html#integrating-external-libraries)
> Note that for the Intel packages discussed here, the directory values in the prefix: entries must be the high-level and typically version-less “installation directory” that has been used by Intel’s product installer. Such a directory will typically accumulate various product versions. Amongst them, Spack will select the correct version-specific product directory based on the @version spec component that each path is being defined for.