### PR TITLE
[eiger pilatus] Update JenkinsfileTestingEB to disable Lmod cache

### DIFF
--- a/jenkins/JenkinsfileTestingEB
+++ b/jenkins/JenkinsfileTestingEB
@@ -83,7 +83,7 @@ stage('Build Stage') {
                                        fi
 
                                        # disable Lmod cache to prevent issues like https://sourceforge.net/p/lmod/mailman/message/34706635
-                                       if [ "$MODULESHOME"=~"lmod" ]; then 
+                                       if [[ "$MODULESHOME" =~ "lmod" ]]; then
                                            echo -e "\\n export LMOD_IGNORE_CACHE=1 \\n"
                                            export LMOD_IGNORE_CACHE=1
                                        fi

--- a/jenkins/JenkinsfileTestingEB
+++ b/jenkins/JenkinsfileTestingEB
@@ -82,6 +82,12 @@ stage('Build Stage') {
                                            mkdir -p $prefix
                                        fi
 
+                                       # disable Lmod cache to prevent issues like https://sourceforge.net/p/lmod/mailman/message/34706635
+                                       if [ $MODULESHOME=~"lmod" ]; then 
+                                           echo -e "\\n export LMOD_IGNORE_CACHE=1 \\n"
+                                           export LMOD_IGNORE_CACHE=1
+                                       fi
+
                                        echo -e "\\n Current diff list by 'git diff origin/master...HEAD --name-only --oneline --no-merges --diff-filter=ACMRTUXB':"
                                        git diff origin/master...HEAD --name-only --oneline --no-merges --diff-filter=ACMRTUXB
                                        # if buildlist is empty, skip this build; otherwise, write .eb files to file

--- a/jenkins/JenkinsfileTestingEB
+++ b/jenkins/JenkinsfileTestingEB
@@ -83,7 +83,7 @@ stage('Build Stage') {
                                        fi
 
                                        # disable Lmod cache to prevent issues like https://sourceforge.net/p/lmod/mailman/message/34706635
-                                       if [ $MODULESHOME=~"lmod" ]; then 
+                                       if [ "$MODULESHOME"=~"lmod" ]; then 
                                            echo -e "\\n export LMOD_IGNORE_CACHE=1 \\n"
                                            export LMOD_IGNORE_CACHE=1
                                        fi


### PR DESCRIPTION
Disable Lmod cache in `TestingEB` to try avoiding [issues](https://sourceforge.net/p/lmod/mailman/message/34706635/) similar to the one experienced in #2964.