### PR TITLE
[dom-gpu] VTK v9.1 for cdt21.09

### DIFF
--- a/easybuild/easyconfigs/v/VTK/VTK-9.1.0-CrayGNU-21.09-EGL-python3.eb
+++ b/easybuild/easyconfigs/v/VTK/VTK-9.1.0-CrayGNU-21.09-EGL-python3.eb
@@ -25,7 +25,7 @@ source_urls = ['http://www.%(namelower)s.org/files/release/%(version_major_minor
 sources = [SOURCE_TAR_GZ]
 
 builddependencies = [
-    ('CMake', '3.21.3', '', True),
+    ('CMake', '3.22.1', '', True),
 ]
 dependencies = [
     ('cray-python', EXTERNAL_MODULE),
@@ -34,7 +34,15 @@ dependencies = [
     ('VisRTX', '0.1.6', '-cuda'),
 ]
 
-configopts = '-DCMAKE_BUILD_TYPE=RelWithDebInfo -DBUILD_SHARED_LIBS:BOOL=ON -DVTK_BUILD_TESTING:STRING=OFF -DVTK_WRAP_PYTHON:BOOL=ON -DCMAKE_C_COMPILER:PATH=cc -DCMAKE_CXX_COMPILER:PATH=CC -DVTK_MODULE_ENABLE_VTK_RenderingRayTracing:STRING=YES -DVTK_ENABLE_VISRTX:BOOL=ON -DVTKOSPRAY_ENABLE_DENOISER:BOOL=ON -Dospray_DIR="$EBROOTOSPRAY" -DOpenImageDenoise_DIR="$EBROOTOIDN/lib/cmake/OpenImageDenoise" -DVisRTX_DIR="$EBROOTVISRTX/lib64/cmake/VisRTX-$EBVERSIONVISRTX" -DVTK_USE_X=OFF -DVTK_SMP_IMPLEMENTATION_TYPE:STRING=TBB -DTBB_INCLUDE_DIR:PATH=/opt/intel/compilers_and_libraries/linux/tbb/include -DTBB_LIBRARY_RELEASE:FILEPATH=/opt/intel/compilers_and_libraries/linux/tbb/lib/intel64/gcc4.8/libtbb.so -DTBB_MALLOC_LIBRARY_RELEASE:FILEPATH="$EBROOTOSPRAY/lib/libtbbmalloc.so" -DVTK_OPENGL_HAS_EGL:BOOL=ON -DOPENGL_egl_LIBRARY:FILEPATH=/usr/lib64/libEGL.so -DOPENGL_opengl_LIBRARY:FILEPATH=/usr/lib64/libOpenGL.so '
+configopts  = '-DCMAKE_BUILD_TYPE=RelWithDebInfo -DBUILD_SHARED_LIBS:BOOL=ON '
+configopts += '-DVTK_BUILD_TESTING:STRING=OFF -DVTK_WRAP_PYTHON:BOOL=ON '
+configopts += '-DCMAKE_C_COMPILER:PATH=cc -DCMAKE_CXX_COMPILER:PATH=CC '
+configopts += '-DVTK_MODULE_ENABLE_VTK_RenderingRayTracing:STRING=YES -DVTK_ENABLE_VISRTX:BOOL=ON '
+configopts += '-DVTKOSPRAY_ENABLE_DENOISER:BOOL=ON -DOpenImageDenoise_DIR="$EBROOTOIDN/lib/cmake/OpenImageDenoise" '
+configopts += '-Dospray_DIR="$EBROOTOSPRAY" -DVisRTX_DIR="$EBROOTVISRTX/lib64/cmake/VisRTX-$EBVERSIONVISRTX" '
+configopts += '-DVTK_SMP_IMPLEMENTATION_TYPE:STRING=TBB -DTBB_INCLUDE_DIR:PATH=/opt/intel/compilers_and_libraries/linux/tbb/include '
+configopts += '-DTBB_LIBRARY_RELEASE:FILEPATH=/opt/intel/compilers_and_libraries/linux/tbb/lib/intel64/gcc4.8/libtbb.so -DTBB_MALLOC_LIBRARY_RELEASE:FILEPATH="$EBROOTOSPRAY/lib/libtbbmalloc.so" '
+configopts += '-DVTK_USE_X=OFF -DVTK_OPENGL_HAS_EGL:BOOL=ON -DOPENGL_egl_LIBRARY:FILEPATH=/usr/lib64/libEGL.so -DOPENGL_opengl_LIBRARY:FILEPATH=/usr/lib64/libOpenGL.so '
 
 maxparallel = 24
 
@@ -44,12 +52,12 @@ sanity_check_paths = {
     'dirs': ['lib64/python%(pyshortver)s/site-packages/', 'include/%(namelower)s-%(version_major_minor)s'],
 }
 
-#sanity_check_commands = [('bin/vtkpython', "-c 'import %(namelower)s'")]
+sanity_check_commands = [('bin/vtkpython', "-c 'import %(namelower)s'")]
 
 modextrapaths = {'PYTHONPATH': ['lib64/python%(pyshortver)s/site-packages']}
 
 modextravars = {
-    'LD_LIBRARY_PATH': '$::env(PYTHONPATH)/lib:$::env(LD_LIBRARY_PATH)',
+    'LD_LIBRARY_PATH': '/opt/intel/compilers_and_libraries/linux/tbb/lib/intel64/gcc4.8:$::env(LD_LIBRARY_PATH)',
     'TBB_ROOT': '/opt/intel/compilers_and_libraries/linux/tbb',
 }
 


### PR DESCRIPTION
restore sanity check and add path to TBB libs

== COMPLETED: Installation ended successfully (took 16 mins 41 secs)
== Results of the build can be found in the log file(s) /scratch/snx3000tds/jfavre/daint/software/VTK/9.1.0-CrayGNU-21.09-EGL-python3/easybuild/easybuild-VTK-9.1.0-20220201.153333.log
