### PR TITLE
[dom-gpu] ParaView with EGL

### DIFF
--- a/easybuild/easyconfigs/p/ParaView/ParaView-5.9.1-CrayGNU-21.09-EGL.eb
+++ b/easybuild/easyconfigs/p/ParaView/ParaView-5.9.1-CrayGNU-21.09-EGL.eb
@@ -1,0 +1,56 @@
+# CrayGNU version by Jean Favre (CSCS)
+easyblock = 'CMakeMake'
+
+name = 'ParaView'
+version = '5.9.1'
+versionsuffix = '-EGL'
+
+homepage = 'http://www.paraview.org'
+description = "ParaView is a scientific parallel visualizer."
+
+toolchain = {'name': 'CrayGNU', 'version': '21.09'}
+toolchainopts = {'pic': True, 'usempi': True, 'verbose': False}
+
+source_urls = [
+    'http://www.%(namelower)s.org/%(namelower)s-downloads/download.php?submit=Download&version=v%(version_major_minor)s&type=source&os=all&downloadFile=',
+]
+sources = ['%(name)s-v%(version)s.tar.gz']
+
+builddependencies = [
+    ('CMake', '3.21.3', '', True)
+]
+
+dependencies = [
+    ('Boost', '1.77.0', '-python%(pymajver)s'),
+    ('cray-python', EXTERNAL_MODULE),
+    ('h5py', '3.6.0', '-serial'),
+    ('oidn', '1.4.2'),
+    ('ospray', '2.8.0'),
+    ('VisRTX', '0.1.6', '-cuda')
+]
+
+configopts = '-DPARAVIEW_USE_MPI:BOOL=ON -DMPI_C_COMPILER=cc -DMPI_CXX_COMPILER=CC -DBUILD_TESTING:BOOL=OFF -DPARAVIEW_BUILD_EDITION=CANONICAL -DPARAVIEW_USE_PYTHON:BOOL=ON -DPYTHON_EXECUTABLE=${EBROOTPYTHON}/bin/python%(pymajver)s -DCMAKE_BUILD_TYPE=RelWithDebInfo -DPARAVIEW_BUILD_SHARED_LIBS:BOOL=ON -DVTK_SMP_IMPLEMENTATION_TYPE=TBB -DTBB_INCLUDE_DIR:PATH=/opt/intel/compilers_and_libraries/linux/tbb/include -DTBB_LIBRARY_RELEASE=/opt/intel/compilers_and_libraries/linux/tbb/lib/intel64/gcc4.8/libtbb.so -DTBB_MALLOC_LIBRARY_RELEASE=/opt/intel/compilers_and_libraries/linux/tbb/lib/intel64/gcc4.8/libtbbmalloc.so -DOPENGL_opengl_LIBRARY=/usr/lib64/libOpenGL.so -DOPENGL_egl_LIBRARY=/usr/lib64/libEGL.so -DOPENGL_INCLUDE_DIR=/opt/cray/nvidia/default/include -DPARAVIEW_USE_VTKM:BO0L=OFF -DPARAVIEW_USE_QT:BOOL=OFF -DPARAVIEW_ENABLE_WEB:BOOL=OFF -DPARAVIEW_ENABLE_XDMF3:BOOL=ON -DVTK_OPENGL_HAS_EGL:BOOL=ON -DVTK_USE_X:BOOL=OFF -DPARAVIEW_ENABLE_RAYTRACING:BOOL=ON -DVTK_ENABLE_OSPRAY:BOOL=ON -DVTK_ENABLE_VISRTX:BOOL=ON -DVTKOSPRAY_ENABLE_DENOISER:BOOL=ON -DOSPRAY_INSTALL_DIR="$EBROOTOSPRAY" -DOpenImageDenoise_DIR="$EBROOTOIDN/lib/cmake/OpenImageDenoise" -DVisRTX_DIR="$EBROOTVISRTX/lib64/cmake/VisRTX-$EBVERSIONVISRTX" -DPARAVIEW_PLUGIN_ENABLE_pvNVIDIAIndeX:BOOL=ON '
+
+maxparallel = 24
+
+postinstallcmds = [
+    "mkdir -p %(installdir)s/share/%(namelower)s-%(version_major_minor)s && cd %(installdir)s/share/%(namelower)s-%(version_major_minor)s && git clone https://gitlab.kitware.com/%(namelower)s/materials",
+]
+
+sanity_check_paths = {
+    'files': ['bin/pvbatch', 'bin/pvserver'],
+    'dirs': ['lib64/python%(pyshortver)s/site-packages', 'lib64/%(namelower)s-%(version_major_minor)s/plugins'],
+}
+
+modextrapaths = {'PYTHONPATH': 'lib64/python%(pyshortver)s/site-packages'}
+
+modextravars = {
+    'NVINDEX_PVPLUGIN_HOME': '/apps/common/UES/easybuild/sources/p/%(name)s',
+    'TBB_ROOT': '/opt/intel/compilers_and_libraries/linux/tbb'
+}
+
+modtclfooter = """
+    prepend-path LD_LIBRARY_PATH /apps/common/UES/easybuild/sources/p/%(name)s/nvindex_default/linux-x86-64/lib:/opt/intel/compilers_and_libraries/linux/tbb/lib/intel64/gcc4.8:/opt/python/%(pyver)s/lib
+"""
+
+moduleclass = 'vis'

--- a/easybuild/easyconfigs/p/ParaView/ParaView-5.9.1-CrayGNU-21.09-EGL.eb
+++ b/easybuild/easyconfigs/p/ParaView/ParaView-5.9.1-CrayGNU-21.09-EGL.eb
@@ -34,7 +34,9 @@ configopts = '-DPARAVIEW_USE_MPI:BOOL=ON -DMPI_C_COMPILER=cc -DMPI_CXX_COMPILER=
 maxparallel = 24
 
 postinstallcmds = [
-    "mkdir -p %(installdir)s/share/%(namelower)s-%(version_major_minor)s && cd %(installdir)s/share/%(namelower)s-%(version_major_minor)s && git clone https://gitlab.kitware.com/%(namelower)s/materials",
+    "tar xf /apps/common/UES/easybuild/sources/%(nameletterlower)s/%(name)s/materials.tar.bz2 -C %(installdir)s/share/%(namelower)s-%(version_major_minor)s"
+# FIXME: avoid git clone on Dom due to SD-53990
+#   "mkdir -p %(installdir)s/share/%(namelower)s-%(version_major_minor)s && cd %(installdir)s/share/%(namelower)s-%(version_major_minor)s && git clone https://gitlab.kitware.com/%(namelower)s/materials"
 ]
 
 sanity_check_paths = {

--- a/jenkins-builds/7.0.UP03-21.09-dom-gpu
+++ b/jenkins-builds/7.0.UP03-21.09-dom-gpu
@@ -31,6 +31,7 @@
  numpy-1.17.2-CrayGNU-21.09.eb                          --set-default-module
  OOOPS-1.0.eb
  ovito-3.5.4-CrayGNU-21.09.eb                           --set-default-module
+ ParaView-5.9.1-CrayGNU-21.09-EGL.eb                    --set-default-module
  PLUMED-2.7.2-CrayGNU-21.09.eb                          --set-default-module
  pycuda-2021.1-CrayGNU-21.09-cuda.eb                    --set-default-module
  QuantumESPRESSO-6.8.0-CrayNvidia-21.09.eb              --set-default-module


### PR DESCRIPTION
I provide the recipe of ParaView with EGL and dependencies with CDT 21.09 on Dom: I have removed the suffix `-python3`, since only Python3 is supported.

Please note that the build of ParaView would fail on GPFS due to the issue reported in [SD-53990](https://jira.cscs.ch/browse/SD-53990), since the `postinstallcmds` use `git clone`.