### PR TITLE
[daint-gpu dom-gpu] Update and rename VMD-1.9.4-a57.eb to VMD-1.9.4a57.eb

### DIFF
--- a/easybuild/easyconfigs/v/VMD/VMD-1.9.4a57.eb
+++ b/easybuild/easyconfigs/v/VMD/VMD-1.9.4a57.eb
@@ -4,7 +4,7 @@ easyblock = "CmdCp"
 
 name = 'VMD'
 version = '1.9.4'
-versionsuffix = '-a57'
+versionsuffix = 'a57'
 
 homepage = 'http://www.ks.uiuc.edu/Research/vmd/'
 description = """

--- a/jenkins-builds/7.0.UP03-21.09-daint-gpu
+++ b/jenkins-builds/7.0.UP03-21.09-daint-gpu
@@ -59,7 +59,7 @@
  Visit-3.3.0-CrayGNU-21.09.eb
  VMD-1.9.3-egl.eb
  VMD-1.9.3-ogl.eb
- VMD-1.9.4-a57.eb                                       --set-default-module
+ VMD-1.9.4a57.eb                                        --set-default-module
  VTK-9.2.2-CrayGNU-21.09-EGL-python3.eb                 --set-default-module
  advisor-2021.1.1.43.eb                                 --set-default-module --installpath=/apps/${system}/UES/jenkins/7.0.UP03/21.09/${system}-gpu/tools
  cgdb-v0.7.1.eb                                         --set-default-module --installpath=/apps/${system}/UES/jenkins/7.0.UP03/21.09/${system}-gpu/tools


### PR DESCRIPTION
Fix `versionsuffix`, recipe name and production list removing `-`.