### PR TITLE
[dom daint eiger pilatus tsa] Set xthostname=1 by default in reframe-cscs-tests

### DIFF
--- a/easybuild/easyconfigs/r/reframe-cscs-tests/reframe-cscs-tests-22.09.eb
+++ b/easybuild/easyconfigs/r/reframe-cscs-tests/reframe-cscs-tests-22.09.eb
@@ -31,6 +31,7 @@ postinstallcmds = [
 modextrapaths = {
     'RFM_CONFIG_FILE': 'config/cscs.py',
     'RFM_CHECK_SEARCH_PATH': 'checks',
+    'RFM_AUTODETECT_XTHOSTNAME': '1',
 }
 
 sanity_check_paths = {


### PR DESCRIPTION
This is not necessary for the latest version of Reframe in the system but as soon we start using ReFrame 4.x we will need it. I am adding it so that we don't forget it since the new recipe will be deplyed automatically. I will also change [the template recipe](https://github.com/eth-cscs/cscs-reframe-tests/blob/main/JenkinsfileDeploy) to 22.09 after that.
```
def ebTemplate = '22.06'                        // The eb recipe of ReFrame to use as template
```
@teojgo am I forgetting anything?