### PR TITLE
[daint,dom] set non-standard PYTHONPATH

### DIFF
--- a/easybuild/easyconfigs/a/Ascent/Ascent-0.8.0-CrayGNU-21.09.eb
+++ b/easybuild/easyconfigs/a/Ascent/Ascent-0.8.0-CrayGNU-21.09.eb
@@ -52,4 +52,6 @@ sanity_check_paths = {
     'dirs': ['include', 'lib'],
 }
 
+modextrapaths = {'PYTHONPATH': 'python-modules'}
+
 moduleclass = 'vis'

--- a/easybuild/easyconfigs/c/Conduit/Conduit-0.8.2-CrayGNU-21.09-python3.eb
+++ b/easybuild/easyconfigs/c/Conduit/Conduit-0.8.2-CrayGNU-21.09-python3.eb
@@ -48,5 +48,6 @@ sanity_check_paths = {
               'lib/libconduit.so'],
     'dirs': ['bin', 'include', 'lib'],
 }
+modextrapaths = {'PYTHONPATH': 'python-modules'}
 
 moduleclass = 'vis'


### PR DESCRIPTION
== COMPLETED: Installation ended successfully (took 1 min 5 secs)
== Results of the build can be found in the log file(s) /scratch/snx3000/jfavre/daint/software/Ascent/0.8.0-CrayGNU-21.09/easybuild/easybuild-Ascent-0.8.0-20220404.112441.log

== COMPLETED: Installation ended successfully (took 1 min 52 secs)
== Results of the build can be found in the log file(s) /scratch/snx3000/jfavre/daint/software/Conduit/0.8.2-CrayGNU-21.09-python3/easybuild/easybuild-Conduit-0.8.2-20220404.112308.log
== Build succeeded for 1 out of 1
