### PR TITLE
[dom-gpu] Update GROMACS gpu with 21.09

### DIFF
--- a/easybuild/easyconfigs/g/GROMACS/GROMACS-2021.5-CrayGNU-21.09-cuda.eb
+++ b/easybuild/easyconfigs/g/GROMACS/GROMACS-2021.5-CrayGNU-21.09-cuda.eb
@@ -1,0 +1,49 @@
+# contributed by Luca Marsella, Victor Holanda Rusu (CSCS)
+#
+# This file is an EasyBuild reciPY as per https://github.com/hpcugent/easybuild
+#
+# Copyright:: Copyright 2012-2013 University of Luxembourg / LCSB, Cyprus Institute / CaSToRC, Ghent University
+# Authors::   Wiktor Jurkowski <wiktor.jurkowski@uni.lu>, Fotis Georgatos <fotis.georgatos@uni.lu>, \
+# George Tsouloupas <g.tsouloupas@cyi.ac.cy>, Kenneth Hoste
+# License::   MIT/GPL
+# $Id$
+#
+# This work implements a part of the HPCBIOS project and is a component of the policy:
+# http://hpcbios.readthedocs.org/en/latest/HPCBIOS_2012-93.html
+#
+easyblock = 'CMakeMake'
+
+name = 'GROMACS'
+version = '2021.5'
+versionsuffix = '-cuda'
+
+homepage = 'http://www.gromacs.org'
+description = """GROMACS is a versatile package to perform molecular dynamics,
+ i.e. simulate the Newtonian equations of motion for systems with hundreds to millions of particles."""
+
+toolchain = {'name': 'CrayGNU', 'version': '21.09'}
+toolchainopts = {'opt': True, 'usempi': True, 'verbose': False, 'pic': True, 'dynamic': False, 'openmp': True}
+
+source_urls = ['ftp://ftp.%(namelower)s.org/pub/%(namelower)s/']
+sources = [SOURCELOWER_TAR_GZ]
+
+# CMake dependency with dummy toolchain
+builddependencies = [
+    ('CMake', '3.22.1', '', True)
+]
+
+dependencies = [
+    ('craype-accel-nvidia60', EXTERNAL_MODULE),
+    ('cray-libsci', EXTERNAL_MODULE)
+]
+
+configopts = [
+    "-DCMAKE_BUILD_TYPE=Release -DCUDA_TOOLKIT_ROOT_DIR=$CUDATOOLKIT_HOME -DGMX_BUILD_OWN_FFTW=ON -DGMX_OPENMP=ON -DGMX_GPU=CUDA -DGMX_PREFER_STATIC_LIBS=ON -DGMX_SIMD=AVX2_256 -DGMX_CYCLE_SUBCOUNTERS=ON -DGMX_MPI=OFF -DGMXAPI=OFF",
+    # MPI
+    "-DCMAKE_BUILD_TYPE=Release -DCUDA_TOOLKIT_ROOT_DIR=$CUDATOOLKIT_HOME -DGMX_BUILD_OWN_FFTW=ON -DGMX_OPENMP=ON -DGMX_GPU=CUDA -DGMX_PREFER_STATIC_LIBS=ON -DGMX_SIMD=AVX2_256 -DGMX_CYCLE_SUBCOUNTERS=ON -DGMX_MPI=ON -DGMXAPI=OFF"
+]
+
+onlytcmod = True
+skipsteps = ['test']
+
+moduleclass = 'bio'

--- a/jenkins-builds/7.0.UP03-21.09-dom-gpu
+++ b/jenkins-builds/7.0.UP03-21.09-dom-gpu
@@ -7,7 +7,7 @@
  CPMD-4.3-CrayIntel-21.09-cuda.eb
  FFmpeg-4.4-CrayGNU-21.09.eb                            --set-default-module
  GREASY-19.03-cscs-CrayGNU-21.09.eb                     --set-default-module
- GROMACS-2021.3-CrayGNU-21.09-cuda.eb                   --set-default-module
+ GROMACS-2021.5-CrayGNU-21.09-cuda.eb                   --set-default-module
  GSL-2.7-CrayGNU-21.09.eb                               --set-default-module
  GSL-2.7-CrayCCE-21.09.eb
  GSL-2.7-CrayIntel-21.09.eb


### PR DESCRIPTION
I provide the recipe for the latest GROMACS release 2021.5 with CDT 21.09.