### PR TITLE
[daint dom] Adding BCFtools and GATK .eb files for CrayGNU 21.09.

### DIFF
--- a/easybuild/easyconfigs/b/bcftools/BCFtools-1.14-CrayGNU-21.09.eb
+++ b/easybuild/easyconfigs/b/bcftools/BCFtools-1.14-CrayGNU-21.09.eb
@@ -1,8 +1,4 @@
-# This file is an EasyBuild reciPY as per https://github.com/easybuilders/easybuild
-# 
-# Author: Jonas Demeulemeester
-# The Francis Crick Insitute, London, UK
-
+# contibuted by Julia Gustavsen (Agroscope) based on BCFtools-1.14-GCC-11.2.0.eb
 easyblock = 'ConfigureMake'
 
 name = 'BCFtools'

--- a/easybuild/easyconfigs/b/bcftools/BCFtools-1.14-CrayGNU-21.09.eb
+++ b/easybuild/easyconfigs/b/bcftools/BCFtools-1.14-CrayGNU-21.09.eb
@@ -1,0 +1,38 @@
+# This file is an EasyBuild reciPY as per https://github.com/easybuilders/easybuild
+# 
+# Author: Jonas Demeulemeester
+# The Francis Crick Insitute, London, UK
+
+easyblock = 'ConfigureMake'
+
+name = 'BCFtools'
+version = '1.14'
+
+homepage = 'https://www.htslib.org/'
+description = """Samtools is a suite of programs for interacting with high-throughput sequencing data.
+ BCFtools - Reading/writing BCF2/VCF/gVCF files and calling/filtering/summarising SNP and short indel sequence
+ variants"""
+
+toolchain = {'name': 'CrayGNU', 'version': '21.09'}
+toolchainopts = {'pic': True}
+
+source_urls = ['https://github.com/samtools/%(namelower)s/releases/download/%(version)s']
+sources = [SOURCELOWER_TAR_BZ2]
+checksums = ['b7ef88ae89fcb55658c5bea2e8cb8e756b055e13860036d6be13756782aa19cb']
+
+dependencies = [
+    ('zlib', '1.2.11'),
+    ('HTSlib', '1.15.1'),
+    ('bzip2', '1.0.8'),
+    ('XZ', '5.2.5'),
+    ('GSL', '2.7'),
+]
+
+configopts = "--with-htslib=$EBROOTHTSLIB --enable-libgsl"
+
+sanity_check_paths = {
+    'files': ['bin/%s' % x for x in ['bcftools', 'plot-vcfstats', 'vcfutils.pl']],
+    'dirs': ['libexec/bcftools']
+}
+
+moduleclass = 'bio'

--- a/easybuild/easyconfigs/g/GATK/GATK-4.2.5.0-CrayGNU-21.09-Java-11.eb
+++ b/easybuild/easyconfigs/g/GATK/GATK-4.2.5.0-CrayGNU-21.09-Java-11.eb
@@ -1,0 +1,55 @@
+##
+# This file is an EasyBuild reciPY as per https://github.com/easybuilders/easybuild
+#
+# Copyright:: Copyright 2012-2013 Cyprus Institute / CaSToRC, University of Luxembourg / LCSB
+# Authors::   George Tsouloupas <g.tsouloupas@cyi.ac.cy>, Fotis Georgatos <fotis.georgatos@uni.lu>,
+#             Kenneth Hoste (UGent)
+# License::   MIT/GPL
+# $Id$
+#
+# This work implements a part of the HPCBIOS project and is a component of the policy:
+# http://hpcbios.readthedocs.org/en/latest/HPCBIOS_2012-94.html
+# Modified by: Adam Huffman, Jonas Demeulemeester
+# The Francis Crick Institute
+# Modified for version 4.0.5.1 by: Ruben van Dijk, University of Groningen
+# Modified for version 4.2.3.0 by: J. Sassmannshausen / GSTT
+##
+
+easyblock = 'Tarball'
+
+name = 'GATK'
+version = '4.2.5.0'
+versionsuffix = '-Java-%(javaver)s'
+
+homepage = 'https://www.broadinstitute.org/gatk/'
+description = """The Genome Analysis Toolkit or GATK is a software package developed at the Broad Institute
+ to analyse next-generation resequencing data. The toolkit offers a wide variety of tools,
+ with a primary focus on variant discovery and genotyping as well as strong emphasis on
+ data quality assurance. Its robust architecture, powerful processing engine and
+ high-performance computing features make it capable of taking on projects of any size."""
+
+toolchain = {'name': 'CrayGNU', 'version': '21.09'}
+
+source_urls = ['https://github.com/broadinstitute/gatk/releases/download/%(version)s/']
+sources = ['gatk-%(version)s.zip']
+checksums = ['203f17868f0a73a8322d2f8bd568b9f7b4bb81e36d37db5b6a142d8050ef049f']
+
+dependencies = [
+    ('Java', '11', '', True),
+    ('cray-python', EXTERNAL_MODULE),
+]
+
+modextrapaths = {'PATH': ''}
+
+sanity_check_paths = {
+    'files': ['gatk'],
+    'dirs': [],
+}
+sanity_check_commands = [
+    "gatk --help",
+    "gatk --list",
+]
+
+modloadmsg = "WARNING: GATK v%(version)s support for Java 11 is in beta state. Use at your own risk.\n"
+
+moduleclass = 'bio'

--- a/easybuild/easyconfigs/g/GATK/GATK-4.2.5.0-CrayGNU-21.09-Java-11.eb
+++ b/easybuild/easyconfigs/g/GATK/GATK-4.2.5.0-CrayGNU-21.09-Java-11.eb
@@ -1,20 +1,4 @@
-##
-# This file is an EasyBuild reciPY as per https://github.com/easybuilders/easybuild
-#
-# Copyright:: Copyright 2012-2013 Cyprus Institute / CaSToRC, University of Luxembourg / LCSB
-# Authors::   George Tsouloupas <g.tsouloupas@cyi.ac.cy>, Fotis Georgatos <fotis.georgatos@uni.lu>,
-#             Kenneth Hoste (UGent)
-# License::   MIT/GPL
-# $Id$
-#
-# This work implements a part of the HPCBIOS project and is a component of the policy:
-# http://hpcbios.readthedocs.org/en/latest/HPCBIOS_2012-94.html
-# Modified by: Adam Huffman, Jonas Demeulemeester
-# The Francis Crick Institute
-# Modified for version 4.0.5.1 by: Ruben van Dijk, University of Groningen
-# Modified for version 4.2.3.0 by: J. Sassmannshausen / GSTT
-##
-
+# contibuted by Julia Gustavsen (Agroscope) based on GATK-4.2.5.0-GCCcore-11.2.0-Java-11.eb
 easyblock = 'Tarball'
 
 name = 'GATK'


### PR DESCRIPTION
A follow-up from [SD-55649](https://jira.cscs.ch/browse/SD-55649). I have added two Easybuild files for BCFtools and GATK. 

This is my first contribution, so please let me know if something is missing. Thanks, Julia