### PR TITLE
[eiger pilatus] Update singularity-3.6.4-eiger.eb

### DIFF
--- a/easybuild/easyconfigs/s/singularity/singularity-3.6.4-eiger.eb
+++ b/easybuild/easyconfigs/s/singularity/singularity-3.6.4-eiger.eb
@@ -36,5 +36,7 @@ setenv("SINGULARITY_BIND", singularityBind)
 setenv("SINGULARITYENV_LD_LIBRARY_PATH", "/lib64:/opt/cray/pe/lib64:/lib64")
 prepend_path("SINGULARITYENV_LD_LIBRARY_PATH", libfabricLib)
 prepend_path("SINGULARITYENV_LD_LIBRARY_PATH", gccLib)
-prepend_path("SINGULARITYENV_LD_LIBRARY_PATH", os.getenv("CRAY_LD_LIBRARY_PATH"))
+if not (os.getenv("CRAY_LD_LIBRARY_PATH") == nil) then
+        prepend_path("SINGULARITYENV_LD_LIBRARY_PATH", os.getenv("CRAY_LD_LIBRARY_PATH"))
+end
 """


### PR DESCRIPTION
Fix Lua footer for singularity module to avoid the following Lmod warning:
```
Lmod Warning:  Syntax error in file: /capstor/apps/cscs/eiger/UES/modulefiles/singularity/3.6.4-eiger.lua
 with command: prepend_path, one or more arguments are not strings.
```
The warning is due to the missing definition of `CRAY_LD_LIBRARY_PATH`, since the user environment does not load the Cray PE any longer by default upon login, but the user needs to do that with the `module load cray`.