### PR TITLE
[daint-gpu] changed CDI reader dependencies to be compatible with ADIOS to enable ParaView v5.12

### DIFF
--- a/easybuild/easyconfigs/a/adios/adios-2.9.2-CrayGNU-21.09.eb
+++ b/easybuild/easyconfigs/a/adios/adios-2.9.2-CrayGNU-21.09.eb
@@ -1,0 +1,64 @@
+# contributed by Jean Favre (CSCS); extended by Samuel Omlin (CSCS)
+
+easyblock = 'CMakeMake'
+
+name = 'adios'
+version = '2.9.2'
+
+homepage = 'https://csmd.ornl.gov/software/adios2'
+description = """The Adaptable IO System (ADIOS) provides a simple, flexible way for scientists 
+to describe the data in their code that may need to be written, read, or processed outside of the running simulation"""
+
+toolchain = {'name': 'CrayGNU', 'version': '21.09'}
+toolchainopts = {'usempi': True, 'pic': True}
+
+source_urls = ['https://github.com/ornladios/ADIOS2/archive/']
+sources = ['release_%(version_major)s%(version_minor)s.zip']
+
+builddependencies = [
+    ('CMake', '3.22.1', '', True),
+]
+
+dependencies = [
+    ('cray-python', EXTERNAL_MODULE),
+    ('cray-hdf5-parallel', EXTERNAL_MODULE),
+    ('bzip2', '1.0.8'),
+    ('zfp', '0.5.5'),
+    ('sz', '2.1.12.2'),
+    ('libpng', '1.6.37'),
+    ('blosc2', '2.9.2'),
+    ('Catalyst', '2.0.0', '-rc4'),
+]
+
+configopts  = '-DCMAKE_BUILD_TYPE=Release '
+configopts += "-DCMAKE_Fortran_FLAGS='-O2 -DNDEBUG -fPIC -fno-math-errno ' "
+configopts += "-DCMAKE_C_FLAGS='-DNDEBUG -fPIC -std=c11' "
+configopts += "-DCMAKE_CXX_FLAGS='-O2 -DNDEBUG -fPIC -std=gnu++11 ' "
+configopts += '-DBUILD_SHARED_LIBS:BOOL=ON -DADIOS2_BUILD_EXAMPLES:BOOL=OFF -DADIOS2_BUILD_TESTING:BOOL=OFF '
+configopts += '-DADIOS2_USE_MPI:BOOL=ON '
+configopts += '-DADIOS2_USE_HDF5:BOOL=ON '
+configopts += '-DADIOS2_USE_Python:BOOL=ON '
+configopts += '-DADIOS2_USE_Fortran:BOOL=ON '
+configopts += '-DADIOS2_USE_SST:BOOL=ON '
+configopts += '-DADIOS2_USE_BZip2:BOOL=ON '
+configopts += '-DADIOS2_USE_ZFP:BOOL=ON '
+configopts += '-DADIOS2_USE_SZ:BOOL=ON '
+configopts += '-DADIOS2_USE_PNG:BOOL=ON '
+configopts += '-DADIOS2_USE_Blosc:BOOL=ON '
+configopts += '-DADIOS2_USE_Catalyst:BOOL=ON '
+
+parallel = 16
+
+_pythonpath = 'lib/python%(pyshortver)s/site-packages'
+
+sanity_check_paths = {
+    'files': ['bin/adios2-config', 'bin/bpls', 'bin/bp4dbg',
+              'include/adios2.h', 'include/adios2_c.h', 'include/adios2/fortran/adios2.mod',
+              'lib64/libadios2_core.so', 'lib64/libadios2_core_mpi.so', 'lib64/cmake/adios2/adios2-config.cmake', 'lib64/libadios2_c.so', 'lib64/libadios2_c_mpi.so', 'lib64/libadios2_cxx11.so', 'lib64/libadios2_cxx11_mpi.so', 'lib64/libadios2_fortran.so', 'lib64/libadios2_fortran_mpi.so', 'lib64/libParaViewADIOSInSituEngine.so'],
+    'dirs': [".", _pythonpath]
+}
+
+modextrapaths = {'PYTHONPATH': _pythonpath}
+
+# check other easyconfigs for possible options
+moduleclass = 'lib'

--- a/easybuild/easyconfigs/c/CDI/CDI-2.3.0-CrayGNU-21.09.eb
+++ b/easybuild/easyconfigs/c/CDI/CDI-2.3.0-CrayGNU-21.09.eb
@@ -1,0 +1,37 @@
+# Contributed by Luca Marsella (CSCS)
+easyblock = 'ConfigureMake'
+
+name = 'CDI'
+version = '2.3.0'
+
+homepage = 'https://code.mpimet.mpg.de/projects/cdi'
+description = """
+    CDI is a C and Fortran Interface to access Climate and NWP model Data. 
+    Supported data formats are GRIB, netCDF, SERVICE, EXTRA and IEG. 
+"""
+
+toolchain = {'name': 'CrayGNU', 'version': '21.09'}
+toolchainopts = {'opt': True, 'pic': True}
+
+# Files visible at https://code.mpimet.mpg.de/projects/cdi/files
+source_urls = ['https://code.mpimet.mpg.de/attachments/download/29020/']
+sources = [SOURCELOWER_TAR_GZ]
+checksums = ['fff47c8eac38ec2e0f47715aadcbc1343b166aa017f0466019e73c4a53a323a6']
+
+dependencies = [
+    ('cray-hdf5-parallel', EXTERNAL_MODULE),
+    ('cray-netcdf-hdf5parallel', EXTERNAL_MODULE),
+    ('ecCodes', '2.23.0')
+]
+
+osdependencies = ['libtool']
+
+configopts = '--enable-iso-c-interface --with-eccodes=$EBROOTECCODES --with-netcdf=$EBROOTNETCDF --disable-cgribex'
+prebuildopts = ' ln -fs $(which libtool) && '
+
+sanity_check_paths = {
+    'files': ['bin/%(namelower)s'],
+    'dirs': [],
+}
+
+moduleclass = 'data'

--- a/easybuild/easyconfigs/e/ecCodes/ecCodes-2.23.0-CrayGNU-21.09.eb
+++ b/easybuild/easyconfigs/e/ecCodes/ecCodes-2.23.0-CrayGNU-21.09.eb
@@ -16,11 +16,11 @@ source_urls = ['https://confluence.ecmwf.int/download/attachments/45757960/']
 sources = ['%(namelower)s-%(version)s-Source.tar.gz']
 
 builddependencies = [
-    ('CMake', '3.21.3', '', True),
+    ('CMake', '3.22.1','', True),
 ]
 dependencies = [
-    ('cray-hdf5', EXTERNAL_MODULE),
-    ('cray-netcdf', EXTERNAL_MODULE),
+    ('cray-hdf5-parallel', EXTERNAL_MODULE),
+    ('cray-netcdf-hdf5parallel', EXTERNAL_MODULE),
     ('JasPer', '2.0.33'),
     ('libaec', '1.0.6'),
     ('libjpeg-turbo', '2.1.1'),

--- a/easybuild/easyconfigs/p/ParaView/ParaView-5.12.0-CrayGNU-21.09-EGL.eb
+++ b/easybuild/easyconfigs/p/ParaView/ParaView-5.12.0-CrayGNU-21.09-EGL.eb
@@ -1,0 +1,108 @@
+# CrayGNU version by Jean Favre (CSCS)
+
+easyblock = 'CMakeMake'
+
+name = 'ParaView'
+version = '5.12.0'
+versionsuffix = '-EGL'
+
+homepage = "http://www.paraview.org"
+description = "ParaView is a scientific parallel visualizer."
+
+toolchain = {'name': 'CrayGNU', 'version': '21.09'}
+toolchainopts = {'pic': True, 'usempi': True, 'verbose': False}
+
+local_download_suffix = 'download.php?submit=Download&version=v%(version_major_minor)s&type=source&os=all&downloadFile='
+source_urls = ['http://www.paraview.org/paraview-downloads/%s' % local_download_suffix]
+sources = ['%(name)s-v%(version)s-RC1.tar.gz']
+
+dependencies = [
+    ('Boost', '1.78.0', '-python%(pymajver)s'),
+    ('CDI', '2.3.0'),
+    ('ospray', '2.10.0'),
+    ('adios', '2.9.2'),
+    ('VisRTX', '0.1.6', '-cuda'),
+    ('Catalyst', '2.0.0', '-rc4'),
+    ('cray-python', EXTERNAL_MODULE),
+]
+
+builddependencies = [
+    ('CMake', '3.26.5','', True),
+]
+
+separate_build_dir = True
+
+maxparallel = 32
+
+configopts =  '-DPARAVIEW_USE_MPI:BOOL=ON '
+configopts += '-DCMAKE_C_COMPILER=gcc -DCMAKE_CXX_COMPILER=g++ '
+configopts += '-DMPI_C_COMPILER=cc -DMPI_CXX_COMPILER=CC '
+configopts += '-DCMAKE_CXX_FLAGS="-O2 -fno-math-errno" -DCMAKE_C_FLAGS="-O2 -fno-math-errno" '
+configopts += '-DPARAVIEW_BUILD_TESTING:BOOL=OFF -DPARAVIEW_BUILD_EDITION=CANONICAL '
+configopts += '-DPARAVIEW_USE_PYTHON:BOOL=ON '
+configopts += '-DCMAKE_BUILD_TYPE=Release -DPARAVIEW_BUILD_SHARED_LIBS:BOOL=ON '
+#configopts += '-DPARAVIEW_BUILD_WITH_KITS:BOOL=ON '
+# use TBB for on-the-node parallelism
+configopts += '-DVTK_SMP_IMPLEMENTATION_TYPE=TBB '
+configopts += '-DTBB_DIR:PATH=/opt/intel/oneapi/tbb/latest/lib/cmake/tbb '
+#
+configopts += '-DOPENGL_opengl_LIBRARY=/usr/lib64/libOpenGL.so '
+configopts += '-DOPENGL_egl_LIBRARY=/usr/lib64/libEGL.so '
+configopts += '-DOPENGL_INCLUDE_DIR=/usr/include '
+configopts += '-DPARAVIEW_USE_VTKM:BO0L=ON '
+configopts += '-DPARAVIEW_USE_QT:BOOL=OFF -DPARAVIEW_ENABLE_WEB:BOOL=OFF '
+configopts += '-DPARAVIEW_ENABLE_XDMF3:BOOL=OFF '
+# CSCS specific for EGL
+configopts += '-DVTK_OPENGL_HAS_EGL:BOOL=ON -DVTK_USE_X:BOOL=OFF '
+# CSCS specific for Raytracing (OSPRAY and/or OptiX)
+configopts += '-DPARAVIEW_ENABLE_RAYTRACING:BOOL=ON '
+configopts += '-DVTK_ENABLE_VISRTX:BOOL=ON '
+configopts += '-DVTKOSPRAY_ENABLE_DENOISER:BOOL=ON '
+configopts += '-DOpenImageDenoise_DIR="$EBROOTOSPRAY/lib/cmake/OpenImageDenoise-1.4.3" '
+configopts += '-DVisRTX_DIR="$EBROOTVISRTX/lib64/cmake/VisRTX-$EBVERSIONVISRTX" '
+# Using Cray HDF5
+#configopts += '-DVTK_MODULE_USE_EXTERNAL_VTK_hdf5:BOOL=ON  '
+#configopts += '-DHDF5_NO_FIND_PACKAGE_CONFIG_FILE:BOOL=ON '
+#configopts += '-DHDF5_C_COMPILER_EXECUTABLE_NO_INTERROGATE:FILEPATH=cc '
+# Using Cray NETCDF
+#configopts += '-DVTK_MODULE_USE_EXTERNAL_VTK_netcdf:BOOL=ON -DnetCDF_DIR=$NETCDF_DIR '
+#configopts += '-DNetCDF_INCLUDE_DIR="$NETCDF_DIR"/include '
+#configopts += '-DNetCDF_LIBRARY="$NETCDF_DIR"/lib/libnetcdf.so '
+# Using CSCS NVIDIA IndeX lib. Auto-load cannot be turned on. See https://jira.cscs.ch/browse/SD-51595
+configopts += '-DPARAVIEW_PLUGIN_ENABLE_pvNVIDIAIndeX:BOOL=ON '
+#configopts += '-DPARAVIEW_PLUGIN_AUTOLOAD_pvNVIDIAIndeX:BOOL=ON '
+#
+#configopts += '-DPARAVIEW_INITIALIZE_MPI_ON_CLIENT=ON '
+configopts += '-DPARAVIEW_INSTALL_DEVELOPMENT_FILES=ON '
+#
+configopts += "-DVTK_MODULE_ENABLE_VTK_GeovisCore:STRING=YES "
+configopts += '-DPARAVIEW_ENABLE_VISITBRIDGE:BOOL=ON '
+#
+configopts += '-DPARAVIEW_ENABLE_CATALYST:BOOL=ON -Dcatalyst_DIR="$EBROOTCATALYST/lib64/cmake/catalyst-2.0" '
+configopts += '-DPARAVIEW_PLUGIN_ENABLE_CDIReader:BOOL=ON -DCDI_DIR="$EBROOTCDI/lib/cmake/libcdi" '
+#
+configopts += '-DADIOS2_DIR="$EBROOTADIOS/lib64/cmake/adios2" -DPARAVIEW_ENABLE_ADIOS2:BOOL=ON '
+configopts += '-DPARAVIEW_ENABLE_FIDES:BOOL=ON '
+
+
+modextravars = { 'LD_LIBRARY_PATH':'/opt/intel/oneapi/tbb/latest/lib/intel64/gcc4.8:/apps/common/UES/easybuild/sources/p/ParaView/nvindex_default/linux-x86-64/lib:/opt/python/%(pyver)s/lib:$::env(LD_LIBRARY_PATH)', 
+                 'NVINDEX_PVPLUGIN_HOME':'/apps/common/UES/easybuild/sources/p/ParaView',
+#                 'TBB_ROOT': '/opt/intel/compilers_and_libraries/linux/tbb',
+               }
+
+
+modextrapaths = {'PYTHONPATH': 'lib64/python%(pyshortver)s/site-packages'}
+
+sanity_check_paths = {
+    'files': ['bin/pvbatch', 'bin/pvserver'],
+    'dirs': ['lib64/python%(pyshortver)s/site-packages', 'lib64/paraview-%(version_major_minor)s/plugins'],
+}
+
+postinstallcmds = [
+    "tar xf /apps/common/UES/easybuild/sources/%(nameletterlower)s/%(name)s/materials.tar.bz2 -C %(installdir)s/share/%(namelower)s-%(version_major_minor)s"
+# FIXME: avoid git clone on Dom due to SD-53990
+#   "mkdir -p %(installdir)s/share/%(namelower)s-%(version_major_minor)s && cd %(installdir)s/share/%(namelower)s-%(version_major_minor)s && git clone https://gitlab.kitware.com/%(namelower)s/materials"
+]
+
+
+moduleclass = 'vis'

--- a/jenkins-builds/7.0.UP03-21.09-daint-gpu
+++ b/jenkins-builds/7.0.UP03-21.09-daint-gpu
@@ -1,5 +1,6 @@
  adios-2.9.0-CrayGNU-21.09.eb                           --set-default-module 
  adios-2.9.1-CrayGNU-21.09.eb
+ adios-2.9.2-CrayGNU-21.09.eb
  Ascent-0.9.1-CrayGNU-21.09.eb
  Ascent-0.9.2-CrayGNU-21.09.eb                          --set-default-module
  Boost-1.78.0-CrayGNU-21.09.eb
@@ -8,6 +9,8 @@
  Catalyst-2.0.0-CrayGNU-21.09-rc4.eb                    --set-default-module
  CMake-3.22.1.eb                                        --set-default-module
  CMake-3.26.5.eb
+ ecCodes-2.23.0-CrayGNU-21.09.eb                        --set-default-module
+ CDI-2.3.0-CrayGNU-21.09.eb                             --set-default-module
  CDO-2.0.5-CrayGNU-21.09.eb                             --set-default-module
  CP2K-9.1-CrayGNU-21.09-cuda.eb                         --set-default-module
  CPMD-4.3-CrayIntel-21.09-cuda.eb                       --set-default-module
@@ -46,6 +49,7 @@
  OOOPS-1.0.eb
  ovito-3.7.7-CrayGNU-21.09.eb                           --set-default-module
  ParaView-5.11.2-CrayGNU-21.09-EGL.eb                   --set-default-module
+ ParaView-5.12.0-CrayGNU-21.09-EGL.eb
  PLUMED-2.7.3-CrayGNU-21.09.eb                          --set-default-module
  PLUMED-2.8.0-CrayGNU-21.09.eb
  pycuda-2021.1-CrayGNU-21.09-cuda.eb                    --set-default-module


### PR DESCRIPTION
== COMPLETED: Installation ended successfully (took 45 mins 59 secs)
== Results of the build can be found in the log file(s) /scratch/snx3000/jfavre/daint/software/ParaView/5.12.0-CrayGNU-21.09-EGL/easybuild/easybuild-ParaView-5.12.0-20231106.103251.log
== Build succeeded for 1 out of 1
== Temporary log file(s) /run/user/1100/easybuild/tmp/eb-93cjb18c/easybuild-qgakgb02.log* have been removed.
== Temporary directory /run/user/1100/easybuild/tmp/eb-93cjb18c has been removed.