### PR TITLE
[daint] Add Julia 1.7.0 pe20.11 without site-wide package installations

### DIFF
--- a/easybuild/easyconfigs/j/Julia/Julia-1.7.0-CrayGNU-20.11-cuda.eb
+++ b/easybuild/easyconfigs/j/Julia/Julia-1.7.0-CrayGNU-20.11-cuda.eb
@@ -1,0 +1,51 @@
+# Recipe for linux, x86_64 created by Samuel Omlin (CSCS), Victor Holanda Rusu (CSCS), Harmen Stoppels (CSCS)
+easyblock = 'PackedBinary'
+
+name = 'Julia'
+version = '1.7.0'
+versionsuffix = '-cuda'
+
+homepage = 'https://julialang.org'
+description = 'Julia is a high-level general-purpose dynamic programming language that was originally designed to address the needs of high-performance numerical analysis and computational science, without the typical need of separate compilation to be fast, also usable for client and server web use, low-level systems programming or as a specification language (wikipedia.org). Julia provides ease and expressiveness for high-level numerical computing, in the same way as languages such as R, MATLAB, and Python, but also supports general programming. To achieve this, Julia builds upon the lineage of mathematical programming languages, but also borrows much from popular dynamic languages, including Lisp, Perl, Python, Lua, and Ruby (julialang.org).'
+
+toolchain = {'name': 'CrayGNU', 'version': '20.11'}
+toolchainopts = {'usempi': True, 'pic': True, 'verbose': True}
+
+source_urls = ['https://julialang-s3.julialang.org/bin/linux/x64/%(version_major_minor)s/']
+sources = ['%(namelower)s-%(version)s-linux-%(arch)s.tar.gz']
+
+builddependencies = [
+    ('cudatoolkit', EXTERNAL_MODULE),
+]
+dependencies = [
+    ('craype-accel-nvidia60', EXTERNAL_MODULE),
+]
+
+sanity_check_paths = {
+    'files': ['bin/julia', 'lib/libjulia.so', 'lib/libjulia.so.%(version_major)s', 'lib/libjulia.so.%(version_major)s.%(version_minor)s', 'lib64/libjulia.so', 'lib64/libjulia.so.%(version_major)s', 'lib64/libjulia.so.%(version_major)s.%(version_minor)s', 'LICENSE.md'],
+    'dirs':  ['bin', 'include', 'lib', 'share', 'lib/julia', 'lib64/julia', 'share/julia'],
+}
+
+modextravars = {
+    'JULIA_LOAD_PATH': '@:@#.#.#-daint-gpu:@stdlib',
+    'JULIA_DEPOT_PATH': '~/.julia/%(version)s/daint-gpu:%(installdir)s/local/share/julia:%(installdir)s/share/julia',
+    'JULIA_PROJECT': '~/.julia/%(version)s/daint-gpu/environments/%(version)s-daint-gpu',
+    'JULIA_MPICC': 'cc',
+    'JULIA_MPIEXEC': 'srun',
+    'JULIA_MPIEXEC_ARGS': "-C gpu",
+    'JULIA_MPI_BINARY': 'system',
+    'JULIA_MPI_PATH': '$::env(CRAY_MPICH_DIR)',
+    'JULIA_MPI_TEST_ARRAYTYPE': 'CuArray',
+    'JULIA_CUDA_USE_BINARYBUILDER': 'false',
+}
+
+# Julia 1.6.0+ uses Downloads.jl with a vendored libcurl.so that's dlopen'ed.
+# See https://julialang.org/blog/2021/03/julia-1.6-highlights/#downloads_networkingoptions
+# xalt hijacks libcurl.so by setting LD_LIBRARY_PATH, which should be avoided,
+# as it is incompatible with the API Julia expects.
+modtclfooter = """
+module unload cray-libsci_acc
+module unload xalt
+"""
+
+moduleclass = 'lang'

--- a/easybuild/easyconfigs/j/Julia/Julia-1.7.0-CrayGNU-20.11-cuda.eb
+++ b/easybuild/easyconfigs/j/Julia/Julia-1.7.0-CrayGNU-20.11-cuda.eb
@@ -13,6 +13,7 @@ toolchainopts = {'usempi': True, 'pic': True, 'verbose': True}
 
 source_urls = ['https://julialang-s3.julialang.org/bin/linux/x64/%(version_major_minor)s/']
 sources = ['%(namelower)s-%(version)s-linux-%(arch)s.tar.gz']
+    checksums = [('sha256', '7299f3a638aec5e0b9e14eaf0e6221c4fe27189aa0b38ac5a36f03f0dc4c0d40')]
 
 builddependencies = [
     ('cudatoolkit', EXTERNAL_MODULE),

--- a/easybuild/easyconfigs/j/Julia/Julia-1.7.0-CrayGNU-20.11.eb
+++ b/easybuild/easyconfigs/j/Julia/Julia-1.7.0-CrayGNU-20.11.eb
@@ -1,0 +1,41 @@
+# Recipe for linux, x86_64 created by Samuel Omlin (CSCS), Victor Holanda Rusu (CSCS), Harmen Stoppels (CSCS)
+easyblock = 'PackedBinary'
+
+name = 'Julia'
+version = '1.7.0'
+
+homepage = 'https://julialang.org'
+description = 'Julia is a high-level general-purpose dynamic programming language that was originally designed to address the needs of high-performance numerical analysis and computational science, without the typical need of separate compilation to be fast, also usable for client and server web use, low-level systems programming or as a specification language (wikipedia.org). Julia provides ease and expressiveness for high-level numerical computing, in the same way as languages such as R, MATLAB, and Python, but also supports general programming. To achieve this, Julia builds upon the lineage of mathematical programming languages, but also borrows much from popular dynamic languages, including Lisp, Perl, Python, Lua, and Ruby (julialang.org).'
+
+toolchain = {'name': 'CrayGNU', 'version': '20.11'}
+toolchainopts = {'usempi': True, 'pic': True, 'verbose': True}
+
+source_urls = ['https://julialang-s3.julialang.org/bin/linux/x64/%(version_major_minor)s/']
+sources = ['%(namelower)s-%(version)s-linux-%(arch)s.tar.gz']
+
+sanity_check_paths = {
+    'files': ['bin/julia', 'lib/libjulia.so', 'lib/libjulia.so.%(version_major)s', 'lib/libjulia.so.%(version_major)s.%(version_minor)s', 'lib64/libjulia.so', 'lib64/libjulia.so.%(version_major)s', 'lib64/libjulia.so.%(version_major)s.%(version_minor)s', 'LICENSE.md'],
+    'dirs':  ['bin', 'include', 'lib', 'share', 'lib/julia', 'lib64/julia', 'share/julia'],
+}
+
+modextravars = {
+    'JULIA_LOAD_PATH': '@:@#.#.#-daint-mc:@stdlib',
+    'JULIA_DEPOT_PATH': '~/.julia/%(version)s/daint-mc:%(installdir)s/local/share/julia:%(installdir)s/share/julia',
+    'JULIA_PROJECT': '~/.julia/%(version)s/daint-mc/environments/%(version)s-daint-mc',
+    'JULIA_MPICC': 'cc',
+    'JULIA_MPIEXEC': 'srun',
+    'JULIA_MPIEXEC_ARGS': "-C mc",
+    'JULIA_MPI_BINARY': 'system',
+    'JULIA_MPI_PATH': '$::env(CRAY_MPICH_DIR)',
+}
+
+# Julia 1.6.0+ uses Downloads.jl with a vendored libcurl.so that's dlopen'ed.
+# See https://julialang.org/blog/2021/03/julia-1.6-highlights/#downloads_networkingoptions
+# xalt hijacks libcurl.so by setting LD_LIBRARY_PATH, which should be avoided,
+# as it is incompatible with the API Julia expects.
+modtclfooter = """
+module unload cray-libsci_acc
+module unload xalt
+"""
+
+moduleclass = 'lang'

--- a/easybuild/easyconfigs/j/Julia/Julia-1.7.0-CrayGNU-20.11.eb
+++ b/easybuild/easyconfigs/j/Julia/Julia-1.7.0-CrayGNU-20.11.eb
@@ -34,7 +34,6 @@ modextravars = {
 # xalt hijacks libcurl.so by setting LD_LIBRARY_PATH, which should be avoided,
 # as it is incompatible with the API Julia expects.
 modtclfooter = """
-module unload cray-libsci_acc
 module unload xalt
 """
 


### PR DESCRIPTION
This Julia recipes does
- install Julia without any packages
- set environment variables for the installation of packages that rely on system libraries (MPI, CUDA)
- set `JULIA_LOAD_PATH`, `JULIA_DEPOT_PATH` and `JULIA_PROJECT` to a default that will separate 'daint-gpu' packages installations from 'daint-mc' packages installations (different CPU architecture...).
