### PR TITLE
 [dom-gpu] update julia version in jupyterlab-3.4.5-CrayGNU-21.09-batchspawner

### DIFF
--- a/easybuild/easyconfigs/j/jupyterlab/jupyterlab-3.4.5-CrayGNU-21.09-batchspawner.eb
+++ b/easybuild/easyconfigs/j/jupyterlab/jupyterlab-3.4.5-CrayGNU-21.09-batchspawner.eb
@@ -19,7 +19,7 @@ builddependencies = [
 dependencies = [
     ('cray-python', EXTERNAL_MODULE),
     ('configurable-http-proxy', '4.5.0'),
-    ('Julia', '1.9.4', '-cuda'),
+    ('Julia', '1.9.4'),
     ('cray-R', EXTERNAL_MODULE),
     ('graphviz', '2.50.0'),
 ]


### PR DESCRIPTION
This is using the updated julia module where all issues have been solved according to user feedback.

The jupyterlab recipe itself has been successfully used during the "GPU programming with Julia" course end of November.