### PR TITLE
[daint] Add Julia 1.6.5 pe20.11 without site-wide package installations

### DIFF
--- a/easybuild/easyconfigs/j/Julia/Julia-1.7.2-CrayGNU-20.11.eb
+++ b/easybuild/easyconfigs/j/Julia/Julia-1.7.2-CrayGNU-20.11.eb
@@ -2,7 +2,7 @@
 easyblock = 'PackedBinary'
 
 name = 'Julia'
-version = '1.7.0'
+version = '1.7.2'
 
 homepage = 'https://julialang.org'
 description = 'Julia is a high-level general-purpose dynamic programming language that was originally designed to address the needs of high-performance numerical analysis and computational science, without the typical need of separate compilation to be fast, also usable for client and server web use, low-level systems programming or as a specification language (wikipedia.org). Julia provides ease and expressiveness for high-level numerical computing, in the same way as languages such as R, MATLAB, and Python, but also supports general programming. To achieve this, Julia builds upon the lineage of mathematical programming languages, but also borrows much from popular dynamic languages, including Lisp, Perl, Python, Lua, and Ruby (julialang.org).'


### PR DESCRIPTION
The 1.6.5 recipes are identical to the recipes from PR #2659, except for the version number.