### PR TITLE
[dom-mc] spack_config: fix dom-mc install path

### DIFF
--- a/jenkins-builds/7.0.UP03-21.09-dom-mc
+++ b/jenkins-builds/7.0.UP03-21.09-dom-mc
@@ -47,6 +47,6 @@
  likwid-1d6636c.eb                                      --set-default-module --installpath=/apps/dom/UES/jenkins/7.0.UP03/21.09/dom-mc/tools
  njmon-v64-SLES15.eb                                    --set-default-module --installpath=/apps/dom/UES/jenkins/7.0.UP03/21.09/dom-mc/tools
  pprof-1a94d86.eb                                       --set-default-module --installpath=/apps/dom/UES/jenkins/7.0.UP03/21.09/dom-mc/tools
- spack-config-1.0-cdt-21.09.eb                          --set-default-module --installpath=/apps/dom/UES/jenkins/7.0.UP03/21.09/dom-gpu/tools
+ spack-config-1.0-cdt-21.09.eb                          --set-default-module --installpath=/apps/dom/UES/jenkins/7.0.UP03/21.09/dom-mc/tools
  termgraph-0.4.2-python3.eb                             --set-default-module --installpath=/apps/dom/UES/jenkins/7.0.UP03/21.09/dom-mc/tools
  vtune_profiler-2021.1.1.61.eb                          --set-default-module --installpath=/apps/dom/UES/jenkins/7.0.UP03/21.09/dom-mc/tools


### PR DESCRIPTION
What about the old install path? How does it get cleaned up?