### PR TITLE
[daint-gpu] Major VTK upgrade

### DIFF
--- a/easybuild/easyconfigs/v/VTK/VTK-9.1.0-CrayGNU-20.11-EGL-python3.eb
+++ b/easybuild/easyconfigs/v/VTK/VTK-9.1.0-CrayGNU-20.11-EGL-python3.eb
@@ -1,0 +1,57 @@
+#
+# This file is an EasyBuild reciPY as per https://github.com/hpcugent/easybuild
+# CrayGNU version by Jean M. Favre and Victor Hollanda (CSCS)
+#
+easyblock = 'CMakeMake'
+
+name = 'VTK'
+version = '9.1.0'
+versionsuffix = '-EGL-python%(pymajver)s'
+
+homepage = 'http://www.vtk.org'
+description = """The Visualization Toolkit (VTK) is an open-source, freely
+available software system for 3D computer graphics, image processing and
+visualization. VTK consists of a C++ class library and several interpreted
+interface layers including Tcl/Tk, Java, and Python. VTK supports a wide
+variety of visualization algorithms including: scalar, vector, tensor, texture,
+and volumetric methods; and advanced modeling techniques such as: implicit
+modeling, polygon reduction, mesh smoothing, cutting, contouring, and Delaunay
+triangulation."""
+
+toolchain = {'name': 'CrayGNU', 'version': '20.11'}
+toolchainopts = {'verbose': False}
+
+source_urls = ['http://www.%(namelower)s.org/files/release/%(version_major_minor)s']
+sources = ['%(name)s-%(version)s.tar.gz']
+
+builddependencies = [
+    ('CMake', '3.14.5', '', True),
+]
+dependencies = [
+    ('cray-python', EXTERNAL_MODULE),
+    ('ospray', '2.7.0'),
+    ('oidn', '1.4.1'),
+    ('VisRTX', '0.1.6', '-cuda'),
+]
+
+configopts = '-DCMAKE_BUILD_TYPE=RelWithDebInfo -DBUILD_SHARED_LIBS:BOOL=ON -DVTK_BUILD_TESTING:STRING=OFF -DVTK_WRAP_PYTHON:BOOL=ON '
+configopts += '-DCMAKE_C_COMPILER:PATH=cc -DCMAKE_CXX_COMPILER:PATH=CC -DVTK_MODULE_ENABLE_VTK_RenderingRayTracing:STRING=YES -DVTK_ENABLE_VISRTX:BOOL=ON -DVTKOSPRAY_ENABLE_DENOISER:BOOL=ON -Dospray_DIR="$EBROOTOSPRAY" -DOpenImageDenoise_DIR="$EBROOTOIDN/lib/cmake/OpenImageDenoise" -DVisRTX_DIR="$EBROOTVISRTX/lib64/cmake/VisRTX-$EBVERSIONVISRTX" -DVTK_USE_X=OFF '
+configopts += '-DVTK_SMP_IMPLEMENTATION_TYPE:STRING=TBB -DTBB_INCLUDE_DIR:PATH=/opt/intel/compilers_and_libraries/linux/tbb/include -DTBB_LIBRARY_RELEASE:FILEPATH=/opt/intel/compilers_and_libraries/linux/tbb/lib/intel64/gcc4.8/libtbb.so -DTBB_MALLOC_LIBRARY_RELEASE:FILEPATH="$EBROOTOSPRAY/lib/libtbbmalloc.so" '
+configopts += '-DVTK_OPENGL_HAS_EGL:BOOL=ON -DOPENGL_egl_LIBRARY:FILEPATH=/usr/lib64/libEGL.so -DOPENGL_opengl_LIBRARY:FILEPATH=/usr/lib64/libOpenGL.so '
+
+maxparallel = 24
+
+sanity_check_paths = {
+    'files': ['bin/vtkpython'],
+    'dirs': ['lib64/python%(pyshortver)s/site-packages/', 'include/%(namelower)s-%(version_major_minor)s'],
+}
+
+#sanity_check_commands = [('bin/vtkpython', "-c 'import %(namelower)s'")]
+
+modextrapaths = {'PYTHONPATH': ['lib64/python%(pyshortver)s/site-packages']}
+
+modextravars = {'LD_LIBRARY_PATH': '$::env(PYTHONPATH)/lib:$::env(LD_LIBRARY_PATH)',
+                'TBB_ROOT': '/opt/intel/compilers_and_libraries/linux/tbb',
+}
+
+moduleclass = 'vis'


### PR DESCRIPTION
== COMPLETED: Installation ended successfully (took 16 mins 42 secs)
== Results of the build can be found in the log file(s) /scratch/snx3000/jfavre/daint/software/VTK/9.1.0-CrayGNU-20.11-EGL-python3/easybuild/easybuild-VTK-9.1.0-20211107.104509.log


Release notes: https://gitlab.kitware.com/vtk/vtk/-/blob/master/Documentation/release/9.1.md