### PR TITLE
[eiger pilatus] VTK on hold

### DIFF
--- a/jenkins-builds/1.4.0-21.12-eiger
+++ b/jenkins-builds/1.4.0-21.12-eiger
@@ -10,8 +10,7 @@
  GSL-2.7-cpeAMD-21.12.eb
  GSL-2.7-cpeCray-21.12.eb
  ParaView-5.10.0-cpeCray-21.12-OSMesa.eb
- VTK-9.1.0-cpeCray-21.12-OSMesa.eb
- VTK-9.2.2-cpeGNU-21.12-OSMesa.eb     --set-default-module
+ VTK-9.1.0-cpeCray-21.12-OSMesa.eb    --set-default-module
  Ascent-0.8.0-cpeGNU-21.12.eb
  Boost-1.78.0-cpeGNU-21.12.eb
  Boost-1.78.0-cpeGNU-21.12-python3.eb --set-default-module


### PR DESCRIPTION
I am removing the latest VTK with the `ospray` dependency until we fix [VCMSA-108](https://jira.cscs.ch/browse/VCMSA-108).