### PR TITLE
[pilatus] jupyterlab-2.2.10-cpeGNU-21.09.eb

### DIFF
--- a/easybuild/easyconfigs/j/jupyterlab/jupyterlab-2.2.10-cpeGNU-21.09.eb
+++ b/easybuild/easyconfigs/j/jupyterlab/jupyterlab-2.2.10-cpeGNU-21.09.eb
@@ -15,7 +15,7 @@ dependencies = [
     ('configurable-http-proxy', '4.2.3'),
     ('graphviz', '2.46.1'),
     ('libffi', '3.3'),
-    ('JuliaExtensions', '1.6.0'),
+    ('JuliaExtensions', '1.6.3'),
     ('cray-R', EXTERNAL_MODULE),
 ]
 


### PR DESCRIPTION
This upgrades the JupyterLab Julia kernel to julia 1.6.3, to match the new version on Pilatus. 