### PR TITLE
[daint-mc] CP2K and SIRIUS with latest ELPA

### DIFF
--- a/easybuild/easyconfigs/c/CP2K/CP2K-9.1-CrayGNU-21.09.eb
+++ b/easybuild/easyconfigs/c/CP2K/CP2K-9.1-CrayGNU-21.09.eb
@@ -31,7 +31,7 @@ builddependencies = [
 ]
 
 dependencies = [
-    ('ELPA', '2021.11.001'),
+    ('ELPA', '2021.11.002'),
     ('Libint-CP2K', '2.6.0'),
     ('libvori', '210412'),
     ('libxc', '5.1.7'),

--- a/easybuild/easyconfigs/s/SIRIUS/SIRIUS-7.3.1-CrayGNU-21.09-mkl.eb
+++ b/easybuild/easyconfigs/s/SIRIUS/SIRIUS-7.3.1-CrayGNU-21.09-mkl.eb
@@ -21,7 +21,7 @@ builddependencies = [
 
 dependencies = [
     ('cray-hdf5', EXTERNAL_MODULE),
-    ('ELPA', '2021.11.001'),
+    ('ELPA', '2021.11.002'),
     ('GSL', '2.7'),
     ('libxc', '5.1.7'),
     ('SpFFT', '1.0.5', versionsuffix),


### PR DESCRIPTION
I provide the recipes of CP2K and SIRIUS (multicore) with the latest ELPA release 2021.11.002.