### PR TITLE
[daint dom eiger pilatus tsa] Update compiler definitions and external metadata

### DIFF
--- a/easybuild/cpe_external_modules_metadata-21.10.cfg
+++ b/easybuild/cpe_external_modules_metadata-21.10.cfg
@@ -1,0 +1,67 @@
+# metadata useful to EasyBuild (hpcugent.github.io/easybuild) for modules provided by Cray on Cray systems
+# authors: Guilherme Peretti-Pezzi (CSCS), Petar Forai (IMP/IMBA), Kenneth Hoste (HPC-UGent), Eirini Koutsaniti (CSCS)
+
+[aocc]
+name = AOCC
+prefix = CRAY_AOCC_PREFIX
+version = 3.1.0
+
+[cray-fftw]
+name = FFTW
+prefix = FFTW_DIR/..
+version = 3.3.8.12
+
+[cray-hdf5]
+name = HDF5
+prefix = CRAY_HDF5_PREFIX
+version = 1.12.0.7
+
+[cray-hdf5-parallel]
+name = HDF5
+prefix = CRAY_HDF5_PARALLEL_PREFIX
+version = 1.12.0.7
+
+[cray-libsci]
+name = LibSci
+prefix = CRAY_LIBSCI_PREFIX_DIR
+version = 21.08.1.2
+
+[cray-netcdf]
+name = netCDF, netCDF-Fortran
+prefix = CRAY_NETCDF_PREFIX
+version = 4.7.4.7, 4.7.4.7
+
+[cray-netcdf-hdf5parallel]
+name = netCDF, netCDF-Fortran
+prefix = CRAY_NETCDF_HDF5PARALLEL_PREFIX
+version = 4.7.4.7, 4.7.4.7
+
+[cray-python]
+name = Python
+prefix = CRAY_PYTHON_PREFIX
+version = 3.9.4.2
+
+[cray-R]
+name = R
+prefix = CRAY_R_PREFIX
+version = 4.1.1.1
+
+[gcc]
+name = GCC
+prefix = GCC_PREFIX
+version = GCC_VERSION
+
+[papi]
+name = PAPI
+prefix = CRAY_PAPI_PREFIX
+version = 6.0.0.10
+
+[pmi]
+name = pmi
+prefix = CRAY_PMI_PREFIX
+version = 6.0.14
+
+[slurm/.default]
+name = slurm
+prefix = SLURMDIR
+version = .default

--- a/easybuild/cpe_external_modules_metadata-21.11.cfg
+++ b/easybuild/cpe_external_modules_metadata-21.11.cfg
@@ -1,0 +1,67 @@
+# metadata useful to EasyBuild (hpcugent.github.io/easybuild) for modules provided by Cray on Cray systems
+# authors: Guilherme Peretti-Pezzi (CSCS), Petar Forai (IMP/IMBA), Kenneth Hoste (HPC-UGent), Eirini Koutsaniti (CSCS)
+
+[aocc]
+name = AOCC
+prefix = CRAY_AOCC_PREFIX
+version = 3.1.0
+
+[cray-fftw]
+name = FFTW
+prefix = FFTW_DIR/..
+version = 3.3.8.12
+
+[cray-hdf5]
+name = HDF5
+prefix = CRAY_HDF5_PREFIX
+version = 1.12.0.7
+
+[cray-hdf5-parallel]
+name = HDF5
+prefix = CRAY_HDF5_PARALLEL_PREFIX
+version = 1.12.0.7
+
+[cray-libsci]
+name = LibSci
+prefix = CRAY_LIBSCI_PREFIX_DIR
+version = 21.08.1.2
+
+[cray-netcdf]
+name = netCDF, netCDF-Fortran
+prefix = CRAY_NETCDF_PREFIX
+version = 4.7.4.7, 4.7.4.7
+
+[cray-netcdf-hdf5parallel]
+name = netCDF, netCDF-Fortran
+prefix = CRAY_NETCDF_HDF5PARALLEL_PREFIX
+version = 4.7.4.7, 4.7.4.7
+
+[cray-python]
+name = Python
+prefix = CRAY_PYTHON_PREFIX
+version = 3.9.4.2
+
+[cray-R]
+name = R
+prefix = CRAY_R_PREFIX
+version = 4.1.1.1
+
+[gcc]
+name = GCC
+prefix = GCC_PREFIX
+version = GCC_VERSION
+
+[papi]
+name = PAPI
+prefix = CRAY_PAPI_PREFIX
+version = 6.0.0.10
+
+[pmi]
+name = pmi
+prefix = CRAY_PMI_PREFIX
+version = 6.0.15
+
+[slurm/.default]
+name = slurm
+prefix = SLURMDIR
+version = .default

--- a/easybuild/easyconfigs/v/VASP/VASP-6.2.1-cpeIntel.makefile.include
+++ b/easybuild/easyconfigs/v/VASP/VASP-6.2.1-cpeIntel.makefile.include
@@ -1,0 +1,1 @@
+VASP-6.2.0-cpeIntel.makefile.include

--- a/easybuild/toolchains/compiler/cpe.py
+++ b/easybuild/toolchains/compiler/cpe.py
@@ -170,10 +170,27 @@ class cpeGCC(cpeCompiler):
 class cpeICC(cpeCompiler):
     """Support for using the Cray Intel compiler wrappers."""
     PRGENV_MODULE_NAME_SUFFIX = 'intel'  # PrgEnv-intel
-    COMPILER_FAMILY = TC_CONSTANT_INTELCOMP
+    COMPILER_FAMILY = 'Intel' #TC_CONSTANT_INTELCOMP
 
     def __init__(self, *args, **kwargs):
-        """cpeINTEL constructor."""
+        """cpeIntel constructor."""
         super(cpeICC, self).__init__(*args, **kwargs)
+        # FIXME: fp-model source gives an error with Intel oneAPI (UES-1591)
+        COMPILER_UNIQUE_OPTION_MAP = {
+            'i8': 'i8',
+            'r8': 'r8',
+            'optarch': 'xHost',
+            'ieee': 'fltconsistency',
+            'strict': ['fp-speculation=strict', 'fp-model strict'],
+            'precise': ['fp-model precise'],
+            'defaultprec': ['ftz', 'fp-speculation=safe'],
+            'loose': ['fp-model fast=1'],
+            'veryloose': ['fp-model fast=2'],
+            'vectorize': {False: 'no-vec', True: 'vec'},
+            'intel-static': 'static-intel',
+            'no-icc': 'no-icc',
+            'error-unknown-option': 'we10006',  # error at warning #10006: ignoring unknown option
+        }
         for precflag in self.COMPILER_PREC_FLAGS:
-            self.COMPILER_UNIQUE_OPTION_MAP[precflag] = IntelIccIfort.COMPILER_UNIQUE_OPTION_MAP[precflag]
+            #self.COMPILER_UNIQUE_OPTION_MAP[precflag] = IntelIccIfort.COMPILER_UNIQUE_OPTION_MAP[precflag]
+            self.COMPILER_UNIQUE_OPTION_MAP[precflag] = COMPILER_UNIQUE_OPTION_MAP[precflag]

--- a/easybuild/toolchains/compiler/craype.py
+++ b/easybuild/toolchains/compiler/craype.py
@@ -41,7 +41,8 @@ import copy
 
 import easybuild.tools.environment as env
 from easybuild.toolchains.compiler.gcc import TC_CONSTANT_GCC, Gcc
-from easybuild.toolchains.compiler.inteliccifort import TC_CONSTANT_INTELCOMP, IntelIccIfort
+#from easybuild.toolchains.compiler.inteliccifort import TC_CONSTANT_INTELCOMP, IntelIccIfort
+from easybuild.toolchains.compiler.intel_compilers import IntelCompilers
 from easybuild.toolchains.compiler.pgi import TC_CONSTANT_PGI, Pgi
 from easybuild.toolchains.compiler.nvhpc import TC_CONSTANT_NVHPC, NVHPC
 from easybuild.tools.build_log import EasyBuildError
@@ -145,13 +146,30 @@ class CrayPEGCC(CrayPECompiler):
 class CrayPEIntel(CrayPECompiler):
     """Support for using the Cray Intel compiler wrappers."""
     PRGENV_MODULE_NAME_SUFFIX = 'intel'  # PrgEnv-intel
-    COMPILER_FAMILY = TC_CONSTANT_INTELCOMP
+    COMPILER_FAMILY = 'Intel' #TC_CONSTANT_INTELCOMP
 
     def __init__(self, *args, **kwargs):
         """CrayPEIntel constructor."""
         super(CrayPEIntel, self).__init__(*args, **kwargs)
+        # FIXME: fp-model source gives an error with Intel oneAPI (UES-1591)
+        COMPILER_UNIQUE_OPTION_MAP = {
+            'i8': 'i8',
+            'r8': 'r8',
+            'optarch': 'xHost',
+            'ieee': 'fltconsistency',
+            'strict': ['fp-speculation=strict', 'fp-model strict'],
+            'precise': ['fp-model precise'],
+            'defaultprec': ['ftz', 'fp-speculation=safe'],
+            'loose': ['fp-model fast=1'],
+            'veryloose': ['fp-model fast=2'],
+            'vectorize': {False: 'no-vec', True: 'vec'},
+            'intel-static': 'static-intel',
+            'no-icc': 'no-icc',
+            'error-unknown-option': 'we10006',  # error at warning #10006: ignoring unknown option
+        }
         for precflag in self.COMPILER_PREC_FLAGS:
-            self.COMPILER_UNIQUE_OPTION_MAP[precflag] = IntelIccIfort.COMPILER_UNIQUE_OPTION_MAP[precflag]
+            #self.COMPILER_UNIQUE_OPTION_MAP[precflag] = IntelIccIfort.COMPILER_UNIQUE_OPTION_MAP[precflag]
+            self.COMPILER_UNIQUE_OPTION_MAP[precflag] = COMPILER_UNIQUE_OPTION_MAP[precflag]
 
 
 class CrayPEPGI(CrayPECompiler):


### PR DESCRIPTION
Update Intel compiler options for oneAPI and add external metadata for CPE 21.10 and 21.11.