### PR TITLE
[pilatus] Update Pilatus builds

### DIFF
--- a/easybuild/easyconfigs/j/Julia/Julia-1.6.3-cpeGNU-21.09.eb
+++ b/easybuild/easyconfigs/j/Julia/Julia-1.6.3-cpeGNU-21.09.eb
@@ -1,0 +1,29 @@
+# Recipe for linux, x86_64 created by Samuel Omlin (CSCS), Victor Holanda Rusu (CSCS)
+name = 'Julia'
+version = '1.6.3'
+
+homepage = 'https://julialang.org'
+description = "Julia is a high-level general-purpose dynamic programming language that was originally designed to address the needs of high-performance numerical analysis and computational science, without the typical need of separate compilation to be fast, also usable for client and server web use, low-level systems programming or as a specification language (wikipedia.org). Julia provides ease and expressiveness for high-level numerical computing, in the same way as languages such as R, MATLAB, and Python, but also supports general programming. To achieve this, Julia builds upon the lineage of mathematical programming languages, but also borrows much from popular dynamic languages, including Lisp, Perl, Python, Lua, and Ruby (julialang.org)."
+
+toolchain = {'name': 'cpeGNU', 'version': '21.09'}
+toolchainopts = {'usempi': True, 'pic': True, 'verbose': True}
+
+source_urls = ['https://julialang-s3.julialang.org/bin/linux/x64/%(version_major_minor)s/']
+sources = ['%(namelower)s-%(version)s-linux-%(arch)s.tar.gz']
+
+arch_name = 'mc'
+exts_defaultclass = 'JuliaPackage'
+
+exts_list = [
+    ('MPI.jl', '0.19.1', {'mpiexec': 'srun', 'mpiexec_args': '-C mc', 'source_tmpl': 'v0.19.1.tar.gz', 'source_urls': ['https://github.com/JuliaParallel/MPI.jl/archive/']}),
+]
+
+modextravars = {
+    'JULIA_MPICC': 'cc',
+    'JULIA_MPIEXEC': 'srun',
+    'JULIA_MPIEXEC_ARGS': "-C mc",
+    'JULIA_MPI_BINARY': 'system',
+    'JULIA_MPI_PATH': '$::env(CRAY_MPICH_DIR)'
+}
+
+moduleclass = 'lang'

--- a/easybuild/easyconfigs/j/JuliaExtensions/JuliaExtensions-1.6.3-cpeGNU-21.09.eb
+++ b/easybuild/easyconfigs/j/JuliaExtensions/JuliaExtensions-1.6.3-cpeGNU-21.09.eb
@@ -1,0 +1,25 @@
+# Recipe for linux, x86_64 created by Samuel Omlin (CSCS), Victor Holanda Rusu (CSCS)
+easyblock = 'JuliaBundle'
+
+name = 'JuliaExtensions'
+version = '1.6.3'
+
+homepage = 'https://julialang.org'
+description = "Extensions for julia"
+
+toolchain = {'name': 'cpeGNU', 'version': '21.09'}
+toolchainopts = {'pic': True, 'verbose': True}
+
+dependencies = [
+    ('Julia', version)
+]
+
+arch_name = 'mc'
+
+exts_list = [
+    ('Plots.jl', '1.22.6', {'source_tmpl': 'v1.22.6.tar.gz', 'source_urls': ['https://github.com/JuliaPlots/Plots.jl/archive/']}),
+    ('PyCall.jl', '1.92.3', {'source_tmpl': 'v1.92.3.tar.gz', 'source_urls': ['https://github.com/JuliaPy/PyCall.jl/archive/']}),
+    ('HDF5.jl', '0.15.6', {'source_tmpl': 'v0.15.6.tar.gz', 'source_urls': ['https://github.com/JuliaIO/HDF5.jl/archive/']})
+]
+
+moduleclass = 'tools'

--- a/easybuild/easyconfigs/o/oidn/oidn-1.4.1-cpeCray-21.09.eb
+++ b/easybuild/easyconfigs/o/oidn/oidn-1.4.1-cpeCray-21.09.eb
@@ -1,0 +1,21 @@
+easyblock = 'Tarball'
+
+name = 'oidn'
+version = '1.4.1'
+
+homepage = 'https://openimagedenoise.github.io'
+description = """Intel® Open Image Denoise is an open source library of high-performance,
+high-quality denoising filters for images rendered with ray tracing"""
+
+toolchain = {'name': 'cpeCray', 'version': '21.09'}
+
+source_urls = ['https://github.com/OpenImageDenoise/%(name)s/releases/download/v%(version)s/']
+sources = ['%(name)s-%(version)s.%(arch)s.linux.tar.gz']
+
+
+sanity_check_paths = {
+    'files': [],
+    'dirs': ['include', 'lib'],
+}
+
+moduleclass = 'devel'

--- a/easybuild/easyconfigs/o/ospray/ospray-2.7.0-cpeCray-21.09.eb
+++ b/easybuild/easyconfigs/o/ospray/ospray-2.7.0-cpeCray-21.09.eb
@@ -1,0 +1,21 @@
+easyblock = 'Tarball'
+
+name = 'ospray'
+version = '2.7.0'
+
+homepage = 'https://github.com/ospray'
+description = """An Open, Scalable, Parallel, Ray Tracing Based Rendering
+Engine for High-Fidelity Visualization"""
+
+toolchain = {'name': 'cpeCray', 'version': '21.09'}
+
+source_urls = ['https://github.com/%(name)s/%(name)s/releases/download/v%(version)s/']
+sources = ['%(name)s-%(version)s.%(arch)s.linux.tar.gz']
+
+
+sanity_check_paths = {
+    'files': [],
+    'dirs': ['include', 'lib'],
+}
+
+moduleclass = 'devel'

--- a/easybuild/easyconfigs/v/VTK/VTK-9.1.0-cpeCray-21.09-OSMesa-python3.eb
+++ b/easybuild/easyconfigs/v/VTK/VTK-9.1.0-cpeCray-21.09-OSMesa-python3.eb
@@ -1,0 +1,56 @@
+#
+# This file is an EasyBuild reciPY as per https://github.com/hpcugent/easybuild
+# CrayGNU version by Jean M. Favre and Victor Hollanda (CSCS)
+#
+easyblock = 'CMakeMake'
+
+name = 'VTK'
+version = '9.1.0'
+versionsuffix = '-OSMesa-python%(pymajver)s'
+
+homepage = 'http://www.vtk.org'
+description = """The Visualization Toolkit (VTK) is an open-source, freely
+available software system for 3D computer graphics, image processing and
+visualization. VTK consists of a C++ class library and several interpreted
+interface layers including Tcl/Tk, Java, and Python. VTK supports a wide
+variety of visualization algorithms including: scalar, vector, tensor, texture,
+and volumetric methods; and advanced modeling techniques such as: implicit
+modeling, polygon reduction, mesh smoothing, cutting, contouring, and Delaunay
+triangulation."""
+
+toolchain = {'name': 'cpeCray', 'version': '21.09'}
+toolchainopts = {'verbose': False}
+
+source_urls = ['http://www.%(namelower)s.org/files/release/%(version_major_minor)s']
+sources = [SOURCE_TAR_GZ]
+
+builddependencies = [
+    ('CMake', '3.20.1', '', True),
+]
+dependencies = [
+    ('cray-python', EXTERNAL_MODULE),
+    ('ospray', '2.7.0'),
+    ('oidn', '1.4.1'),
+    ('Mesa', '21.2.1'),
+]
+
+configopts = '-DCMAKE_BUILD_TYPE=RelWithDebInfo -DBUILD_SHARED_LIBS:BOOL=ON -DVTK_BUILD_TESTING:STRING=OFF -DVTK_WRAP_PYTHON:BOOL=ON -DCMAKE_C_COMPILER:PATH=cc -DCMAKE_CXX_COMPILER:PATH=CC -DVTK_MODULE_ENABLE_VTK_RenderingRayTracing:STRING=YES -DVTKOSPRAY_ENABLE_DENOISER:BOOL=ON -Dospray_DIR="$EBROOTOSPRAY" -DOpenImageDenoise_DIR="$EBROOTOIDN/lib/cmake/OpenImageDenoise" -DVTK_SMP_IMPLEMENTATION_TYPE:STRING=TBB -DTBB_INCLUDE_DIR:PATH=/opt/intel/compilers_and_libraries/linux/tbb/include -DTBB_LIBRARY_RELEASE:FILEPATH=/opt/intel/compilers_and_libraries/linux/tbb/lib/intel64/gcc4.8/libtbb.so -DTBB_MALLOC_LIBRARY_RELEASE:FILEPATH="$EBROOTOSPRAY/lib/libtbbmalloc.so" -DVTK_USE_X:BOOL=OFF -DVTK_OPENGL_HAS_OSMESA:BOOL=ON -DOSMESA_INCLUDE_DIR:PATH=${EBROOTMESA}/include -DOSMESA_LIBRARY:FILEPATH=${EBROOTMESA}/lib/libOSMesa.so -DVTK_PYTHON_OPTIONAL_LINK:BOOL=OFF '
+
+maxparallel = 32
+
+
+sanity_check_paths = {
+    'files': ['bin/vtkpython'],
+    'dirs': ['lib64/python%(pyshortver)s/site-packages/', 'include/%(namelower)s-%(version_major_minor)s'],
+}
+
+#sanity_check_commands = [('bin/vtkpython', "-c 'import %(namelower)s'")]
+
+modextrapaths = {'PYTHONPATH': ['lib64/python%(pyshortver)s/site-packages']}
+
+modextravars = {
+    'LD_LIBRARY_PATH': '$::env(PYTHONPATH)/lib:$::env(LD_LIBRARY_PATH)',
+    'TBB_ROOT': '/opt/intel/compilers_and_libraries/linux/tbb',
+}
+
+moduleclass = 'vis'

--- a/easybuild/module/EasyBuild-custom/cscs.lua
+++ b/easybuild/module/EasyBuild-custom/cscs.lua
@@ -64,9 +64,9 @@ end
 -- SYSTEM SPECIFIC (Cray with Lmod)
 local system=os.getenv("LMOD_SYSTEM_NAME") or os.getenv("CLUSTER_NAME")
 if system == "eiger" then
-	setenv("EASYBUILD_EXTERNAL_MODULES_METADATA", pathJoin(eb_custom_repository, "cpe_external_modules_metadata-21.04.cfg"))
-elseif system == "pilatus" then
 	setenv("EASYBUILD_EXTERNAL_MODULES_METADATA", pathJoin(eb_custom_repository, "cpe_external_modules_metadata-21.08.cfg"))
+elseif system == "pilatus" then
+	setenv("EASYBUILD_EXTERNAL_MODULES_METADATA", pathJoin(eb_custom_repository, "cpe_external_modules_metadata-21.09.cfg"))
 else
 	LmodError("System ", system, " is currently unsupported\n")
 end

--- a/jenkins-builds/1.4.0-21.09-eiger
+++ b/jenkins-builds/1.4.0-21.09-eiger
@@ -4,10 +4,11 @@
  hwloc-2.4.1.eb                       --set-default-module
  jupyter-utils-0.1.eb                 --set-default-module
  NCL-6.6.2.eb                         --set-default-module
- reframe-3.8.1.eb                     --set-default-module
+ reframe-3.9.0.eb                     --set-default-module
  singularity-3.5.3-eiger.eb
  GSL-2.7-cpeAMD-21.09.eb
  GSL-2.7-cpeCray-21.09.eb
+ ParaView-5.9.1-cpeCray-21.09-OSMesa-python3.eb
  Boost-1.75.0-cpeGNU-21.09.eb
  Boost-1.75.0-cpeGNU-21.09-python3.eb --set-default-module
  CDO-1.9.10-cpeGNU-21.09.eb
@@ -17,13 +18,14 @@
  GREASY-19.03-cscs-cpeGNU-21.09.eb
  GROMACS-2021.3-cpeGNU-21.09.eb
  GSL-2.7-cpeGNU-21.09.eb
- Julia-1.6.0-cpeGNU-21.09.eb
- JuliaExtensions-1.6.0-cpeGNU-21.09.eb
+ Julia-1.6.3-cpeGNU-21.09.eb
+ JuliaExtensions-1.6.3-cpeGNU-21.09.eb
  LAMMPS-20Sep21-cpeGNU-21.09.eb
  matplotlib-3.4.3-cpeGNU-21.09.eb
  NAMD-2.14-cpeGNU-21.09.eb
  NCO-5.0.1-cpeGNU-21.09.eb
- Scalasca-2.6-cpeGNU-21.09.eb       --set-default-module
+ Scalasca-2.6-cpeGNU-21.09.eb       
  GSL-2.7-cpeIntel-21.09.eb
  QuantumESPRESSO-6.8.0-cpeIntel-21.09.eb
  VASP-6.2.1-cpeIntel-21.09.eb
+ VTK-9.1.0-cpeCray-21.09-OSMesa-python3.eb


### PR DESCRIPTION
Pilatus toolchains default version is now 21.09, while Eiger will still keep 21.08: I have fixed the EasyBuild metadata accordingly. 
I am also updating the production list of 21.09 with the latest version of ReFrame, Julia, JuliaExtensions and VTK.