### PR TITLE
WIP eiger build Meson with cpeGNU

### DIFF
--- a/easybuild/easyconfigs/m/Meson/Meson-0.60.2-cpeGNU-21.12.eb
+++ b/easybuild/easyconfigs/m/Meson/Meson-0.60.2-cpeGNU-21.12.eb
@@ -1,0 +1,34 @@
+# contributed by Jean M. Favre and Luca Marsella (CSCS)
+easyblock = 'PythonPackage'
+
+name = 'Meson'
+version = '0.60.2'
+
+homepage = 'https://mesonbuild.com'
+description = """Meson is a cross-platform build system designed to be both as
+fast and as user friendly as possible."""
+
+toolchain = {'name': 'cpeGNU', 'version': '21.12'}
+
+source_urls = ['https://github.com/mesonbuild/%(namelower)s/releases/download/%(version)s/']
+sources = [SOURCELOWER_TAR_GZ]
+
+builddependencies = [
+    ('wheel', '0.37.0')
+]
+dependencies = [
+    ('cray-python', EXTERNAL_MODULE),
+    ('Ninja', '1.10.2')
+]
+
+download_dep_fail = True
+use_pip = True
+
+options = {'modulename': 'mesonbuild'}
+
+sanity_check_paths = {
+    'files': ['bin/%(namelower)s'],
+    'dirs': []
+}
+
+moduleclass = 'tools'

--- a/easybuild/easyconfigs/n/Ninja/Ninja-1.10.2-cpeGNU-21.12.eb
+++ b/easybuild/easyconfigs/n/Ninja/Ninja-1.10.2-cpeGNU-21.12.eb
@@ -1,0 +1,27 @@
+# jf (Jean Favre) CSCS
+easyblock = 'CmdCp'
+
+name = 'Ninja'
+version = '1.10.2'
+
+homepage = 'https://ninja-build.org/'
+description = "Ninja is a small build system with a focus on speed."
+
+toolchain = {'name': 'cpeGNU', 'version': '21.12'}
+
+source_urls = ['https://github.com/%(namelower)s-build/%(namelower)s/archive/']
+sources = ['v%(version)s.tar.gz']
+
+builddependencies = [
+    ('cray-python', EXTERNAL_MODULE),
+]
+
+files_to_copy = [(['%(namelower)s'], 'bin')]
+cmds_map = [('.*', './configure.py --bootstrap')]
+
+sanity_check_paths = {
+    'files': ['bin/%(namelower)s'],
+    'dirs': [],
+}
+
+moduleclass = 'tools'

--- a/easybuild/easyconfigs/w/wheel/wheel-0.37.0-cpeGNU-21.12.eb
+++ b/easybuild/easyconfigs/w/wheel/wheel-0.37.0-cpeGNU-21.12.eb
@@ -1,0 +1,25 @@
+# contributed by Rafael Sarmiento and Luca Marsella (CSCS)
+easyblock = 'PythonPackage'
+
+name = 'wheel'
+version = '0.37.0'
+
+homepage = 'https://pypi.python.org/pypi/wheel'
+description = """A built-package format for Python."""
+
+toolchain = {'name': 'cpeGNU', 'version': '21.12'}
+
+sources = [SOURCE_TAR_GZ]
+
+dependencies = [
+    ('cray-python', EXTERNAL_MODULE),
+]
+
+use_pip = True
+
+sanity_check_paths = {
+    'files': ['bin/%(name)s'],
+    'dirs': ['lib/python%(pyshortver)s/site-packages'],
+}
+
+moduleclass = 'tools'


### PR DESCRIPTION
@lucamar I would appreciate your help to resolve the following error with the Meson build on eiger:

module swap PrgEnv-cray PrgEnv-gnu
module load EasyBuild-custom/cscs
eb -f Meson-0.60.2-cpeGNU-21.12.eb -r

== FAILED: Installation ended unsuccessfully (build directory: /run/user/1100/easybuild/build/Meson/0.60.2/cpeGNU-21.12): build failed (first 300 chars): Module command '/usr/share/lmod/lmod/libexec/lmod python load wheel/.0.37.0' failed with exit code 1; stderr: Lmod has detected the following error: The following module(s) are unknown: "wheel/.0.37.0"

Please check the spelling or version number. Also try "module spider ..."
It is also possible you (took 12 secs)
== Results of the build can be found in the log file(s) /run/user/1100/easybuild/tmp/eb-mwwnugkb/easybuild-Meson-0.60.2-20221011.080126.xwvpc.log