### PR TITLE
[daint, dom] Dask updated modules

### DIFF
--- a/easybuild/easyconfigs/d/dask/dask-2.2.0-CrayGNU-21.09-python3.eb
+++ b/easybuild/easyconfigs/d/dask/dask-2.2.0-CrayGNU-21.09-python3.eb
@@ -33,7 +33,9 @@ exts_list = [
     ('PyYAML', '5.1.2', {'modulename': 'yaml'}),
     ('HeapDict', '1.0.0'),
     ('zict', '1.0.0'),
-    ('tornado', '6.0.3'),
+    # MKr - 18.02.2022: 
+    # update to be compatible with jupyterhub    
+    ('tornado', '6.1'),
     ('msgpack', '0.6.1'),
     ('tblib', '1.4.0'),
     ('psutil', '5.6.3'),
@@ -41,7 +43,9 @@ exts_list = [
     ('distributed', '2.2.0'),
     ('MarkupSafe', '1.1.1'),
     ('Jinja2', '2.10.1'),
-    ('bokeh', '1.3.4'),
+    # MKr - 18.02.2022
+    # Updated due to a warning inside jupyterhub
+    ('bokeh', '2.4.2'),
     ('packaging', '19.1'),
     ('Pillow', '6.1.0', {'modulename': 'PIL'}),
     ('fsspec', '0.4.1'),

--- a/easybuild/easyconfigs/d/dask/dask-2.2.0-CrayGNU-21.09-python3.eb
+++ b/easybuild/easyconfigs/d/dask/dask-2.2.0-CrayGNU-21.09-python3.eb
@@ -45,7 +45,7 @@ exts_list = [
     ('Jinja2', '2.10.1'),
     # MKr - 18.02.2022
     # Updated due to a warning inside jupyterhub
-    ('bokeh', '2.4.2'),
+    ('bokeh', '2.1.0'),
     ('packaging', '19.1'),
     ('Pillow', '6.1.0', {'modulename': 'PIL'}),
     ('fsspec', '0.4.1'),


### PR DESCRIPTION
Request based on issues reported by users of JupyterHub.

tornado 6.0.3 incompatible - requirement 6.1 (prevented JupyterHub from starting)
bokeh was updated based on a warning found inside the `jupyterhub_slurmspawner_36763588.log`:

`pkg_resources.VersionConflict: (bokeh 1.3.4 (/apps/common/UES/sandbox/kraushm/daint/software/dask/2.2.0-CrayGNU-21.09-python3/lib/python3.9/site-packages), Requirement.        parse('bokeh>2.1'))`