### PR TITLE
[dom-gpu] VASP 6.2.1

### DIFF
--- a/easybuild/easyconfigs/v/VASP/VASP-6.2.1-CrayIntel-21.09-cuda.eb
+++ b/easybuild/easyconfigs/v/VASP/VASP-6.2.1-CrayIntel-21.09-cuda.eb
@@ -1,0 +1,40 @@
+# contributed by Luca Marsella (CSCS)
+easyblock = 'MakeCp'
+
+name = 'VASP'
+version = '6.2.1'
+versionsuffix = '-cuda'
+
+homepage = 'http://www.vasp.at'
+description = "The Vienna Ab initio Simulation Package (VASP) is a computer program for atomic scale materials modelling, e.g. electronic structure calculations and quantum-mechanical molecular dynamics, from first principles. "
+
+toolchain = {'name': 'CrayIntel', 'version': '21.09'}
+toolchainopts = {'usempi': True}
+
+sources = [
+    '/apps/common/UES/easybuild/sources/%(nameletterlower)s/%(name)s/%(namelower)s-%(version)s.tar.bz2',
+]
+patches = [
+    ('%(name)s-%(version)s-%(toolchain_name)s%(versionsuffix)s.makefile.include', '%(builddir)s/%(namelower)s-%(version)s'),
+]
+
+builddependencies = [
+    ('cudatoolkit', EXTERNAL_MODULE),
+    ('Wannier90', '3.1.0')
+]
+
+prebuildopts = " mv %(name)s-%(version)s-%(toolchain_name)s%(versionsuffix)s.makefile.include makefile.include && "
+# build type
+buildopts = " gpu gpu_ncl "
+
+# don't use parallel make, results in compilation failure
+parallel = 1
+
+files_to_copy = [(['./bin/vasp_*'], 'bin')]
+
+sanity_check_paths = {
+    'files': ['bin/vasp_gpu', 'bin/vasp_gpu_ncl'],
+    'dirs': [],
+}
+
+moduleclass = 'phys'

--- a/easybuild/easyconfigs/v/VASP/VASP-6.2.1-CrayIntel-cuda.makefile.include
+++ b/easybuild/easyconfigs/v/VASP/VASP-6.2.1-CrayIntel-cuda.makefile.include
@@ -1,0 +1,1 @@
+VASP-6.2.0-CrayIntel-cuda.makefile.include

--- a/jenkins-builds/7.0.UP03-21.09-dom-gpu
+++ b/jenkins-builds/7.0.UP03-21.09-dom-gpu
@@ -41,7 +41,8 @@
  QuantumESPRESSO-7.0-CrayNvidia-21.09.eb                --set-default-module
  singularity-3.8.0-daint.eb
  Spark-2.4.7-CrayGNU-21.09-Hadoop-2.7.eb                --set-default-module
- VASP-6.2.1-CrayNvidia-21.09-acc.eb                     --set-default-module
+ VASP-6.2.1-CrayIntel-21.09-cuda.eb                     --set-default-module
+ VASP-6.2.1-CrayNvidia-21.09-acc.eb
  Vc-1.4.1-CrayGNU-21.09.eb                              --set-default-module
  Visit-3.2.0-CrayGNU-21.09.eb                           --set-default-module
  VMD-1.9.3-egl.eb


### PR DESCRIPTION
Recipe for the CUDA port of VASP 6.2.1 in production (it might still outperform the OpenACC port in some cases, therefore I keep it default although deprecated).