### PR TITLE
[dom] Update JupyterLab release in production

### DIFF
--- a/jenkins-builds/7.0.UP03-21.09-dom-gpu
+++ b/jenkins-builds/7.0.UP03-21.09-dom-gpu
@@ -21,7 +21,7 @@
  Julia-1.6.3-CrayGNU-21.09-cuda.eb                      --set-default-module
  JuliaExtensions-1.6.3-CrayGNU-21.09-cuda.eb            --set-default-module
  jupyter-utils-0.1.eb                                   --set-default-module
- jupyterlab-2.2.10-CrayGNU-21.09-batchspawner-cuda.eb   --set-default-module
+ jupyterlab-3.2.8-CrayGNU-21.09-batchspawner-cuda.eb    --set-default-module
  LAMMPS-20Sep21-CrayGNU-21.09-cuda.eb                   --set-default-module
  Lmod-7.8.2.eb                                          --set-default-module --hidden
  magma-2.5.4-CrayIntel-21.09-cuda.eb                    --set-default-module

--- a/jenkins-builds/7.0.UP03-21.09-dom-mc
+++ b/jenkins-builds/7.0.UP03-21.09-dom-mc
@@ -19,6 +19,7 @@
  IDL-8.7.2-CSCS.eb
  Julia-1.6.3-CrayGNU-21.09.eb                           --set-default-module
  JuliaExtensions-1.6.3-CrayGNU-21.09.eb                 --set-default-module
+ jupyterlab-3.2.8-CrayGNU-21.09-batchspawner.eb    --set-default-module
  jupyter-utils-0.1.eb                                   --set-default-module
  LAMMPS-20Sep21-CrayGNU-21.09.eb                        --set-default-module
  Lmod-7.8.2.eb                                          --set-default-module --hidden

--- a/jenkins-builds/7.0.UP03-21.09-dom-mc
+++ b/jenkins-builds/7.0.UP03-21.09-dom-mc
@@ -19,7 +19,7 @@
  IDL-8.7.2-CSCS.eb
  Julia-1.6.3-CrayGNU-21.09.eb                           --set-default-module
  JuliaExtensions-1.6.3-CrayGNU-21.09.eb                 --set-default-module
- jupyterlab-3.2.8-CrayGNU-21.09-batchspawner.eb    --set-default-module
+ jupyterlab-3.2.8-CrayGNU-21.09-batchspawner.eb         --set-default-module
  jupyter-utils-0.1.eb                                   --set-default-module
  LAMMPS-20Sep21-CrayGNU-21.09.eb                        --set-default-module
  Lmod-7.8.2.eb                                          --set-default-module --hidden


### PR DESCRIPTION
Adds Jupyterlab 3.2.8 and removes the temporary Jupyterlab 2, which will not be supported. 