### PR TITLE
[daint dom] Link MPI-only ELPA with CP2K

### DIFF
--- a/easybuild/easyconfigs/c/CP2K/CP2K-9.1-CrayGNU-cuda.psmp
+++ b/easybuild/easyconfigs/c/CP2K/CP2K-9.1-CrayGNU-cuda.psmp
@@ -15,7 +15,7 @@ AR             = ar -r
 DFLAGS   = -D__ACC -D__DBCSR_ACC -D__GRID_CUDA -D__GFORTRAN -D__HAS_smm_dnn -D__MAX_CONTR=4 -D__MPI_VERSION=3 -D__parallel -D__PW_CUDA -D__SCALAPACK
 DFLAGS  += -D__ELPA -D__ELPA_NVIDIA_GPU -D__FFTW3 -D__GSL -D__LIBINT -D__LIBVORI -D__LIBXC -D__PLUMED2 -D__SIRIUS  -D__SPGLIB
 CFLAGS  = -O2 -fopenmp -fopenmp-simd -ftree-vectorize -funroll-loops -g $(DFLAGS) -I$(CUDA_HOME)/include 
-CFLAGS  += -I$(ELPA_OPENMP_INCLUDE_DIR)/elpa -I$(ELPA_OPENMP_INCLUDE_DIR)/modules 
+CFLAGS  += -I$(ELPA_INCLUDE_DIR)/elpa -I$(ELPA_INCLUDE_DIR)/modules 
 CFLAGS  += -I$(EBROOTFFTW)/include
 CFLAGS  += -I$(EBROOTGSL)/include
 CFLAGS  += -I$(EBROOTLIBINTMINCP2K)/include -I$(EBROOTLIBINTMINCP2K)/include/libint2
@@ -30,7 +30,7 @@ endif
 FCFLAGS  += -fbacktrace -ffree-form -ffree-line-length-none -fno-omit-frame-pointer -std=f2008 
 LDFLAGS  = $(FCFLAGS) -L$(CUDA_HOME)/lib64 -Wl,-rpath=$(CUDA_HOME)/lib64
 OFFLOAD_FLAGS = $(DFLAGS) -O3 -Xcompiler="-fopenmp" -arch sm_60 --std=c++11
-LIBS     += -L$(EBROOTELPA)/lib -lelpa_openmp
+LIBS     += -L$(EBROOTELPA)/lib -lelpa
 LIBS   	 += -L$(EBROOTFFTW)/lib -lfftw3 -lfftw3_threads
 LIBS   	 += -L$(EBROOTGSL)/lib -lgsl
 LIBS     += -L$(EBROOTLIBINTMINCP2K)/lib -lint2

--- a/easybuild/easyconfigs/c/CP2K/CP2K-9.1-CrayGNU.psmp
+++ b/easybuild/easyconfigs/c/CP2K/CP2K-9.1-CrayGNU.psmp
@@ -12,7 +12,7 @@ AR             = ar -r
 DFLAGS   = -D__GFORTRAN -D__HAS_smm_dnn -D__MAX_CONTR=4 -D__MPI_VERSION=3 -D__parallel -D__SCALAPACK
 DFLAGS  += -D__ELPA -D__FFTW3 -D__GSL -D__LIBINT -D__LIBVORI -D__LIBXC -D__PLUMED2 -D__SIRIUS -D__SPGLIB
 CFLAGS  = -O2 -fopenmp -fopenmp-simd -ftree-vectorize -funroll-loops -g $(DFLAGS)
-CFLAGS  += -I$(ELPA_OPENMP_INCLUDE_DIR)/elpa -I$(ELPA_OPENMP_INCLUDE_DIR)/modules 
+CFLAGS  += -I$(ELPA_INCLUDE_DIR)/elpa -I$(ELPA_INCLUDE_DIR)/modules 
 CFLAGS  += -I$(EBROOTFFTW)/include
 CFLAGS  += -I$(EBROOTGSL)/include
 CFLAGS  += -I$(EBROOTLIBINTMINCP2K)/include -I$(EBROOTLIBINTMINCP2K)/include/libint2
@@ -26,7 +26,7 @@ ifeq ($(shell (( $(shell gcc -dumpversion | cut -d. -f1) > 9 )) && echo yes), ye
 endif
 FCFLAGS  += -fbacktrace -ffree-form -ffree-line-length-none -fno-omit-frame-pointer -std=f2008 
 LDFLAGS  = $(FCFLAGS)
-LIBS     += -L$(EBROOTELPA)/lib -lelpa_openmp
+LIBS     += -L$(EBROOTELPA)/lib -lelpa
 LIBS   	 += -L$(EBROOTFFTW)/lib -lfftw3 -lfftw3_threads
 LIBS   	 += -L$(EBROOTGSL)/lib -lgsl
 LIBS     += -L$(EBROOTLIBINTMINCP2K)/lib -lint2


### PR DESCRIPTION
I suggest to link MPI-only ELPA with CP2K on the Cray XC systems, since `cray-mpich` does not provide a sufficient level of threading support according to ELPA requirements. See [SD-54759](https://jira.cscs.ch/browse/SD-54759) for more details.