### PR TITLE
[eiger pilatus] Fix system name

### DIFF
--- a/easybuild/module/EasyBuild-custom/cscs
+++ b/easybuild/module/EasyBuild-custom/cscs
@@ -65,11 +65,10 @@ if { $status == 0 } {
 # SYSTEM SPECIFIC SETUP #
 #########################
 # current system name
-if { [ string match *esch* $::env(HOSTNAME) ] } {
- set system [regsub {[cl]n-[0-9]+} $::env(HOSTNAME) ""]
-} elseif { [ string match *uan0\[1-3\]* $::env(HOSTNAME) ] } {
+#if { [ string match *uan0\[1-3\]* $::env(HOSTNAME) ] } {
+if { [ string match *eiger* $::env(LMOD_SYSTEM_NAME) ] } {
  set system "eiger"
-} elseif { [ string match *uan04* $::env(HOSTNAME) ] } {
+} elseif { [ string match *pilatus* $::env(LMOD_SYSTEM_NAME) ] } {
  set system "pilatus"
 } else {
  set system [regsub {[0-9]+} $::env(HOSTNAME) ""]

--- a/easybuild/module/EasyBuild-custom/cscs
+++ b/easybuild/module/EasyBuild-custom/cscs
@@ -65,7 +65,12 @@ if { $status == 0 } {
 # SYSTEM SPECIFIC SETUP #
 #########################
 # current system name (/etc/xthostname exists on Dom, Piz Daint and Alps)
-set system [exec cat /etc/xthostname]
+if { [ file exists /etc/xthostname ] } {
+	set system [exec cat /etc/xthostname]
+# the following applies to Arolla and Tsa instead
+} else {
+	set system [exec sh -c {hostname | sed 's/-[cl]n[0-9]*//g'}]
+}
 
 # system specific setup
 if { [ string match *daint* $system ] } {
@@ -90,18 +95,12 @@ if { [ string match *daint* $system ] } {
     setenv EASYBUILD_OPTARCH                    $::env(CRAY_CPU_TARGET)
     setenv EASYBUILD_MODULE_NAMING_SCHEME       HierarchicalMNS
     setenv EASYBUILD_RECURSIVE_MODULE_UNLOAD    0
-} elseif { [ string match *esch* $system ] } {
-    setenv EASYBUILD_EXTERNAL_MODULES_METADATA $::env(EB_CUSTOM_REPOSITORY)/cray_external_modules_metadata.cfg
-    setenv EASYBUILD_MODULE_NAMING_SCHEME       LowercaseModuleNamingScheme
 } elseif { [ string match *arolla* $system ] || [ string match *tsa* $system ] } {
     setenv EASYBUILD_EXTERNAL_MODULES_METADATA $::env(EB_CUSTOM_REPOSITORY)/cray_external_modules_metadata.cfg
     setenv EASYBUILD_MODULE_NAMING_SCHEME       LowercaseModuleNamingScheme
     setenv EASYBUILD_MODULES_TOOL               EnvironmentModulesC
     setenv EASYBUILD_RECURSIVE_MODULE_UNLOAD    1
     setenv EASYBUILD_RPATH                      1
-} elseif { [ string match *fulen* $system ] } {
-    setenv EASYBUILD_EXTERNAL_MODULES_METADATA $::env(EB_CUSTOM_REPOSITORY)/cray_external_modules_metadata.cfg
-    setenv XDG_RUNTIME_DIR                      /dev/shm/$::env(USER)
 } else {
     setenv EASYBUILD_EXTERNAL_MODULES_METADATA $::env(EB_CUSTOM_REPOSITORY)/cray_external_modules_metadata.cfg
     setenv EASYBUILD_RECURSIVE_MODULE_UNLOAD    1

--- a/easybuild/module/EasyBuild-custom/cscs
+++ b/easybuild/module/EasyBuild-custom/cscs
@@ -64,14 +64,8 @@ if { $status == 0 } {
 #########################
 # SYSTEM SPECIFIC SETUP #
 #########################
-# current system name
-if { [ string match *eiger* $::env(LMOD_SYSTEM_NAME) ] } {
- set system "eiger"
-} elseif { [ string match *pilatus* $::env(LMOD_SYSTEM_NAME) ] } {
- set system "pilatus"
-} else {
- set system [regsub {[0-9]+} $::env(HOSTNAME) ""]
-}
+# current system name (/etc/xthostname exists on Dom, Piz Daint and Alps)
+set system [exec cat /etc/xthostname]
 
 # system specific setup
 if { [ string match *daint* $system ] } {

--- a/easybuild/module/EasyBuild-custom/cscs
+++ b/easybuild/module/EasyBuild-custom/cscs
@@ -65,7 +65,6 @@ if { $status == 0 } {
 # SYSTEM SPECIFIC SETUP #
 #########################
 # current system name
-#if { [ string match *uan0\[1-3\]* $::env(HOSTNAME) ] } {
 if { [ string match *eiger* $::env(LMOD_SYSTEM_NAME) ] } {
  set system "eiger"
 } elseif { [ string match *pilatus* $::env(LMOD_SYSTEM_NAME) ] } {


### PR DESCRIPTION
I update the system name match in the EasyBuild custom module addressing Eiger and Pilatus and removing outdated matches of dismissed systems: this should fix the error of [ProductionEB](https://jenkins.cscs.ch/view/Production/job/ProductionEB) on Eiger (see my comment in #2790 ).