### PR TITLE
[daint-gpu] VASP 6.3.0 fix with 21.05

### DIFF
--- a/easybuild/easyconfigs/c/CrayNvidia/CrayNvidia-21.05.eb
+++ b/easybuild/easyconfigs/c/CrayNvidia/CrayNvidia-21.05.eb
@@ -16,11 +16,11 @@ dependencies = [
     ('cdt-cuda/%s' % version, EXTERNAL_MODULE)
 ]
 
-## fix CPATH https://github.com/vkarak/eurohack21/wiki/Piz-Daint's-programming-environment#prgenv-pgi-vs-prgenv-nvidia
+# fix CPATH https://github.com/vkarak/eurohack21/wiki/Piz-Daint's-programming-environment#prgenv-pgi-vs-prgenv-nvidia
 modtclfooter = """
-prepend-path CPATH /opt/nvidia/hpc_sdk/Linux_x86_64/21.3/cuda/11.2/targets/x86_64-linux/include
-remove-path CPATH /opt/nvidia/hpc_sdk/Linux_x86_64/21.3/compilers/include
-prepend-path LD_LIBRARY_PATH /opt/nvidia/hpc_sdk/Linux_x86_64/21.3/comm_libs/nccl/lib
+prepend-path CPATH $::env(CRAY_NVIDIA_PREFIX)/cuda/11.2/targets/x86_64-linux/include
+remove-path CPATH $::env(CRAY_NVIDIA_PREFIX)/compilers/include
+prepend-path LD_LIBRARY_PATH $::env(CRAY_NVIDIA_PREFIX)/compilers/extras/qd/lib:$::env(CRAY_NVIDIA_PREFIX)/comm_libs/nccl/lib
 """
 
 # LD_LIBRARY_PATH is now updated by production.git/login/daint.footer

--- a/easybuild/easyconfigs/v/VASP/VASP-6.3.0-CrayNvidia-21.05-acc.eb
+++ b/easybuild/easyconfigs/v/VASP/VASP-6.3.0-CrayNvidia-21.05-acc.eb
@@ -21,15 +21,15 @@ patches = [('%(name)s-%(version)s-%(toolchain_name)s%(versionsuffix)s.makefile.i
 
 sources = ['/apps/common/UES/easybuild/sources/%(nameletterlower)s/%(name)s/' + SOURCELOWER_TAR_BZ2]
 
+# nvidia loaded by PrgEnv-nvidia but EBROOTNVIDIA not defined unless listed as dependency
 builddependencies = [
-    ('cudatoolkit/21.3_11.2', EXTERNAL_MODULE),
+    ('cudatoolkit', EXTERNAL_MODULE),
     ('Wannier90', '3.1.0')
 ]
 
 dependencies = [
     ('cray-hdf5', EXTERNAL_MODULE),
-    ('intel', EXTERNAL_MODULE),
-    ('QD', '2.3.23')
+    ('intel', EXTERNAL_MODULE)
 ]
 
 # parallel make tend to fail
@@ -45,7 +45,7 @@ files_to_copy = [(['./bin/vasp_*'],'bin')]
 
 sanity_check_paths = {
     'files': ['bin/vasp_gam','bin/vasp_ncl','bin/vasp_std'],
-    'dirs': [],
+    'dirs': []
 }
 
 # define MPICH_RDMA_ENABLED_CUDA to enable CUDA-aware MPI

--- a/easybuild/easyconfigs/v/VASP/VASP-6.3.0-CrayNvidia-acc.makefile.include
+++ b/easybuild/easyconfigs/v/VASP/VASP-6.3.0-CrayNvidia-acc.makefile.include
@@ -58,13 +58,15 @@ CXX_PARS    = nvc++ --no_warnings
 # Specify your NV HPC-SDK installation (mandatory)
 #... first try to set it automatically
 #NVROOT      =$(shell which nvfortran | awk -F /compilers/bin/nvfortran '{ print $$1 }')
-
 # If the above fails, then NVROOT needs to be set manually
-NVROOT      = $(EBROOTNVIDIA)
+
+# nvidia module loaded by PrgEnv-nvidia but EBROOTNVIDIA not defined unless listed as dependency
+NVROOT      = $(CRAY_NVIDIA_PREFIX)
 
 # Software emulation of quadruple precsion (mandatory)
-LLIBS      += -L$(EBROOTQD)/lib -lqdmod -lqd
-INCS       += -I$(EBROOTQD)/include/qd
+QD         = $(NVROOT)/compilers/extras/qd
+LLIBS      += -L$(QD)/lib -lqdmod -lqd
+INCS       += -I$(QD)/include/qd
 
 # Intel MKL (FFTW, BLAS, LAPACK, and scaLAPACK)
 LLIBS      += -Mmkl -L$(MKLROOT)/lib/intel64 -lmkl_scalapack_lp64 -lmkl_blacs_intelmpi_lp64


### PR DESCRIPTION
Use QD from module `nvidia` and add QD library path to `CrayNvidia` modulefile at runtime.