### PR TITLE
[daint dom] Remove CPMD from licensed software

### DIFF
--- a/jenkins-builds/production.sh
+++ b/jenkins-builds/production.sh
@@ -219,8 +219,8 @@ for((i=0; i<${#eb_files[@]}; i++)); do
 # define name and version of the current build starting from the recipe name (obtained removing EasyBuild options from eb_files)
     recipe=$(echo ${eb_files[$i]} | cut -d' ' -f 1)
     name=$(echo $recipe | cut -d'-' -f 1)
-# build licensed software (CPMD, IDL, MATLAB, VASP) on Dom and Piz Daint
-    if [[ "$name" =~ "CPMD" || "$name" =~ "IDL" ||  "$name" =~ "MATLAB" || "$name" =~ "VASP" ]] && [[ "$system" =~ "daint" || "$system" =~ "dom" ]]; then
+# build licensed software (IDL, MATLAB, VASP) on Dom and Piz Daint
+    if [[ "$name" =~ "IDL" ||  "$name" =~ "MATLAB" || "$name" =~ "VASP" ]] && [[ "$system" =~ "daint" || "$system" =~ "dom" ]]; then
         version=$(echo $recipe | sed -e "s/^${name}-//" -e "s/.eb//")
 # custom footer for ${name} modulefile with a warning for users not belonging to corresponding group
         if [[ "$name" =~ "IDL" ]]; then

--- a/jenkins/JenkinsfileUpdateEB
+++ b/jenkins/JenkinsfileUpdateEB
@@ -47,7 +47,7 @@ stage('Machine Selection') {
   - the target Cray PE version is selected by the user and stored in "params.pe_target"
 */
 def updates = [:]
-def licensed_software = "CPMD IDL MATLAB VASP"
+def licensed_software = "IDL MATLAB VASP"
 
 stage('Update Stage') {
     for (system in machineConfigurations) {


### PR DESCRIPTION
I remove CPMD from the list of licensed software in the production scripts to reflect the new licensing terms pointed out in [SD-57890](https://jira.cscs.ch/browse/SD-57890) and updated in the [CPMD page on the User Portal](https://user.cscs.ch/computing/applications/cpmd/).