### PR TITLE
[daint,dom] spack-config 1.6

### DIFF
--- a/easybuild/easyconfigs/s/spack-config/spack-config-1.6-cdt-21.09.eb
+++ b/easybuild/easyconfigs/s/spack-config/spack-config-1.6-cdt-21.09.eb
@@ -20,7 +20,7 @@ configure_cmd='true'
 
 build_cmd='make'
 
-install_cmd='make install DESTDIR=%(installdir)s'
+install_cmd='make install DESTDIR=%(installdir)s CONFIG_FLAGS="--upstream_path=/apps/daint/UES/jenscscs/store"'
 
 sanity_check_paths = {
     'files': ['%s/compilers.yaml' %_cdt, '%s/packages.yaml' %_cdt],

--- a/easybuild/easyconfigs/s/spack-config/spack-config-1.6-cdt-21.09.eb
+++ b/easybuild/easyconfigs/s/spack-config/spack-config-1.6-cdt-21.09.eb
@@ -1,7 +1,7 @@
 easyblock = 'ConfigureMake'
 
 name = 'spack-config'
-version = '1.5'
+version = '1.6'
 _cdt = 'cdt-21.09'
 
 homepage = 'https://github.com/eth-cscs/spack-config-generator'
@@ -14,7 +14,7 @@ sources = [{
     'filename': '%(version)s.tar.gz'
 }]
 
-checksums = ['31c9415dfd494d884ce7e8c8fab74af084ce29efe636208b04b0d944b1101c13']
+checksums = ['405e75ecd62a98c38e198d0cd05d0bfb3b723881df5d0e0706581650a944553d']
 
 configure_cmd='true'
 

--- a/easybuild/easyconfigs/s/spack-config/spack-config-1.6-cdt-cuda-21.09.eb
+++ b/easybuild/easyconfigs/s/spack-config/spack-config-1.6-cdt-cuda-21.09.eb
@@ -1,7 +1,7 @@
 easyblock = 'ConfigureMake'
 
 name = 'spack-config'
-version = '1.5'
+version = '1.6'
 _cdt = 'cdt-cuda-21.09'
 
 homepage = 'https://github.com/eth-cscs/spack-config-generator'
@@ -14,13 +14,13 @@ sources = [{
     'filename': '%(version)s.tar.gz'
 }]
 
-checksums = ['31c9415dfd494d884ce7e8c8fab74af084ce29efe636208b04b0d944b1101c13']
+checksums = ['405e75ecd62a98c38e198d0cd05d0bfb3b723881df5d0e0706581650a944553d']
 
 configure_cmd='true'
 
 build_cmd='make'
 
-install_cmd='make install DESTDIR=%(installdir)s'
+install_cmd='make install DESTDIR=%(installdir)s CONFIG_FLAGS="--upstream_path=/apps/daint/UES/jenscscs/store"'
 
 sanity_check_paths = {
     'files': ['%s/compilers.yaml' %_cdt, '%s/packages.yaml' %_cdt],


### PR DESCRIPTION
- Adds `upstreams.yaml` as part of `module load spack-config` for reuse of binaries
- Makes `pkg-config` the default `pkgconfig` provider, since that's what cray compilers rely on by default

Purposely not changing the default version (requires some real life testing on daint).