### PR TITLE
[daint dom] Revert ecCodes dependencies

### DIFF
--- a/easybuild/easyconfigs/e/ecCodes/ecCodes-2.23.0-CrayGNU-21.09.eb
+++ b/easybuild/easyconfigs/e/ecCodes/ecCodes-2.23.0-CrayGNU-21.09.eb
@@ -16,14 +16,14 @@ source_urls = ['https://confluence.ecmwf.int/download/attachments/45757960/']
 sources = ['%(namelower)s-%(version)s-Source.tar.gz']
 
 builddependencies = [
-    ('CMake', '3.22.1','', True),
+    ('CMake', '3.21.3','', True)
 ]
 dependencies = [
-    ('cray-hdf5-parallel', EXTERNAL_MODULE),
-    ('cray-netcdf-hdf5parallel', EXTERNAL_MODULE),
+    ('cray-hdf5', EXTERNAL_MODULE),
+    ('cray-netcdfl', EXTERNAL_MODULE),
     ('JasPer', '2.0.33'),
     ('libaec', '1.0.6'),
-    ('libjpeg-turbo', '2.1.1'),
+    ('libjpeg-turbo', '2.1.1')
 ]
 
 configopts = " -DENABLE_AEC=ON -DCMAKE_Fortran_COMPILER=gfortran -DENABLE_ECCODES_OMP_THREADS=ON "

--- a/easybuild/easyconfigs/e/ecCodes/ecCodes-2.23.0-CrayGNU-21.09.eb
+++ b/easybuild/easyconfigs/e/ecCodes/ecCodes-2.23.0-CrayGNU-21.09.eb
@@ -20,7 +20,7 @@ builddependencies = [
 ]
 dependencies = [
     ('cray-hdf5', EXTERNAL_MODULE),
-    ('cray-netcdfl', EXTERNAL_MODULE),
+    ('cray-netcdf', EXTERNAL_MODULE),
     ('JasPer', '2.0.33'),
     ('libaec', '1.0.6'),
     ('libjpeg-turbo', '2.1.1')


### PR DESCRIPTION
Revert to `cray-hdf5` and `cray-netcdf` to avoid the issues reported in [the regression tests](https://jenkins.cscs.ch/blue/organizations/jenkins/reframe-daint-production-daily/detail/reframe-daint-production-daily/2674/pipeline) for CDO and ParaView.