### PR TITLE
[daint-gpu dom-gpu] CDI wih ecCodes parallel

### DIFF
--- a/easybuild/easyconfigs/c/CDI/CDI-2.3.0-CrayGNU-21.09.eb
+++ b/easybuild/easyconfigs/c/CDI/CDI-2.3.0-CrayGNU-21.09.eb
@@ -19,10 +19,7 @@ sources = [SOURCELOWER_TAR_GZ]
 checksums = ['fff47c8eac38ec2e0f47715aadcbc1343b166aa017f0466019e73c4a53a323a6']
 
 dependencies = [
-# the following modules are already loaded by ecCodes:
-#    ('cray-hdf5-parallel', EXTERNAL_MODULE),
-#    ('cray-netcdf-hdf5parallel', EXTERNAL_MODULE),
-    ('ecCodes', '2.23.0')
+    ('ecCodes', '2.23.0', '-parallel')
 ]
 
 osdependencies = ['libtool']

--- a/easybuild/easyconfigs/e/ecCodes/ecCodes-2.23.0-CrayGNU-21.09-parallel.eb
+++ b/easybuild/easyconfigs/e/ecCodes/ecCodes-2.23.0-CrayGNU-21.09-parallel.eb
@@ -1,0 +1,33 @@
+# contributed by Sebastan Keller and Luca Marsella (CSCS)
+easyblock = 'CMakeMake'
+
+name = 'ecCodes'
+version = '2.23.0'
+versionsuffix = '-parallel'
+
+homepage = 'https://confluence.ecmwf.int/display/ECC/ecCodes+Home'
+description = """ecCodes is a package developed by ECMWF which provides an
+application programming interface and a set of tools for decoding and encoding
+messages in different formats"""
+
+toolchain = {'name': 'CrayGNU', 'version': '21.09'}
+toolchainopts = {'openmp': True, 'verbose': False}
+
+source_urls = ['https://confluence.ecmwf.int/download/attachments/45757960/']
+sources = ['%(namelower)s-%(version)s-Source.tar.gz']
+
+builddependencies = [
+    ('CMake', '3.22.1','', True)
+]
+dependencies = [
+    ('cray-hdf5-parallel', EXTERNAL_MODULE),
+    ('cray-netcdf-hdf5parallel', EXTERNAL_MODULE),
+    ('JasPer', '2.0.33'),
+    ('libaec', '1.0.6'),
+    ('libjpeg-turbo', '2.1.1')
+]
+
+configopts = " -DENABLE_AEC=ON -DCMAKE_Fortran_COMPILER=gfortran -DENABLE_ECCODES_OMP_THREADS=ON "
+
+
+moduleclass = 'data'

--- a/jenkins-builds/7.0.UP03-21.09-daint-gpu
+++ b/jenkins-builds/7.0.UP03-21.09-daint-gpu
@@ -48,8 +48,8 @@
  numpy-1.21.4-CrayGNU-21.09.eb                          --set-default-module
  OOOPS-1.0.eb
  ovito-3.7.7-CrayGNU-21.09.eb                           --set-default-module
- ParaView-5.11.2-CrayGNU-21.09-EGL.eb                   --set-default-module
- ParaView-5.12.0-CrayGNU-21.09-EGL.eb
+ ParaView-5.11.2-CrayGNU-21.09-EGL.eb                   
+ ParaView-5.12.0-CrayGNU-21.09-EGL.eb                   --set-default-module
  PLUMED-2.7.3-CrayGNU-21.09.eb                          --set-default-module
  PLUMED-2.8.0-CrayGNU-21.09.eb
  pycuda-2021.1-CrayGNU-21.09-cuda.eb                    --set-default-module

--- a/jenkins-builds/7.0.UP03-21.09-daint-gpu
+++ b/jenkins-builds/7.0.UP03-21.09-daint-gpu
@@ -48,8 +48,8 @@
  numpy-1.21.4-CrayGNU-21.09.eb                          --set-default-module
  OOOPS-1.0.eb
  ovito-3.7.7-CrayGNU-21.09.eb                           --set-default-module
- ParaView-5.11.2-CrayGNU-21.09-EGL.eb                   
- ParaView-5.12.0-CrayGNU-21.09-EGL.eb                   --set-default-module
+ ParaView-5.11.2-CrayGNU-21.09-EGL.eb                   --set-default-module
+ ParaView-5.12.0-CrayGNU-21.09-EGL.eb                   
  PLUMED-2.7.3-CrayGNU-21.09.eb                          --set-default-module
  PLUMED-2.8.0-CrayGNU-21.09.eb
  pycuda-2021.1-CrayGNU-21.09-cuda.eb                    --set-default-module


### PR DESCRIPTION
Provide the recipe `ecCodes-parallel` to build `CDI` and ParaView 5.12.0 compatible with `ADIOS` on `daint-gpu` as requiested in #2923, fixing the regression test on Piz Daint: see the [failed check](https://jenkins.cscs.ch/blue/organizations/jenkins/reframe-daint-production-daily/detail/reframe-daint-production-daily/2674/pipeline) with ParaView.