### PR TITLE
Revert "[daint,dom] spack-config 1.6"

### DIFF
--- a/easybuild/easyconfigs/s/spack-config/spack-config-1.5-cdt-21.09.eb
+++ b/easybuild/easyconfigs/s/spack-config/spack-config-1.5-cdt-21.09.eb
@@ -1,7 +1,7 @@
 easyblock = 'ConfigureMake'
 
 name = 'spack-config'
-version = '1.6'
+version = '1.5'
 _cdt = 'cdt-21.09'
 
 homepage = 'https://github.com/eth-cscs/spack-config-generator'
@@ -14,13 +14,13 @@ sources = [{
     'filename': '%(version)s.tar.gz'
 }]
 
-checksums = ['405e75ecd62a98c38e198d0cd05d0bfb3b723881df5d0e0706581650a944553d']
+checksums = ['31c9415dfd494d884ce7e8c8fab74af084ce29efe636208b04b0d944b1101c13']
 
 configure_cmd='true'
 
 build_cmd='make'
 
-install_cmd='make install DESTDIR=%(installdir)s CONFIG_FLAGS="--upstream_path=/apps/daint/UES/jenscscs/store"'
+install_cmd='make install DESTDIR=%(installdir)s'
 
 sanity_check_paths = {
     'files': ['%s/compilers.yaml' %_cdt, '%s/packages.yaml' %_cdt],

--- a/easybuild/easyconfigs/s/spack-config/spack-config-1.5-cdt-cuda-21.09.eb
+++ b/easybuild/easyconfigs/s/spack-config/spack-config-1.5-cdt-cuda-21.09.eb
@@ -1,7 +1,7 @@
 easyblock = 'ConfigureMake'
 
 name = 'spack-config'
-version = '1.6'
+version = '1.5'
 _cdt = 'cdt-cuda-21.09'
 
 homepage = 'https://github.com/eth-cscs/spack-config-generator'
@@ -14,13 +14,13 @@ sources = [{
     'filename': '%(version)s.tar.gz'
 }]
 
-checksums = ['405e75ecd62a98c38e198d0cd05d0bfb3b723881df5d0e0706581650a944553d']
+checksums = ['31c9415dfd494d884ce7e8c8fab74af084ce29efe636208b04b0d944b1101c13']
 
 configure_cmd='true'
 
 build_cmd='make'
 
-install_cmd='make install DESTDIR=%(installdir)s CONFIG_FLAGS="--upstream_path=/apps/daint/UES/jenscscs/store"'
+install_cmd='make install DESTDIR=%(installdir)s'
 
 sanity_check_paths = {
     'files': ['%s/compilers.yaml' %_cdt, '%s/packages.yaml' %_cdt],


### PR DESCRIPTION
Reverts eth-cscs/production#2681: I did not realised that @haampie renamed the 1.5 configuration file.
You also need to correct the entry in the production list, since [the CI/CD fails](https://jenkins.cscs.ch/blue/organizations/jenkins/ProductionEB/detail/ProductionEB/2163/pipeline) with the error below:
```
ERROR: One or more files not found: spack-config-1.5-cdt-21.09.eb
```
Otherwise, you could keep the older configuration files instead of renaming them: it is important that the most recent one is present in the [production list]().