### PR TITLE
[daint] GEOS-3.9.3-CrayGNU-21.09.eb

### DIFF
--- a/easybuild/easyconfigs/g/GEOS/GEOS-3.9.3-CrayGNU-21.09.eb
+++ b/easybuild/easyconfigs/g/GEOS/GEOS-3.9.3-CrayGNU-21.09.eb
@@ -1,0 +1,23 @@
+easyblock = 'ConfigureMake'
+
+name = 'GEOS'
+version = '3.9.3'
+
+homepage = 'http://trac.osgeo.org/geos'
+description = """
+    GEOS (Geometry Engine - Open Source) is a C++ port of the Java Topology
+    Suite (JTS)
+"""
+
+toolchain = {'name': 'CrayGNU', 'version': '21.09'}
+
+source_urls = ['http://download.osgeo.org/%(namelower)s/']
+sources = [SOURCELOWER_TAR_BZ2]
+
+
+sanity_check_paths = {
+    'files': ['bin/%(namelower)s-config', 'lib/libgeos.so', 'lib/libgeos.a', 'include/%(namelower)s.h'],
+    'dirs': [],
+}
+
+moduleclass = 'math'


### PR DESCRIPTION
Testing: Used it in combination with PROJ/8.1.1-CrayGNU-21.09 to install cartopy