### PR TITLE
[pilatus] Update Python packages

### DIFF
--- a/easybuild/easyconfigs/m/Mako/Mako-1.1.5-cpeCray-21.09-python3.eb
+++ b/easybuild/easyconfigs/m/Mako/Mako-1.1.5-cpeCray-21.09-python3.eb
@@ -12,17 +12,16 @@ from the existing templating languages"""
 toolchain = {'name': 'cpeCray', 'version': '21.09'}
 
 sources = [SOURCE_TAR_GZ]
-patches = [('site.py', '%(builddir)s/site.py')]
 
 dependencies = [
     ('cray-python', EXTERNAL_MODULE),
 ]
 
-postinstallcmds = ['cp %(builddir)s/site.py %(installdir)s/lib/python%(pyshortver)s/site-packages/site.py']
+use_pip = True
 
 sanity_check_paths = {
-    'files': ['bin/%(namelower)s-render', 'lib/python%(pyshortver)s/site-packages/site.py'],
-    'dirs': ['bin', 'lib'],
+    'files': ['bin/%(namelower)s-render'],
+    'dirs': ['bin', 'lib']
 }
 
 moduleclass = 'devel'

--- a/easybuild/easyconfigs/m/Meson/Meson-0.59.2-cpeCray-21.09-python3.eb
+++ b/easybuild/easyconfigs/m/Meson/Meson-0.59.2-cpeCray-21.09-python3.eb
@@ -13,20 +13,24 @@ toolchain = {'name': 'cpeCray', 'version': '21.09'}
 
 source_urls = ['https://github.com/mesonbuild/%(namelower)s/releases/download/%(version)s/']
 sources = [SOURCELOWER_TAR_GZ]
-patches = [('site.py', '%(builddir)s/site.py')]
+
+builddependencies = [
+    ('wheel', '0.37.0')
+]
 
 dependencies = [
     ('cray-python', EXTERNAL_MODULE),
-    ('Ninja', '1.10.2', '-python%(pymajver)s'),
+    ('Ninja', '1.10.2', '-python%(pymajver)s')
 ]
 
-postinstallcmds = ['cp %(builddir)s/site.py %(installdir)s/lib/python%(pyshortver)s/site-packages/site.py']
 download_dep_fail = True
 options = {'modulename': 'mesonbuild'}
 
+use_pip = True
+
 sanity_check_paths = {
-    'files': ['bin/%(namelower)s', 'lib/python%(pyshortver)s/site-packages/site.py'],
-    'dirs': [],
+    'files': ['bin/%(namelower)s'],
+    'dirs': []
 }
 
 moduleclass = 'tools'

--- a/easybuild/easyconfigs/w/wheel/wheel-0.37.0-cpeCray-21.09.eb
+++ b/easybuild/easyconfigs/w/wheel/wheel-0.37.0-cpeCray-21.09.eb
@@ -1,0 +1,26 @@
+# contributed by Rafael Sarmiento and Luca Marsella (CSCS)
+easyblock = 'PythonPackage'
+
+name = 'wheel'
+version = '0.37.0'
+
+homepage = 'https://pypi.python.org/pypi/wheel'
+description = """A built-package format for Python."""
+
+toolchain = {'name': 'cpeCray', 'version': '21.09'}
+
+source_urls = [PYPI_SOURCE]
+sources = [SOURCE_TAR_GZ]
+
+dependencies = [
+    ('cray-python', EXTERNAL_MODULE)
+]
+
+use_pip = True
+
+sanity_check_paths = {
+    'files': ['bin/wheel'],
+    'dirs': ['lib/python%(pyshortver)s/site-packages']
+}
+
+moduleclass = 'tools'


### PR DESCRIPTION
I provide updated recipes for Python packages on Pilatus with Cray PE 21.09 as in  #2566.