### PR TITLE
[daint-mc dom-mc] Remove non-default jupyterlab from daint-mc

### DIFF
--- a/jenkins-builds/7.0.UP03-21.09-daint-mc
+++ b/jenkins-builds/7.0.UP03-21.09-daint-mc
@@ -23,7 +23,6 @@
  Julia-1.9.4-CrayGNU-21.09.eb
  JuliaExtensions-1.6.3-CrayGNU-21.09.eb                 --set-default-module
  jupyterlab-3.2.8-CrayGNU-21.09-batchspawner.eb         --set-default-module
- jupyterlab-3.4.5-CrayGNU-21.09-batchspawner.eb
  jupyter-utils-0.1.eb                                   --set-default-module
  LAMMPS-20Sep21-CrayGNU-21.09.eb                        --set-default-module
  LAMMPS-23Jun2022-CrayGNU-21.09.eb


### PR DESCRIPTION
Remove recipe `jupyterlab-3.4.5-CrayGNU-21.09-batchspawner.eb` from the list `7.0.UP03-21.09-daint-mc`, since the build fails on `dom-mc`.