### PR TITLE
[eiger pilatus] Update reframe-cscs-tests

### DIFF
--- a/jenkins-builds/1.4.0-21.12-eiger
+++ b/jenkins-builds/1.4.0-21.12-eiger
@@ -5,7 +5,7 @@
  jupyter-utils-0.1.eb                 --set-default-module
  NCL-6.6.2.eb                         --set-default-module
  reframe-3.12.0.eb                    --set-default-module
- reframe-cscs-tests-22.10.eb          --set-default-module
+ reframe-cscs-tests-22.10.1.eb        --set-default-module
  singularity-3.6.4-eiger.eb
  GSL-2.7-cpeAMD-21.12.eb
  GSL-2.7-cpeCray-21.12.eb


### PR DESCRIPTION
Update the default module with the new tag 22.10.1 that includes the recent changes of the `sarus` check.