### PR TITLE
[dom-gpu] Update JupyterLab dependencies

### DIFF
--- a/easybuild/easyconfigs/c/configurable-http-proxy/configurable-http-proxy-4.5.0-CrayGNU-21.09.eb
+++ b/easybuild/easyconfigs/c/configurable-http-proxy/configurable-http-proxy-4.5.0-CrayGNU-21.09.eb
@@ -17,7 +17,7 @@ local_fixme_sourcepath = '/apps/common/UES/easybuild/sources/%(nameletter)s/'
 sources = [local_fixme_sourcepath + '%(name)s-%(version)s.tar.gz']
 
 dependencies = [
-    ('nodejs', '16.13.1')
+    ('nodejs', '16.13.2', '', True)
 ]
 
 install_cmd = "npm install --no-package-lock -g --prefix %(installdir)s {0}%(name)s-%(version)s.tar.gz".format(local_fixme_sourcepath)

--- a/easybuild/easyconfigs/j/jupyterlab/jupyterlab-2.2.10-CrayGNU-21.09-batchspawner-cuda.eb
+++ b/easybuild/easyconfigs/j/jupyterlab/jupyterlab-2.2.10-CrayGNU-21.09-batchspawner-cuda.eb
@@ -68,7 +68,7 @@ export EBJULIA_ADMIN_DEPOT_PATH=%(installdir)s/share/IJulia &&
 export JULIA_DEPOT_PATH=%(installdir)s/share/IJulia && 
 export JULIA_PROJECT=%(installdir)s/share/IJulia/environments/$EBJULIA_ENV_NAME && 
 julia -e 'using Pkg; Pkg.add("IJulia");' && 
-chmod -R +rX %(installdir)s/share/IJulia # Adjust permissions of IJulia files
+chmod -R +rX %(installdir)s/share/IJulia && # Adjust permissions of IJulia files
 file=%(installdir)s/share/jupyter/kernels/julia-1.6/kernel.json && cp $file ${file}.orig && cat $file.orig | perl -pe 's/"--project=.*",//g' > $file # Remove IJulia specific project configuration
 """
 ]

--- a/easybuild/easyconfigs/j/jupyterlab/jupyterlab-2.2.10-CrayGNU-21.09-batchspawner-cuda.eb
+++ b/easybuild/easyconfigs/j/jupyterlab/jupyterlab-2.2.10-CrayGNU-21.09-batchspawner-cuda.eb
@@ -1,5 +1,4 @@
 # @author: robinson (omlins and hvictor for IJulia)
-
 easyblock = 'PythonBundle'
 
 name = 'jupyterlab'
@@ -13,16 +12,16 @@ toolchain = {'name': 'CrayGNU', 'version': '21.09'}
 toolchainopts = {'pic': True, 'verbose': False}
 
 builddependencies = [
-    ('wheel', '0.37.0'),
+    ('wheel', '0.37.0')
 ]
 
 dependencies = [
+    ('configurable-http-proxy', '4.5.0'),
     ('cray-python', EXTERNAL_MODULE),
     ('cudatoolkit', EXTERNAL_MODULE),
-    ('libffi', '3.2.1', '', True),
-    ('configurable-http-proxy', '4.5.0'),
-    ('JuliaExtensions', '1.6.3', '-cuda'),
     ('graphviz', '2.50.0'),
+    ('JuliaExtensions', '1.6.3', '-cuda'),
+    ('libffi', '3.4.2')
 ]
 
 modtclfooter = """
@@ -35,13 +34,11 @@ postinstallcmds = [
 """
 export YARN_CACHE_FOLDER=/tmp/$USER//12345/yarn_cache && 
 export NODE_OPTIONS=--max-old-space-size=4096 &&
-export JUPYTERLAB_DIR=%(installdir)s/share/jupyter/lab/ && 
-export PYTHONPATH=%(installdir)s/lib/python%(pyshortver)s/site-packages:$PYTHONPATH && 
-#export JUPYTER_PATH=%(installdir)s/share/jupyter/ && 
-export JUPYTER_DATA_DIR=%(installdir)s/share/jupyter/ && 
 export JULIA_DEPOT_PATH=%(installdir)s/share/julia/site/ && 
 export JUPYTER=%(installdir)s/bin/jupyter &&   # Needed for IJulia 
-
+export JUPYTER_DATA_DIR=%(installdir)s/share/jupyter/ && 
+export JUPYTERLAB_DIR=%(installdir)s/share/jupyter/lab/ && 
+export PYTHONPATH=%(installdir)s/lib/python%(pyshortver)s/site-packages:$PYTHONPATH &&
 %(installdir)s/bin/jupyter-labextension install -y @jupyter-widgets/jupyterlab-manager@2.0.0 jupyter-matplotlib@0.10.4 --no-build && 
 %(installdir)s/bin/jupyter labextension install dask-labextension@4.0.1 --no-build && 
 %(installdir)s/bin/jupyter-labextension install jupyterlab-datawidgets@6.3.0 --no-build && 
@@ -59,7 +56,7 @@ cd ipyparaview &&
 git checkout 074d548 && 
 %(installdir)s/bin/jupyter labextension install js --no-build && 
 
-#now finally do the JupyterLab build
+# JupyterLab build
 %(installdir)s/bin/jupyter lab build --debug --dev-build=False --minimize=False &&
 rm -r $YARN_CACHE_FOLDER && 
 # Bash kernel - https://github.com/takluyver/bash_kernel
@@ -71,9 +68,9 @@ export EBJULIA_ADMIN_DEPOT_PATH=%(installdir)s/share/IJulia &&
 export JULIA_DEPOT_PATH=%(installdir)s/share/IJulia && 
 export JULIA_PROJECT=%(installdir)s/share/IJulia/environments/$EBJULIA_ENV_NAME && 
 julia -e 'using Pkg; Pkg.add("IJulia");' && 
-chmod -R +rX %(installdir)s/share/IJulia &&  # Adjust permissions of IJulia files
+chmod -R +rX %(installdir)s/share/IJulia # Adjust permissions of IJulia files
 file=%(installdir)s/share/jupyter/kernels/julia-1.6/kernel.json && cp $file ${file}.orig && cat $file.orig | perl -pe 's/"--project=.*",//g' > $file # Remove IJulia specific project configuration
-""",
+"""
 ]
 
 exts_default_options = {
@@ -169,7 +166,7 @@ exts_list = [
     ('pamela', '1.0.0'),
     ('jupyterhub', '2.0.1'),
 
-    #matplotlib and widgets  
+    # matplotlib and widgets  
     ('Pillow', '9.0.0', {'modulename': 'PIL'}),
     ('kiwisolver', '1.3.2'),
     ('matplotlib', '3.5.1'),
@@ -181,7 +178,7 @@ exts_list = [
     ('ipywidgets', '7.6.5', {'use_pip': True, 'source_tmpl': '%(name)s-%(version)s-py2.py3-none-any.whl', 'unpack_sources': False}),
     ('jupyterlab_widgets', '1.0.2', {'use_pip': True, 'source_tmpl': '%(name)s-%(version)s-py3-none-any.whl', 'unpack_sources': False}),
 
-    #dask and dask labextension 
+    # dask and dask labextension 
     ('click', '8.0.3'),
     ('cloudpickle', '2.0.0'),
     ('dask', '2021.12.0'),
@@ -255,22 +252,21 @@ exts_list = [
     ('bash_kernel', '0.7.2', {'use_pip': False}),
 
     # custom batchspawner
-    ('batchspawner', '68a1fcd', {'source_urls': ['https://github.com/jupyterhub/batchspawner/tarball/%(version)s']}),
+    ('batchspawner', '68a1fcd', {'source_urls': ['https://github.com/jupyterhub/batchspawner/tarball/%(version)s']})
 ]
 
 sanity_check_paths = {
     'files': [],
-    'dirs': ['lib/python%(pyshortver)s/site-packages', 'share/jupyter/lab/extensions', 'share/jupyter/lab/schemas', 'share/jupyter/lab/staging', 'share/jupyter/lab/static', 'share/jupyter/lab/themes'],
+    'dirs': ['lib/python%(pyshortver)s/site-packages', 'share/jupyter/lab/extensions', 'share/jupyter/lab/schemas', 'share/jupyter/lab/staging', 'share/jupyter/lab/static', 'share/jupyter/lab/themes']
 }
 
 modextrapaths = {
-    'JUPYTER_PATH': 'share/jupyter',
-    'PYTHONPATH': ['lib/python%(pyshortver)s/site-packages'],
+    'JUPYTER_PATH': 'share/jupyter'
 }
 
 modextravars = {
     'JUPYTER': '%(installdir)s/bin/jupyter',
-    'JUPYTERLAB_DIR': '%(installdir)s/share/jupyter/lab/',
+    'JUPYTERLAB_DIR': '%(installdir)s/share/jupyter/lab/'
 }
 
 moduleclass = 'tools'

--- a/easybuild/easyconfigs/n/nodejs/nodejs-16.13.2-CrayGNU-21.09.eb
+++ b/easybuild/easyconfigs/n/nodejs/nodejs-16.13.2-CrayGNU-21.09.eb
@@ -1,0 +1,27 @@
+# contributed by Luca Marsella (CSCS)
+easyblock = 'ConfigureMake'
+
+name = 'nodejs'
+version = '16.13.2'
+
+homepage = 'http://nodejs.org'
+description = """Node.js is a platform built on Chrome's JavaScript runtime 
+ for easily building fast, scalable network applications. Node.js uses an 
+ event-driven, non-blocking I/O model that makes it lightweight and efficient, 
+ perfect for data-intensive real-time applications that run across distributed devices."""
+
+toolchain = {'name': 'CrayGNU', 'version': '21.09'}
+
+source_urls = ['http://%(name)s.org/dist/v%(version)s/']
+sources = ['node-v%(version)s.tar.gz']
+
+builddependencies = [
+    ('cray-python', EXTERNAL_MODULE)
+]
+
+sanity_check_paths = {
+    'files': ['bin/node', 'bin/npm'],
+    'dirs': ['lib/node_modules', 'include/node']
+}
+
+moduleclass = 'lang'

--- a/easybuild/easyconfigs/n/nodejs/nodejs-16.13.2.eb
+++ b/easybuild/easyconfigs/n/nodejs/nodejs-16.13.2.eb
@@ -1,0 +1,23 @@
+# contributed by Luca Marsella (CSCS)
+easyblock = 'ConfigureMake'
+
+name = 'nodejs'
+version = '16.13.2'
+
+homepage = 'http://nodejs.org'
+description = """Node.js is a platform built on Chrome's JavaScript runtime 
+ for easily building fast, scalable network applications. Node.js uses an 
+ event-driven, non-blocking I/O model that makes it lightweight and efficient, 
+ perfect for data-intensive real-time applications that run across distributed devices."""
+
+toolchain = SYSTEM
+
+source_urls = ['http://%(name)s.org/dist/v%(version)s/']
+sources = ['node-v%(version)s.tar.gz']
+
+sanity_check_paths = {
+    'files': ['bin/node', 'bin/npm'],
+    'dirs': ['lib/node_modules', 'include/node']
+}
+
+moduleclass = 'lang'


### PR DESCRIPTION
The new `nodejs` recipe used by `configurable-http-proxy` will build with the compiler provided by the operating system (the CrayGNU `nodejs` recipe is enclosed to the pull request but not used as dependency in any recipe at present).