### PR TITLE
[daint] minor subversion update of ParaView, adding ospray 2.10

### DIFF
--- a/easybuild/easyconfigs/l/LLVM/LLVM-9.0.1-CrayGNU-21.09.eb
+++ b/easybuild/easyconfigs/l/LLVM/LLVM-9.0.1-CrayGNU-21.09.eb
@@ -20,7 +20,7 @@ source_urls = ['https://github.com/%(namelower)s/%(namelower)s-project/releases/
 sources = ['%(namelower)s-%(version)s.src.tar.xz']
 
 builddependencies = [
-    ('CMake', '3.21.3', '', True)
+    ('CMake', '3.22.1', '', True)
 ]
 
 # required to install extra tools in bin/

--- a/easybuild/easyconfigs/o/ospray/ospray-2.10.0-CrayGNU-21.09.eb
+++ b/easybuild/easyconfigs/o/ospray/ospray-2.10.0-CrayGNU-21.09.eb
@@ -1,0 +1,41 @@
+# Jean Favre (CSCS)
+easyblock = 'CMakeMake'
+
+name = 'ospray'
+version = '2.10.0'
+
+homepage = 'https://github.com/ospray'
+description = """An Open, Scalable, Parallel, Ray Tracing Based Rendering
+Engine for High-Fidelity Visualization"""
+
+toolchain = {'name': 'CrayGNU', 'version': '21.09'}
+
+source_urls = ['https://github.com/%(name)s/OSPRay/archive/']
+sources = ['v%(version)s.tar.gz']
+
+builddependencies = [
+    ('CMake', '3.22.1', '', True),
+#    ('git-lfs', '3.2.0', '', True),
+]
+
+#configopts =  '-DCMAKE_CXX_COMPILER=g++ -DCMAKE_C_COMPILER=gcc '
+configopts = '-DINSTALL_IN_SEPARATE_DIRECTORIES:BOOL=OFF '
+configopts += '-DTBB_DIR=/opt/intel/oneapi/tbb/latest '
+configopts += '-DDOWNLOAD_TBB:BOOL=OFF '
+configopts += '-DBUILD_OSPRAY_APPS:BOOL=OFF '
+configopts += '-DBUILD_GLFW:BOOL=OFF '
+configopts += '-DBUILD_OIDN:BOOL=ON '
+configopts += '-DBUILD_OIDN_FROM_SOURCE:BOOL=OFF '
+
+srcdir = 'scripts/superbuild'
+
+build_cmd = "export TBB_DIR=/opt/intel/oneapi/tbb/latest; cmake --build ."
+
+skipsteps = ['install']
+
+sanity_check_paths = {
+    'files': ['include/ospray/ospray.h', 'lib64/libospray.so'],
+    'dirs': ['include', 'lib64'],
+}
+
+moduleclass = 'vis'

--- a/easybuild/easyconfigs/p/ParaView/ParaView-5.11.2-CrayGNU-21.09-OSMesa.eb
+++ b/easybuild/easyconfigs/p/ParaView/ParaView-5.11.2-CrayGNU-21.09-OSMesa.eb
@@ -1,0 +1,91 @@
+# CrayGNU version by Jean Favre (CSCS)
+easyblock = 'CMakeMake'
+
+name = 'ParaView'
+version = '5.11.2'
+versionsuffix = '-OSMesa'
+
+homepage = 'http://www.paraview.org'
+description = "ParaView is a scientific parallel visualizer."
+
+toolchain = {'name': 'CrayGNU', 'version': '21.09'}
+toolchainopts = {'pic': True, 'usempi': True, 'verbose': False}
+
+source_urls = [
+    'http://www.%(namelower)s.org/%(namelower)s-downloads/download.php?submit=Download&version=v%(version_major_minor)s&type=source&os=all&downloadFile=',
+]
+sources = ['%(name)s-v%(version)s.tar.gz']
+
+builddependencies = [
+    ('CMake', '3.26.5', '', True)
+]
+dependencies = [
+    ('cray-python', EXTERNAL_MODULE),
+    ('h5py', '3.6.0', '-serial'),
+    ('Boost', '1.78.0', '-python%(pymajver)s'),
+    ('CDI', '2.1.0'),
+    ('Catalyst', '2.0.0', '-rc4'),
+    ('Mesa', '21.3.1'),
+    ('ospray', '2.10.0'),
+]
+
+configopts = '-DPARAVIEW_USE_MPI:BOOL=ON '
+configopts += '-DCMAKE_C_COMPILER=gcc -DCMAKE_CXX_COMPILER=g++ '
+configopts += '-DMPI_C_COMPILER=cc -DMPI_CXX_COMPILER=CC '
+configopts += '-DBUILD_TESTING:BOOL=OFF -DBUILD_EXAMPLES:BOOL=OFF -DPARAVIEW_BUILD_EDITION=CANONICAL '
+configopts += '-DPARAVIEW_USE_PYTHON:BOOL=ON '
+configopts += '-DCMAKE_BUILD_TYPE=Release -DPARAVIEW_BUILD_SHARED_LIBS:BOOL=ON '
+# use TBB for on-the-node parallelism
+configopts += '-DVTK_SMP_IMPLEMENTATION_TYPE=TBB '
+configopts += '-DTBB_DIR:PATH=/opt/intel/oneapi/tbb/latest/lib/cmake/tbb '
+configopts += '-DTBB_INCLUDE_DIR:PATH=/opt/intel/oneapi/tbb/latest/include '
+configopts += '-DTBB_LIBRARY_RELEASE:FILEPATH=/opt/intel/oneapi/tbb/latest/lib/intel64/gcc4.8/libtbb.so '
+configopts += '-DTBB_MALLOC_LIBRARY_RELEASE:FILEPATH=/opt/intel/oneapi/tbb/latest/lib/intel64/gcc4.8/libtbbmalloc.so '
+#
+configopts += '-DPARAVIEW_USE_VTKM:BO0L=ON '
+configopts += '-DPARAVIEW_USE_QT:BOOL=OFF -DPARAVIEW_ENABLE_WEB:BOOL=OFF '
+configopts += '-DPARAVIEW_ENABLE_XDMF3:BOOL=OFF '
+#
+configopts += '-DCMAKE_EXE_LINKER_FLAGS_RELWITHDEBINFO="-Wl,-rpath,${EBROOTLLVM}/lib -L${EBROOTLLVM}/lib" '
+configopts += '-DVTK_USE_X:BOOL=OFF -DOPENGL_gl_LIBRARY= -DOPENGL_glu_LIBRARY= '
+configopts += '-DVTK_OPENGL_HAS_OSMESA:BOOL=ON -DOSMESA_INCLUDE_DIR:PATH=${EBROOTMESA}/include -DOSMESA_LIBRARY:FILEPATH=${EBROOTMESA}/lib/libOSMesa.so '
+# CSCS specific for Raytracing (OSPRay)
+configopts += '-DPARAVIEW_ENABLE_RAYTRACING:BOOL=ON '
+configopts += '-DVTKOSPRAY_ENABLE_DENOISER:BOOL=ON '
+configopts += '-DOSPRAY_INSTALL_DIR="$EBROOTOSPRAY" '
+configopts += '-DOpenImageDenoise_DIR="$EBROOTOSPRAY/lib/cmake/OpenImageDenoise-1.4.3" '
+#
+configopts += '-DPARAVIEW_INSTALL_DEVELOPMENT_FILES:BOOL=ON '
+
+#
+configopts += "-DVTK_MODULE_ENABLE_VTK_GeovisCore:STRING=YES "
+configopts += '-DPARAVIEW_ENABLE_VISITBRIDGE:BOOL=ON '
+#
+configopts += '-DPARAVIEW_ENABLE_CATALYST:BOOL=ON -Dcatalyst_DIR="$EBROOTCATALYST/lib64/cmake/catalyst-2.0" '
+#
+configopts += '-DPARAVIEW_PLUGIN_ENABLE_CDIReader:BOOL=ON -DCDI_DIR="$EBROOTCDI/lib/cmake/libcdi" '
+
+maxparallel = 32
+
+postinstallcmds = [
+    "export GALLIUM_DRIVER=llvmpipe; mkdir -p %(installdir)s/share/%(namelower)s-%(version_major_minor)s && tar xf /apps/common/UES/easybuild/sources/%(nameletterlower)s/%(name)s/materials.tar.bz2 -C %(installdir)s/share/%(namelower)s-%(version_major_minor)s"
+# FIXME: avoid git clone on Dom due to SD-53990
+#   "export GALLIUM_DRIVER=llvmpipe; mkdir -p %(installdir)s/share/%(namelower)s-%(version_major_minor)s && cd %(installdir)s/share/%(namelower)s-%(version_major_minor)s && git clone https://gitlab.kitware.com/%(namelower)s/materials"
+]
+
+sanity_check_paths = {
+    'files': ['bin/pvbatch', 'bin/pvserver'],
+    'dirs': ['lib64/python%(pyshortver)s/site-packages', 'lib64/%(namelower)s-%(version_major_minor)s/plugins'],
+}
+
+modextrapaths = {'PYTHONPATH': 'lib64/python%(pyshortver)s/site-packages'}
+
+modextravars = { 'LD_LIBRARY_PATH':'/opt/intel/oneapi/tbb/latest/lib/intel64/gcc4.8:/opt/python/%(pyver)s/lib:$::env(LD_LIBRARY_PATH)',
+                 'TBB_ROOT': '/opt/intel/oneapi/tbb/latest',
+               }
+
+modtclfooter = """
+prepend-path LD_LIBRARY_PATH /opt/intel/compilers_and_libraries/linux/tbb/lib/intel64/gcc4.8:/opt/python/%(pyver)s/lib
+"""
+
+moduleclass = 'vis'

--- a/jenkins-builds/7.0.UP03-21.09-daint-mc
+++ b/jenkins-builds/7.0.UP03-21.09-daint-mc
@@ -37,7 +37,7 @@
  netcdf4-python-1.5.8-CrayGNU-21.09.eb                  --set-default-module
  numpy-1.21.4-CrayGNU-21.09.eb                          --set-default-module
  OOOPS-1.0.eb
- ParaView-5.11.0-CrayGNU-21.09-OSMesa.eb                --set-default-module
+ ParaView-5.11.2-CrayGNU-21.09-OSMesa.eb                --set-default-module
  PLUMED-2.7.3-CrayGNU-21.09.eb                          --set-default-module
  PLUMED-2.8.0-CrayGNU-21.09.eb
  QuantumESPRESSO-7.0-CrayIntel-21.09.eb                 --set-default-module


### PR DESCRIPTION
LLVM now uses the new default CMake
Ospray is updated to v2.10
ParaView has a minor update

== COMPLETED: Installation ended successfully (took 36 mins 36 secs)
== Results of the build can be found in the log file(s) /scratch/snx3000/jfavre/daint/software/ParaView/5.11.2-CrayGNU-21.09-OSMesa/easybuild/easybuild-ParaView-5.11.2-20230928.153027.log
