### PR TITLE
[tsa] Updated CDO with ecCodes and libaec

### DIFF
--- a/easybuild/easyconfigs/c/CDO/CDO-1.9.10-foss-2019b.eb
+++ b/easybuild/easyconfigs/c/CDO/CDO-1.9.10-foss-2019b.eb
@@ -10,8 +10,8 @@ description = "CDO is a collection of command line Operators to manipulate and a
 toolchain = {'name': 'foss', 'version': '2019b'}
 toolchainopts = {'opt': True, 'pic': True}
 
-source_urls = ['https://code.mpimet.mpg.de/attachments/download/20124']
-sources = [SOURCELOWER_TAR_GZ]
+# download from https://code.mpimet.mpg.de/projects/cdo/files often fails
+sources = ['/apps/common/UES/easybuild/sources/%(nameletterlower)s/%(name)s/%(namelower)s-%(version)s.tar.gz']
 
 # OpenMP support for compute intensive operators: https://code.zmaw.de/projects/cdo/wiki/OpenMP_support, no MPI support
 builddependencies = [

--- a/easybuild/easyconfigs/c/CDO/CDO-1.9.10-foss-2019b.eb
+++ b/easybuild/easyconfigs/c/CDO/CDO-1.9.10-foss-2019b.eb
@@ -1,0 +1,38 @@
+# Updated by @gppezzi @jgphpc and Luca Marsella (CSCS)
+easyblock = 'ConfigureMake'
+
+name = 'CDO'
+version = '1.9.10'
+
+homepage = 'https://code.zmaw.de/projects/cdo'
+description = "CDO is a collection of command line Operators to manipulate and analyse Climate and NWP model Data."
+
+toolchain = {'name': 'foss', 'version': '2019b'}
+toolchainopts = {'opt': True, 'pic': True}
+
+source_urls = ['https://code.mpimet.mpg.de/attachments/download/20124']
+sources = [SOURCELOWER_TAR_GZ]
+
+# OpenMP support for compute intensive operators: https://code.zmaw.de/projects/cdo/wiki/OpenMP_support, no MPI support
+builddependencies = [
+    ('HDF5', '1.10.5'),
+    ('netCDF-Fortran', '4.4.5'),
+    ('UDUNITS', '2.2.26', '', True),
+    ('PROJ', '6.1.1'),
+    ('libaec', '1.0.6'),
+    ('ecCodes', '2.23.0', '-python3'),
+    ('YAXT', '0.6.2'),
+]
+
+preconfigopts = " export NC_CONFIG=$EBROOTNETCDF/bin/nc-config && "
+configopts = " --enable-cdi-lib --with-szlib=$EBROOTLIBAEC --with-hdf5=$HDF5_DIR --with-netcdf=$EBROOTNETCDFMINFORTRAN  --with-udunits2=$EBROOTUDUNITS --with-fftw3 --with-proj=$EBROOTPROJ  --with-curl=$EBROOTCURL --with-eccodes=$EBROOTECCODES "
+
+# fix for linking issues with HDF5 libraries for libcdi, should link with both -lnetcdf and -lhdf5_hl -lhdf5
+#prebuildopts =  " libcdi -name Makefile -exec sed -i 's/-lnetcdf/-lnetcdff -lnetcdf/g' '{}' \; && "
+
+sanity_check_paths = {
+    'files': ['bin/%(namelower)s'],
+    'dirs': [],
+}
+
+moduleclass = 'data'

--- a/easybuild/easyconfigs/c/CDO/CDO-1.9.10-fosscuda-2019b.eb
+++ b/easybuild/easyconfigs/c/CDO/CDO-1.9.10-fosscuda-2019b.eb
@@ -1,0 +1,39 @@
+# Updated by @gppezzi @jgphpc and Luca Marsella (CSCS)
+easyblock = 'ConfigureMake'
+
+name = 'CDO'
+version = '1.9.10'
+
+homepage = 'https://code.zmaw.de/projects/cdo'
+description = "CDO is a collection of command line Operators to manipulate and analyse Climate and NWP model Data."
+
+toolchain = {'name': 'fosscuda', 'version': '2019b'}
+toolchainopts = {'opt': True, 'pic': True}
+
+source_urls = ['https://code.mpimet.mpg.de/attachments/download/20124']
+sources = [SOURCELOWER_TAR_GZ]
+
+# OpenMP support for compute intensive operators: https://code.zmaw.de/projects/cdo/wiki/OpenMP_support, no MPI support
+builddependencies = [
+    ('HDF5', '1.10.5'),
+    ('netCDF-Fortran', '4.4.5'),
+    ('UDUNITS', '2.2.26', '', True),
+    ('PROJ', '6.1.1'),
+    ('libaec', '1.0.6'),
+    ('ecCodes', '2.23.0', '-python3'),
+    ('YAXT', '0.6.2'),
+]
+
+preconfigopts = " export NC_CONFIG=$EBROOTNETCDF/bin/nc-config && "
+configopts = " --enable-cdi-lib --with-szlib=$EBROOTLIBAEC --with-hdf5=$HDF5_DIR --with-netcdf=$EBROOTNETCDFMINFORTRAN  --with-udunits2=$EBROOTUDUNITS --with-fftw3 --with-proj=$EBROOTPROJ  --with-curl=$EBROOTCURL --with-eccodes=$EBROOTECCODES "
+
+
+# fix for linking issues with HDF5 libraries for libcdi, should link with both -lnetcdf and -lhdf5_hl -lhdf5
+# prebuildopts =  " libcdi -name Makefile -exec sed -i 's/-lnetcdf/-lnetcdff -lnetcdf/g' '{}' \; && "
+
+sanity_check_paths = {
+    'files': ['bin/%(namelower)s'],
+    'dirs': [],
+}
+
+moduleclass = 'data'

--- a/easybuild/easyconfigs/c/CDO/CDO-1.9.10-fosscuda-2019b.eb
+++ b/easybuild/easyconfigs/c/CDO/CDO-1.9.10-fosscuda-2019b.eb
@@ -10,8 +10,8 @@ description = "CDO is a collection of command line Operators to manipulate and a
 toolchain = {'name': 'fosscuda', 'version': '2019b'}
 toolchainopts = {'opt': True, 'pic': True}
 
-source_urls = ['https://code.mpimet.mpg.de/attachments/download/20124']
-sources = [SOURCELOWER_TAR_GZ]
+# download from https://code.mpimet.mpg.de/projects/cdo/files often fails
+sources = ['/apps/common/UES/easybuild/sources/%(nameletterlower)s/%(name)s/%(namelower)s-%(version)s.tar.gz']
 
 # OpenMP support for compute intensive operators: https://code.zmaw.de/projects/cdo/wiki/OpenMP_support, no MPI support
 builddependencies = [

--- a/easybuild/easyconfigs/e/ecCodes/ecCodes-2.23.0-foss-2019b-python3.eb
+++ b/easybuild/easyconfigs/e/ecCodes/ecCodes-2.23.0-foss-2019b-python3.eb
@@ -1,0 +1,34 @@
+# contributed by Matthias Kraushaar and Luca Marsella (CSCS)
+easyblock = 'CMakeMake'
+
+name = 'ecCodes'
+version = '2.23.0'
+versionsuffix = '-python3'
+
+homepage = 'https://confluence.ecmwf.int/display/ECC/ecCodes+Home'
+description = """ecCodes is a package developed by ECMWF which provides an application programming interface 
+and a set of tools for decoding and encoding messages in the WMO GRIB and BUFR formats."""
+
+toolchain = {'name': 'foss', 'version': '2019b'}
+
+source_urls = ['https://confluence.ecmwf.int/download/attachments/45757960/']
+sources = ['%(namelower)s-%(version)s-Source.tar.gz']
+
+builddependencies = [
+    ('CMake', '3.14.5', '', True),
+    ('JasPer', '2.0.14'),
+    ('libaec', '1.0.6'),
+    ('netCDF', '4.7.0'),
+    ('PyExtensions', '3.7.4'),
+]
+
+configopts = "-DENABLE_AEC=ON -DENABLE_JPG=ON -DENABLE_NETCDF=ON -DENABLE_PYTHON=ON"
+
+separate_build_dir = True
+
+sanity_check_paths = {
+    'files': ['bin/bufr_copy', 'bin/bufr_dump', 'bin/bufr_filter', 'bin/bufr_ls', 'bin/codes_count', 'bin/codes_info', 'bin/codes_split_file', 'bin/grib_copy', 'bin/grib_dump', 'bin/grib_filter', 'bin/grib_ls'],
+    'dirs': [],
+}
+
+moduleclass = 'tools'

--- a/easybuild/easyconfigs/e/ecCodes/ecCodes-2.23.0-fosscuda-2019b-python3.eb
+++ b/easybuild/easyconfigs/e/ecCodes/ecCodes-2.23.0-fosscuda-2019b-python3.eb
@@ -1,0 +1,33 @@
+# contributed by Matthias Kraushaar and Luca Marsella (CSCS)
+easyblock = 'CMakeMake'
+
+name = 'ecCodes'
+version = '2.23.0'
+versionsuffix = '-python3'
+
+homepage = 'https://confluence.ecmwf.int/display/ECC/ecCodes+Home'
+description = """ecCodes is a package developed by ECMWF which provides an application programming interface 
+and a set of tools for decoding and encoding messages in the WMO GRIB and BUFR formats."""
+
+toolchain = {'name': 'fosscuda', 'version': '2019b'}
+
+source_urls = ['https://confluence.ecmwf.int/download/attachments/45757960/']
+sources = ['%(namelower)s-%(version)s-Source.tar.gz']
+
+builddependencies = [
+    ('CMake', '3.14.5', '', True),
+    ('JasPer', '2.0.14'),
+    ('libaec', '1.0.6'),
+    ('netCDF', '4.7.0'),
+    ('PyExtensions', '3.7.4'),
+]
+
+configopts = "-DENABLE_AEC=ON -DENABLE_JPG=ON -DENABLE_NETCDF=ON -DENABLE_PYTHON=ON"
+
+
+sanity_check_paths = {
+    'files': ['bin/bufr_copy', 'bin/bufr_dump', 'bin/bufr_filter', 'bin/bufr_ls', 'bin/codes_count', 'bin/codes_info', 'bin/codes_split_file', 'bin/grib_copy', 'bin/grib_dump', 'bin/grib_filter', 'bin/grib_ls'],
+    'dirs': [],
+}
+
+moduleclass = 'tools'

--- a/easybuild/easyconfigs/l/libaec/libaec-1.0.6-foss-2019b.eb
+++ b/easybuild/easyconfigs/l/libaec/libaec-1.0.6-foss-2019b.eb
@@ -1,0 +1,42 @@
+# Contributed by Matthias Kraushaar and Luca Marsella (CSCS)
+easyblock = 'ConfigureMake'
+
+name = 'libaec'
+version = '1.0.6'
+
+homepage = 'https://gitlab.dkrz.de/k202009/libaec'
+description = """
+    libaec - Adaptive Entropy Coding library
+
+    Libaec provides fast lossless compression of 1 up to 32 bit wide
+    signed or unsigned integers (samples). The library achieves best
+    results for low entropy data as often encountered in space imaging
+    instrument data or numerical model output from weather or climate
+    simulations. While floating point representations are not directly
+    supported, they can also be efficiently coded by grouping exponents
+    and mantissa.
+
+    *****************  SZIP compatibility *********************** 
+    Libaec includes a free drop-in replacement for the SZIP library (http://www.hdfgroup.org/doc_resource/SZIP). 
+    Just replace SZIP's shared library libsz.so* with libaec.so* and libsz.so* from libaec. 
+    Code which is dynamically linked with SZIP such as HDF5 should continue to work with libaec. 
+    No re-compilation required. HDF5 files which contain SZIP encoded data can be decoded by HDF5 
+    using libaec and vice versa.
+"""
+
+toolchain = {'name': 'foss', 'version': '2019b'}
+toolchainopts = {'pic': 'True'}
+
+source_urls = ['https://gitlab.dkrz.de/k202009/%(name)s/-/archive/v%(version)s']
+sources = ['%(name)s-v%(version)s.tar.bz2']
+
+# confgiure script missing in downloaded package
+preconfigopts = " autoreconf -iv && "
+
+
+sanity_check_paths = {
+    'files': ['lib/libsz.a'],
+    'dirs': ['lib', 'include'],
+}
+
+moduleclass = 'data'

--- a/easybuild/easyconfigs/l/libaec/libaec-1.0.6-fosscuda-2019b.eb
+++ b/easybuild/easyconfigs/l/libaec/libaec-1.0.6-fosscuda-2019b.eb
@@ -1,0 +1,42 @@
+# Contributed by Matthias Kraushaar and Luca Marsella (CSCS)
+easyblock = 'ConfigureMake'
+
+name = 'libaec'
+version = '1.0.6'
+
+homepage = 'https://gitlab.dkrz.de/k202009/libaec'
+description = """
+    libaec - Adaptive Entropy Coding library
+
+    Libaec provides fast lossless compression of 1 up to 32 bit wide
+    signed or unsigned integers (samples). The library achieves best
+    results for low entropy data as often encountered in space imaging
+    instrument data or numerical model output from weather or climate
+    simulations. While floating point representations are not directly
+    supported, they can also be efficiently coded by grouping exponents
+    and mantissa.
+
+    *****************  SZIP compatibility *********************** 
+    Libaec includes a free drop-in replacement for the SZIP library (http://www.hdfgroup.org/doc_resource/SZIP). 
+    Just replace SZIP's shared library libsz.so* with libaec.so* and libsz.so* from libaec. 
+    Code which is dynamically linked with SZIP such as HDF5 should continue to work with libaec. 
+    No re-compilation required. HDF5 files which contain SZIP encoded data can be decoded by HDF5 
+    using libaec and vice versa.
+"""
+
+toolchain = {'name': 'fosscuda', 'version': '2019b'}
+toolchainopts = {'pic': 'True'}
+
+source_urls = ['https://gitlab.dkrz.de/k202009/%(name)s/-/archive/v%(version)s']
+sources = ['%(name)s-v%(version)s.tar.bz2']
+
+# confgiure script missing in downloaded package
+preconfigopts = " autoreconf -iv && "
+
+
+sanity_check_paths = {
+    'files': ['lib/libsz.a'],
+    'dirs': ['lib', 'include'],
+}
+
+moduleclass = 'data'


### PR DESCRIPTION
I provide the recipes of CDO, ecCodes and libaec with the toolchains `foss` and `fosscuda`, version `2019b` (see [SD-53816](https://jira.cscs.ch/browse/SD-53816)).