### PR TITLE
[daint-gpu dom-gpu] Update 7.0.UP03-21.09-daint-gpu

### DIFF
--- a/jenkins-builds/7.0.UP03-21.09-daint-gpu
+++ b/jenkins-builds/7.0.UP03-21.09-daint-gpu
@@ -50,7 +50,7 @@
  Spark-2.4.7-CrayGNU-21.09-Hadoop-2.7.eb                --set-default-module
  VASP-6.3.0-CrayNvidia-21.09-acc.eb                     --set-default-module
  Vc-1.4.1-CrayGNU-21.09.eb                              --set-default-module
- Visit-3.2.0-CrayGNU-21.09.eb                           --set-default-module
+ Visit-3.2.2-CrayGNU-21.09.eb                           --set-default-module
  VMD-1.9.3-egl.eb
  VMD-1.9.3-ogl.eb
  VMD-1.9.4.eb                                           --set-default-module


### PR DESCRIPTION
update Visit to 3.2.2 to support Blueprint HDF5