### PR TITLE
[daint-mc] BAGEL with Cray

### DIFF
--- a/easybuild/easyconfigs/b/BAGEL/BAGEL-1.2.2-CrayGNU-20.11.eb
+++ b/easybuild/easyconfigs/b/BAGEL/BAGEL-1.2.2-CrayGNU-20.11.eb
@@ -8,13 +8,14 @@ homepage = "http://www.nubakery.org"
 description = """BAGEL (Brilliantly Advanced General Electronic-structure Library)
 is a parallel electronic-structure program."""
 
-toolchain = {'name': 'CrayIntel', 'version': '20.11'}
+toolchain = {'name': 'CrayGNU', 'version': '20.11'}
 
 source_urls = ['https://github.com/nubakery/bagel/archive/']
 sources = ['v%(version)s.tar.gz']
 
 dependencies = [
-    ('Boost', '1.70.0'),
+    ('Boost', '1.70.0', '-python3'),
+    ('intel', EXTERNAL_MODULE),
     ('libxc', '5.1.6')
 ]
 

--- a/easybuild/easyconfigs/b/BAGEL/BAGEL-1.2.2-CrayIntel-20.11.eb
+++ b/easybuild/easyconfigs/b/BAGEL/BAGEL-1.2.2-CrayIntel-20.11.eb
@@ -1,0 +1,30 @@
+# contributed by Luca Marsella (CSCS)
+easyblock = 'ConfigureMake'
+
+name = 'BAGEL'
+version = '1.2.2'
+
+homepage = "http://www.nubakery.org"
+description = """BAGEL (Brilliantly Advanced General Electronic-structure Library)
+is a parallel electronic-structure program."""
+
+toolchain = {'name': 'CrayIntel', 'version': '20.11'}
+
+source_urls = ['https://github.com/nubakery/bagel/archive/']
+sources = ['v%(version)s.tar.gz']
+
+dependencies = [
+    ('Boost', '1.70.0'),
+    ('libxc', '5.1.6')
+]
+
+preconfigopts = ' sed -i "s|-gcc-mt||g" configure.ac && ./autogen.sh && '
+preconfigopts += ' module unload cray-libsci && MPICC=cc MPICXX=CC '
+configopts = ' --enable-mkl --with-boost=$EBROOTBOOST --with-libxc --with-mpi=intel '
+
+sanity_check_paths = {
+    'files': ['bin/BAGEL', 'lib/libbagel.%s' % SHLIB_EXT],
+    'dirs': []
+}
+
+moduleclass = 'phys'

--- a/easybuild/easyconfigs/b/Boost/Boost-1.70.0-CrayIntel-20.11.eb
+++ b/easybuild/easyconfigs/b/Boost/Boost-1.70.0-CrayIntel-20.11.eb
@@ -10,12 +10,12 @@ description = """
 toolchain = {'name': 'CrayIntel', 'version': '20.11'}
 toolchainopts = {'pic': True, 'usempi': True, 'verbose': False}
 
-sources = ['%%(namelower)s_%s.tar.bz2' % '_'.join(version.split('.'))]
-source_urls = ['https://dl.bintray.com/boostorg/release/%(version)s/source/']
+source_urls = ['https://boostorg.jfrog.io/artifactory/main/release/%(version)s/source']
+sources = ['%(namelower)s_%(version_major)s_%(version_minor)s_0.tar.bz2']
 
 dependencies = [
-    ('bzip2', '1.0.6'),
-    ('zlib', '1.2.11'),
+    ('bzip2', '1.0.8'),
+    ('zlib', '1.2.11')
 ]
 
 configopts = '--without-libraries=python'

--- a/easybuild/easyconfigs/b/Boost/Boost-1.70.0-CrayIntel-20.11.eb
+++ b/easybuild/easyconfigs/b/Boost/Boost-1.70.0-CrayIntel-20.11.eb
@@ -1,0 +1,28 @@
+# contributed by Luca Marsella (CSCS)
+name = 'Boost'
+version = "1.70.0"
+
+homepage = 'http://www.boost.org/'
+description = """
+    Boost provides free peer-reviewed portable C++ source libraries.
+"""
+
+toolchain = {'name': 'CrayIntel', 'version': '20.11'}
+toolchainopts = {'pic': True, 'usempi': True, 'verbose': False}
+
+sources = ['%%(namelower)s_%s.tar.bz2' % '_'.join(version.split('.'))]
+source_urls = ['https://dl.bintray.com/boostorg/release/%(version)s/source/']
+
+dependencies = [
+    ('bzip2', '1.0.6'),
+    ('zlib', '1.2.11'),
+]
+
+configopts = '--without-libraries=python'
+boost_mpi = True
+
+modextravars = {
+    'BOOST_ROOT' : "%(installdir)s",
+}
+
+moduleclass = 'devel'

--- a/easybuild/easyconfigs/l/libxc/libxc-5.1.6-CrayGNU-20.11.eb
+++ b/easybuild/easyconfigs/l/libxc/libxc-5.1.6-CrayGNU-20.11.eb
@@ -1,0 +1,33 @@
+# contributed by Luca Marsella (CSCS)
+easyblock = 'CMakeMake'
+
+name = 'libxc'
+version = '5.1.6'
+
+homepage = 'http://www.tddft.org/programs/octopus/wiki/index.php/Libxc'
+description = """Libxc is a library of exchange-correlation functionals for density-functional theory.
+ The aim is to provide a portable, well tested and reliable set of exchange and correlation functionals."""
+
+toolchain = {'name': 'CrayGNU', 'version': '20.11'}
+toolchainopts = {'opt': True}
+
+source_urls = ['https://gitlab.com/%(name)s/%(name)s/-/archive/%(version)s']
+sources = [SOURCE_TAR_BZ2]
+
+builddependencies = [
+    ('bzip2', '1.0.8'),
+    ('CMake', '3.14.5', '', True)
+]
+
+configopts = [
+    " -DENABLE_FORTRAN=ON -DCMAKE_INSTALL_LIBDIR=lib ",
+    " -DENABLE_FORTRAN=ON -DCMAKE_INSTALL_LIBDIR=lib  -DBUILD_SHARED_LIBS=ON ",
+]
+
+
+sanity_check_paths = {
+    'files': ['lib/%(name)s.a', 'lib/%(name)s.so', 'lib/%(name)sf90.a', 'lib/%(name)sf90.so', 'lib/%(name)sf03.a', 'lib/%(name)sf03.so'],
+    'dirs': ['include'],
+}
+
+moduleclass = 'chem'


### PR DESCRIPTION
Tentative recipe of BAGEL with CrayIntel 20.11 for [SD-54169](https://jira.cscs.ch/browse/SD-54169): I had to use Boost 1.70.0 as a dependency since 1.75.0 was making the build fail. 
The configure option `--with-mpi=intel` is due to the limited choices available (`intel`, `mvapich` or `openmpi` only): the executable [needs to be tested beforehand](https://nubakery.org/quickstart/how_to_run_bagel.html).