### PR TITLE
[dom] Update lists and recipes for Dom

### DIFF
--- a/easybuild/easyconfigs/c/Cython/Cython-0.29.25-CrayGNU-21.09.eb
+++ b/easybuild/easyconfigs/c/Cython/Cython-0.29.25-CrayGNU-21.09.eb
@@ -1,0 +1,31 @@
+# contributed by Luca Marsella (CSCS)
+easyblock = 'PythonPackage'
+
+name = 'Cython'
+version = '0.29.25'
+
+homepage = 'https://pypi.python.org/pypi/Cython/'
+description = """The Cython language makes writing C extensions for the Python language as easy as Python itself.
+Cython is a source code translator based on the well-known Pyrex, but supports more cutting edge functionality and optimizations."""
+
+toolchain = {'name': 'CrayGNU', 'version': '21.09'}
+
+source_urls = [PYPI_SOURCE]
+sources = [SOURCE_TAR_GZ]
+
+dependencies = [
+    ('cray-python', EXTERNAL_MODULE)
+]
+
+local_cythonlibdir = 'lib/python%(pyshortver)s/site-packages/Cython-%(version)s-py%(pyshortver)s-linux-x86_64.egg'
+
+sanity_check_paths = {
+    'files': ['bin/cygdb', 'bin/cython', '%s/%%(namelower)s.py' % local_cythonlibdir],
+    'dirs': [local_cythonlibdir + '/%(name)s']
+}
+
+modextrapaths = { 
+    'PYTHONPATH': local_cythonlibdir
+}
+
+moduleclass = 'lang'

--- a/easybuild/easyconfigs/c/cftime/site.py
+++ b/easybuild/easyconfigs/c/cftime/site.py
@@ -1,0 +1,76 @@
+def __boot():
+    import sys
+    import os
+    PYTHONPATH = os.environ.get('PYTHONPATH')
+    if PYTHONPATH is None or (sys.platform == 'win32' and not PYTHONPATH):
+        PYTHONPATH = []
+    else:
+        PYTHONPATH = PYTHONPATH.split(os.pathsep)
+
+    pic = getattr(sys, 'path_importer_cache', {})
+    stdpath = sys.path[len(PYTHONPATH):]
+    mydir = os.path.dirname(__file__)
+
+    for item in stdpath:
+        if item == mydir or not item:
+            continue  # skip if current dir. on Windows, or my own directory
+        importer = pic.get(item)
+        if importer is not None:
+            loader = importer.find_module('site')
+            if loader is not None:
+                # This should actually reload the current module
+                loader.load_module('site')
+                break
+        else:
+            try:
+                import imp  # Avoid import loop in Python 3
+                stream, path, descr = imp.find_module('site', [item])
+            except ImportError:
+                continue
+            if stream is None:
+                continue
+            try:
+                # This should actually reload the current module
+                imp.load_module('site', stream, path, descr)
+            finally:
+                stream.close()
+            break
+    else:
+        raise ImportError("Couldn't find the real 'site' module")
+
+    # 2.2 comp
+    known_paths = dict([(
+        makepath(item)[1], 1) for item in sys.path])  # noqa
+
+    oldpos = getattr(sys, '__egginsert', 0)  # save old insertion position
+    sys.__egginsert = 0  # and reset the current one
+
+    for item in PYTHONPATH:
+        addsitedir(item)  # noqa
+
+    sys.__egginsert += oldpos  # restore effective old position
+
+    d, nd = makepath(stdpath[0])  # noqa
+    insert_at = None
+    new_path = []
+
+    for item in sys.path:
+        p, np = makepath(item)  # noqa
+
+        if np == nd and insert_at is None:
+            # We've hit the first 'system' path entry, so added entries go here
+            insert_at = len(new_path)
+
+        if np in known_paths or insert_at is None:
+            new_path.append(item)
+        else:
+            # new path after the insert point, back-insert it
+            new_path.insert(insert_at, item)
+            insert_at += 1
+
+    sys.path[:] = new_path
+
+
+if __name__ == 'site':
+    __boot()
+    del __boot

--- a/easybuild/easyconfigs/n/NCO/NCO-5.0.4-CrayGNU-21.09.eb
+++ b/easybuild/easyconfigs/n/NCO/NCO-5.0.4-CrayGNU-21.09.eb
@@ -1,0 +1,29 @@
+# contributed by Luca Marsella (CSCS), updated by Samuel Omlin (CSCS)
+easyblock = 'ConfigureMake'
+
+name = 'NCO'
+version = '5.0.4'
+
+homepage = 'http://nco.sourceforge.net/'
+description = "The NCO toolkit manipulates and analyzes data stored in netCDF-accessible formats, including DAP, HDF4, and HDF5."
+
+toolchain = {'name': 'CrayGNU', 'version': '21.09'}
+toolchainopts = {'opt': True, 'pic': True}
+
+sources = ['https://github.com/%(namelower)s/%(namelower)s/archive/%(version)s.tar.gz']
+
+dependencies = [
+    ('ANTLR', '2.7.7', '-python3'),
+    ('cray-hdf5', EXTERNAL_MODULE),
+    ('cray-netcdf', EXTERNAL_MODULE),
+    ('JasPer', '2.0.33'),
+    ('UDUNITS', '2.2.28')
+]
+
+
+sanity_check_paths = {
+    'files': ['bin/ncbo'],
+    'dirs': []
+}
+
+moduleclass = 'data'

--- a/easybuild/easyconfigs/n/numpy/mkl-2021-sitecfg.patch
+++ b/easybuild/easyconfigs/n/numpy/mkl-2021-sitecfg.patch
@@ -1,0 +1,16 @@
+diff -Nru numpy-1.16.4.orig/site.cfg numpy-1.16.4/site.cfg
+--- numpy-1.16.4.orig/site.cfg	1970-01-01 01:00:00.000000000 +0100
++++ numpy-1.16.4/site.cfg	2019-10-04 13:51:55.000000000 +0200
+@@ -0,0 +1,12 @@
++# MKL
++#----
++# Intel MKL is Intel's very optimized yet proprietary implementation of BLAS and
++# Lapack. Find the latest info on building numpy with Intel MKL in this article:
++# https://software.intel.com/en-us/articles/numpyscipy-with-intel-mkl
++# Assuming you installed the mkl in /opt/intel/compilers_and_libraries_2019/linux/mkl,
++# for 64 bits code at Linux:
++[mkl]
++library_dirs = /opt/intel/mkl/lib/intel64
++include_dirs = /opt/intel/mkl/include
++mkl_libs = mkl_rt
++lapack_libs = 

--- a/easybuild/easyconfigs/n/numpy/numpy-1.21.4-CrayGNU-21.09.eb
+++ b/easybuild/easyconfigs/n/numpy/numpy-1.21.4-CrayGNU-21.09.eb
@@ -1,0 +1,36 @@
+# contributed by Luca Marsella (CSCS)
+easyblock = 'PythonPackage'
+
+name = 'numpy'
+version = '1.21.4'
+
+homepage = 'https://github.com/numpy/numpy'
+description = """NumPy is the fundamental package for scientific computing with Python. It contains among other things:
+ a powerful N-dimensional array object, sophisticated (broadcasting) functions, tools for integrating C/C++ and Fortran
+ code, useful linear algebra, Fourier transform, and random number capabilities. Besides its obvious scientific uses,
+ NumPy can also be used as an efficient multi-dimensional container of generic data. Arbitrary data-types can be
+ defined. This allows NumPy to seamlessly and speedily integrate with a wide variety of databases."""
+
+toolchain = {'name': 'CrayGNU', 'version': '21.09'}
+toolchainopts = {'verbose': False}
+
+sources = ['https://github.com/%(name)s/%(name)s/archive/refs/tags/v%(version)s.tar.gz']
+patches = [('mkl-2021-sitecfg.patch', 1)]
+
+dependencies = [
+    ('cray-python', EXTERNAL_MODULE),
+    ('Cython', '0.29.25')
+]
+
+skipsteps = ['build']
+
+sanity_check_paths = {
+    'files': [],
+    'dirs': ['lib/python%(pyshortver)s/site-packages']
+}
+
+modextravars = {
+    'LD_LIBRARY_PATH': '/opt/intel/mkl/lib/intel64:$::env(LD_LIBRARY_PATH)'
+}
+
+moduleclass = 'tools'

--- a/easybuild/easyconfigs/p/pycuda/site.py
+++ b/easybuild/easyconfigs/p/pycuda/site.py
@@ -1,0 +1,76 @@
+def __boot():
+    import sys
+    import os
+    PYTHONPATH = os.environ.get('PYTHONPATH')
+    if PYTHONPATH is None or (sys.platform == 'win32' and not PYTHONPATH):
+        PYTHONPATH = []
+    else:
+        PYTHONPATH = PYTHONPATH.split(os.pathsep)
+
+    pic = getattr(sys, 'path_importer_cache', {})
+    stdpath = sys.path[len(PYTHONPATH):]
+    mydir = os.path.dirname(__file__)
+
+    for item in stdpath:
+        if item == mydir or not item:
+            continue  # skip if current dir. on Windows, or my own directory
+        importer = pic.get(item)
+        if importer is not None:
+            loader = importer.find_module('site')
+            if loader is not None:
+                # This should actually reload the current module
+                loader.load_module('site')
+                break
+        else:
+            try:
+                import imp  # Avoid import loop in Python 3
+                stream, path, descr = imp.find_module('site', [item])
+            except ImportError:
+                continue
+            if stream is None:
+                continue
+            try:
+                # This should actually reload the current module
+                imp.load_module('site', stream, path, descr)
+            finally:
+                stream.close()
+            break
+    else:
+        raise ImportError("Couldn't find the real 'site' module")
+
+    # 2.2 comp
+    known_paths = dict([(
+        makepath(item)[1], 1) for item in sys.path])  # noqa
+
+    oldpos = getattr(sys, '__egginsert', 0)  # save old insertion position
+    sys.__egginsert = 0  # and reset the current one
+
+    for item in PYTHONPATH:
+        addsitedir(item)  # noqa
+
+    sys.__egginsert += oldpos  # restore effective old position
+
+    d, nd = makepath(stdpath[0])  # noqa
+    insert_at = None
+    new_path = []
+
+    for item in sys.path:
+        p, np = makepath(item)  # noqa
+
+        if np == nd and insert_at is None:
+            # We've hit the first 'system' path entry, so added entries go here
+            insert_at = len(new_path)
+
+        if np in known_paths or insert_at is None:
+            new_path.append(item)
+        else:
+            # new path after the insert point, back-insert it
+            new_path.insert(insert_at, item)
+            insert_at += 1
+
+    sys.path[:] = new_path
+
+
+if __name__ == 'site':
+    __boot()
+    del __boot

--- a/jenkins-builds/7.0.UP03-21.09-dom-gpu
+++ b/jenkins-builds/7.0.UP03-21.09-dom-gpu
@@ -25,10 +25,10 @@
  magma-2.5.4-CrayIntel-21.09-cuda.eb                    --set-default-module
  matplotlib-3.5.0-CrayGNU-21.09.eb                      --set-default-module
  NCL-6.6.2.eb                                           --set-default-module
- NCO-4.8.1-CrayGNU-21.09.eb                             --set-default-module
+ NCO-5.0.4-CrayGNU-21.09.eb                             --set-default-module
  ncview-2.1.7-CrayGNU-21.09.eb                          --set-default-module
  netcdf4-python-1.5.8-CrayGNU-21.09.eb                  --set-default-module
- numpy-1.17.2-CrayGNU-21.09.eb                          --set-default-module
+ numpy-1.21.4-CrayGNU-21.09.eb                          --set-default-module
  OOOPS-1.0.eb
  ovito-3.5.4-CrayGNU-21.09.eb                           --set-default-module
  ParaView-5.9.1-CrayGNU-21.09-EGL.eb                    --set-default-module

--- a/jenkins-builds/7.0.UP03-21.09-dom-mc
+++ b/jenkins-builds/7.0.UP03-21.09-dom-mc
@@ -23,11 +23,11 @@
  LAMMPS-20Sep21-CrayGNU-21.09.eb                        --set-default-module
  Lmod-7.8.2.eb                                          --set-default-module --hidden
  matplotlib-3.5.0-CrayGNU-21.09.eb                      --set-default-module
- NCL-6.4.0.eb                                           --set-default-module
- NCO-4.8.1-CrayGNU-21.09.eb                             --set-default-module
+ NCL-6.6.2.eb                                           --set-default-module
+ NCO-5.0.4-CrayGNU-21.09.eb                             --set-default-module
  ncview-2.1.7-CrayGNU-21.09.eb                          --set-default-module
  netcdf4-python-1.5.8-CrayGNU-21.09.eb                  --set-default-module
- numpy-1.17.2-CrayGNU-21.09.eb                          --set-default-module
+ numpy-1.21.4-CrayGNU-21.09.eb                          --set-default-module
  OOOPS-1.0.eb
  PLUMED-2.7.2-CrayGNU-21.09.eb                          --set-default-module
  QuantumESPRESSO-6.8.0-CrayIntel-21.09.eb               --set-default-module

--- a/jenkins/JenkinsfileUpdateEB
+++ b/jenkins/JenkinsfileUpdateEB
@@ -83,6 +83,7 @@ stage('Update Stage') {
                     */
                     def eb_flags
                     def eb_tcflags
+                    def eb_buildpath
                     def eb_installpath
                     def eb_modulespath
                     def load_pe
@@ -90,6 +91,7 @@ stage('Update Stage') {
                     if(machineName == "daint" || machineName == "dom"){
                         eb_flags = "--ignore-locks --modules-header=$WORKSPACE/login/daint-${architecture}.h --modules-footer=$WORKSPACE/login/daint.footer -r"
                         eb_tcflags = "--hidden"
+                        eb_buildpath = "/dev/shm/\$USER" //\$XDG_RUNTIME_DIR"
                         eb_installpath = "${params.eb_prefix}/${params.pe_target}/$machineLabel"
                         eb_metadata="$WORKSPACE/easybuild/cray_external_modules_metadata-${pe_target}.cfg"
                         eb_modulespath = "${eb_installpath}/modules/all"
@@ -97,10 +99,11 @@ stage('Update Stage') {
                         load_pe = architecture == "" ?
                             "module load cdt-cuda/${pe_target} && module list" :
                             "module load cdt-cuda/${pe_target} daint-$architecture && module list"
-                        toolchains = "CrayCCE CrayGNU CrayIntel"
+                        toolchains = "CrayCCE CrayGNU CrayIntel CrayNvidia"
                     } else if(machineName == "eiger" || machineName == "pilatus"){
                         eb_flags = "--ignore-locks -r"
                         eb_tcflags = ""
+                        eb_buildpath = "/dev/shm/\$USER"
                         eb_installpath = "${params.eb_prefix}/"
                         eb_metadata="$WORKSPACE/easybuild/cpe_external_modules_metadata-${pe_target}.cfg"
                         eb_modulespath = "${eb_installpath}/modules/all/Core"
@@ -140,7 +143,7 @@ stage('Update Stage') {
                                      $load_easybuild
 
                                      # update buildpath and metadata file for external modules
-                                     export EASYBUILD_BUILDPATH="/dev/shm/\$USER/$machineLabel"
+                                     export EASYBUILD_BUILDPATH="$eb_buildpath"
                                      export EASYBUILD_EXTERNAL_MODULES_METADATA="$eb_metadata"
 
                                      # unuse paths


### PR DESCRIPTION
I provide some minor updates for the new production lists and recipes with Cray PE 21.09 on Dom, including `NCO` @omlins and `numpy` @henrique (is it still needed? The recent `cray-python/3.9.4.1` features `numpy` release `1.20.1`).