### PR TITLE
[daint-gpu] CP2K and SIRIUS with latest ELPA

### DIFF
--- a/easybuild/easyconfigs/c/CP2K/CP2K-9.1-CrayGNU-21.09-cuda.eb
+++ b/easybuild/easyconfigs/c/CP2K/CP2K-9.1-CrayGNU-21.09-cuda.eb
@@ -32,7 +32,7 @@ builddependencies = [
     ('flex', '2.6.4')
 ]
 dependencies = [
-    ('ELPA', '2021.11.001', versionsuffix),
+    ('ELPA', '2021.11.002', versionsuffix),
     ('Libint-CP2K', '2.6.0'),
     ('libvori', '210412'),
     ('libxc', '5.1.7'),

--- a/easybuild/easyconfigs/s/SIRIUS/SIRIUS-7.3.1-CrayGNU-21.09-cuda-mkl.eb
+++ b/easybuild/easyconfigs/s/SIRIUS/SIRIUS-7.3.1-CrayGNU-21.09-cuda-mkl.eb
@@ -21,7 +21,7 @@ builddependencies = [
 
 dependencies = [
     ('cray-hdf5', EXTERNAL_MODULE),
-    ('ELPA', '2021.11.001', '-cuda'),
+    ('ELPA', '2021.11.002', '-cuda'),
     ('GSL', '2.7'),
     ('libxc', '5.1.7'),
     ('SpFFT', '1.0.5', versionsuffix),


### PR DESCRIPTION
I provide the recipes of CP2K and SIRIUS with the latest ELPA release `2021.11.002`.