### PR TITLE
[dom-gpu] CP2K 9.1 with SIRIUS (cuda-mkl)

### DIFF
--- a/easybuild/easyconfigs/c/CP2K/CP2K-9.1-CrayGNU-21.09-cuda.eb
+++ b/easybuild/easyconfigs/c/CP2K/CP2K-9.1-CrayGNU-21.09-cuda.eb
@@ -38,7 +38,7 @@ dependencies = [
     ('libxc', '5.1.7'),
     ('PLUMED', '2.7.3'),
     ('spglib', '1.16.3'),
-    #('SIRIUS', '7.3.0', versionsuffix)
+    ('SIRIUS', '7.3.1', versionsuffix+'-mkl')
 ]
 
 # build type

--- a/easybuild/easyconfigs/c/CP2K/CP2K-9.1-CrayGNU-cuda.psmp
+++ b/easybuild/easyconfigs/c/CP2K/CP2K-9.1-CrayGNU-cuda.psmp
@@ -12,15 +12,14 @@ LD             = ftn
 AR             = ar -r
 
 # LIBXSMM (-D__LIBXSMM) is slower than LIBSMM (-D__HAS_smm_dnn)
-DFLAGS   = -D__ACC -D__DBCSR_ACC -D__GRID_CUDA -D__GFORTRAN -D__HAS_smm_dnn -D__MAX_CONTR=4 -D__MPI_VERSION=3 -D__parallel -D__SCALAPACK
-DFLAGS  += -D__ELPA -D__ELPA_NVIDIA_GPU -D__FFTW3 -D__GSL -D__LIBINT -D__LIBVORI -D__LIBXC -D__PLUMED2 -D__SIRIUS -D__SPGLIB
+DFLAGS   = -D__ACC -D__DBCSR_ACC -D__GRID_CUDA -D__GFORTRAN -D__HAS_smm_dnn -D__MAX_CONTR=4 -D__MPI_VERSION=3 -D__parallel -D__PW_CUDA -D__SCALAPACK
+DFLAGS  += -D__ELPA -D__ELPA_NVIDIA_GPU -D__FFTW3 -D__GSL -D__LIBINT -D__LIBVORI -D__LIBXC -D__PLUMED2 -D__SPGLIB
 CFLAGS  = -O2 -fopenmp -fopenmp-simd -ftree-vectorize -funroll-loops -g $(DFLAGS) -I$(CUDA_HOME)/include 
 CFLAGS  += -I$(ELPA_OPENMP_INCLUDE_DIR)/elpa -I$(ELPA_OPENMP_INCLUDE_DIR)/modules 
 CFLAGS  += -I$(EBROOTFFTW)/include
 CFLAGS  += -I$(EBROOTGSL)/include
 CFLAGS  += -I$(EBROOTLIBINTMINCP2K)/include -I$(EBROOTLIBINTMINCP2K)/include/libint2
 CFLAGS  += -I$(EBROOTLIBXC)/include
-CFLAGS  += -I$(EBROOTSIRIUS)/include/sirius
 CFLAGS  += -I$(EBROOTSPGLIB)/include
 CXXFLAGS = $(CFLAGS) -std=c++11
 FCFLAGS  = $(CFLAGS)
@@ -36,7 +35,6 @@ LIBS   	 += -L$(EBROOTGSL)/lib -lgsl
 LIBS     += -L$(EBROOTLIBINTMINCP2K)/lib -lint2
 LIBS     += $(EBROOTLIBVORI)/lib/libvori.a
 LIBS     += -L$(EBROOTLIBXC)/lib -lxcf03 -lxc
-LIBS     += -L$(EBROOTSIRIUS)/lib -lsirius
 LIBS     += -L$(EBROOTSPGLIB)/lib -lsymspg
 LIBS     += -lcudart -lcublas -lcufft -lnvrtc -lrt
 LIBS     += -lplumed -lz -ldl -lstdc++

--- a/easybuild/easyconfigs/c/CP2K/CP2K-9.1-CrayGNU-cuda.psmp
+++ b/easybuild/easyconfigs/c/CP2K/CP2K-9.1-CrayGNU-cuda.psmp
@@ -13,13 +13,14 @@ AR             = ar -r
 
 # LIBXSMM (-D__LIBXSMM) is slower than LIBSMM (-D__HAS_smm_dnn)
 DFLAGS   = -D__ACC -D__DBCSR_ACC -D__GRID_CUDA -D__GFORTRAN -D__HAS_smm_dnn -D__MAX_CONTR=4 -D__MPI_VERSION=3 -D__parallel -D__SCALAPACK
-DFLAGS  += -D__ELPA -D__ELPA_NVIDIA_GPU -D__FFTW3 -D__GSL -D__LIBINT -D__LIBVORI -D__LIBXC -D__PLUMED2 -D__SPGLIB
+DFLAGS  += -D__ELPA -D__ELPA_NVIDIA_GPU -D__FFTW3 -D__GSL -D__LIBINT -D__LIBVORI -D__LIBXC -D__PLUMED2 -D__SIRIUS -D__SPGLIB
 CFLAGS  = -O2 -fopenmp -fopenmp-simd -ftree-vectorize -funroll-loops -g $(DFLAGS) -I$(CUDA_HOME)/include 
 CFLAGS  += -I$(ELPA_OPENMP_INCLUDE_DIR)/elpa -I$(ELPA_OPENMP_INCLUDE_DIR)/modules 
 CFLAGS  += -I$(EBROOTFFTW)/include
 CFLAGS  += -I$(EBROOTGSL)/include
 CFLAGS  += -I$(EBROOTLIBINTMINCP2K)/include -I$(EBROOTLIBINTMINCP2K)/include/libint2
 CFLAGS  += -I$(EBROOTLIBXC)/include
+CFLAGS  += -I$(EBROOTSIRIUS)/include/sirius
 CFLAGS  += -I$(EBROOTSPGLIB)/include
 CXXFLAGS = $(CFLAGS) -std=c++11
 FCFLAGS  = $(CFLAGS)
@@ -35,6 +36,7 @@ LIBS   	 += -L$(EBROOTGSL)/lib -lgsl
 LIBS     += -L$(EBROOTLIBINTMINCP2K)/lib -lint2
 LIBS     += $(EBROOTLIBVORI)/lib/libvori.a
 LIBS     += -L$(EBROOTLIBXC)/lib -lxcf03 -lxc
+LIBS     += -L$(EBROOTSIRIUS)/lib -lsirius
 LIBS     += -L$(EBROOTSPGLIB)/lib -lsymspg
 LIBS     += -lcudart -lcublas -lcufft -lnvrtc -lrt
 LIBS     += -lplumed -lz -ldl -lstdc++

--- a/easybuild/easyconfigs/s/SIRIUS/SIRIUS-7.3.1-CrayGNU-21.09-cuda-mkl.eb
+++ b/easybuild/easyconfigs/s/SIRIUS/SIRIUS-7.3.1-CrayGNU-21.09-cuda-mkl.eb
@@ -2,8 +2,8 @@
 easyblock = 'CMakeMake'
 
 name = 'SIRIUS'
-version = '7.2.8'
-versionsuffix = '-cuda'
+version = '7.3.1'
+versionsuffix = '-cuda-mkl'
 
 homepage = 'https://electronic-structure.github.io/SIRIUS/'
 description = "Domain specific library for electronic structure calculations."
@@ -15,21 +15,24 @@ source_urls = ['https://github.com/electronic-structure/%(name)s/archive/']
 sources = ['v%(version)s.tar.gz']
 
 builddependencies = [
-    ('CMake', '3.21.3', '', True)
+    ('CMake', '3.22.1', '', True),
+    ('intel', EXTERNAL_MODULE)
 ]
 
 dependencies = [
     ('cray-hdf5', EXTERNAL_MODULE),
-    ('ELPA', '2021.05.002', versionsuffix),
+    ('ELPA', '2021.11.001', '-cuda'),
     ('GSL', '2.7'),
     ('libxc', '5.1.7'),
-    ('SpFFT', '1.0.5', versionsuffix+'-mkl'),
+    ('SpFFT', '1.0.5', versionsuffix),
     ('spglib', '1.16.3'),
-    ('SPLA', '1.5.2', versionsuffix+'-mkl')
+    ('SPLA', '1.5.2', versionsuffix)
 ]
 
 preconfigopts = " CXX=CC CC=cc FC=ftn && "
-configopts = "-DUSE_CUDA=0 -DBUILD_TESTS=0 -DUSE_CRAY_LIBSCI=1 -DUSE_MAGMA=0 -DUSE_MKL=0 -DUSE_SCALAPACK=1 -DUSE_ELPA=1 -DSpFFT_DIR=$EBROOTSPFFT/lib64/cmake/SpFFT"
+configopts = "-DUSE_CUDA=1 -DBUILD_TESTS=0 -DUSE_CRAY_LIBSCI=0 -DUSE_MAGMA=0 -DUSE_MKL=1 -DUSE_SCALAPACK=1 -DUSE_ELPA=1 -DSpFFT_DIR=$EBROOTSPFFT/lib64/cmake/SpFFT"
+
+prebuildopts = "module unload cray-libsci && module unload cray-libsci_acc && module list &&"
 
 modextrapaths = {'CPATH': ['include/%(namelower)s']}
 


### PR DESCRIPTION
I provide the recipe of CP2K 9.1 with the latest SIRIUS including ELPA: I kept `-DUSE_CRAY_LIBSCI=0` and `-DUSE_MKL=1` as in the current modulefile in production, although the build with `cray-libsci` seems to work well too.