### PR TITLE
[eiger] Update TestingEB

### DIFF
--- a/jenkins/JenkinsfileTestingEB
+++ b/jenkins/JenkinsfileTestingEB
@@ -82,12 +82,6 @@ stage('Build Stage') {
                                            mkdir -p $prefix
                                        fi
 
-                                       # disable Lmod cache to prevent issues like https://sourceforge.net/p/lmod/mailman/message/34706635
-                                       if [[ "$MODULESHOME" =~ "lmod" ]]; then
-                                           echo -e "\\n export LMOD_IGNORE_CACHE=1 \\n"
-                                           export LMOD_IGNORE_CACHE=1
-                                       fi
-
                                        echo -e "\\n Current diff list by 'git diff origin/master...HEAD --name-only --oneline --no-merges --diff-filter=ACMRTUXB':"
                                        git diff origin/master...HEAD --name-only --oneline --no-merges --diff-filter=ACMRTUXB
                                        # if buildlist is empty, skip this build; otherwise, write .eb files to file
@@ -95,7 +89,13 @@ stage('Build Stage') {
                                            echo -e "\\n No EasyBuild recipe to build, skipping build \\n\"
                                            exit 0
                                        else
-                                           echo \$buildlist | sed 's/\\b[^[:space:]]*\\.eb\\b/& --set-default-module\\n/g' | sed '\${/^\$/d;}' > \"$prefix/${projectName}.txt\"
+                                           #FIXME Easybuild with hierarchical MNS and Lmod: create toolchain modules as default
+                                           if [[ "$MODULESHOME" =~ "lmod" ]]; then
+                                               echo \$buildlist | egrep -o "cpe(AMD|Cray|GNU|Intel)-[0-9]{2}\\.[0-9]{2}.eb" | sed 's/\\b[^[:space:]]*\\.eb\\b/& --set-default-module\\n/g' | sed '\${/^\$/d;} | sort -u > \"$prefix/${projectName}.txt\"
+                                               echo \$buildlist | sed '\${/^\$/d;}' >> \"$prefix/${projectName}.txt\"
+                                           else
+                                               echo \$buildlist | sed '\${/^\$/d;}' > \"$prefix/${projectName}.txt\"
+                                           fi
                                        fi
 
                                        $commandComplete

--- a/jenkins/JenkinsfileTestingEB
+++ b/jenkins/JenkinsfileTestingEB
@@ -91,7 +91,7 @@ stage('Build Stage') {
                                        else
                                            #FIXME Easybuild with hierarchical MNS and Lmod: create toolchain modules as default
                                            if [[ "$MODULESHOME" =~ "lmod" ]]; then
-                                               echo \$buildlist | egrep -o "cpe(AMD|Cray|GNU|Intel)-[0-9]{2}\\.[0-9]{2}.eb" | sed 's/\\b[^[:space:]]*\\.eb\\b/& --set-default-module\\n/g' | sed '\${/^\$/d;} | sort -u > \"$prefix/${projectName}.txt\"
+                                               echo \$buildlist | egrep -o "cpe(AMD|Cray|GNU|Intel)-[0-9]{2}\\.[0-9]{2}.eb" | sed 's/\\b[^[:space:]]*\\.eb\\b/& --set-default-module\\n/g' | sed '\${/^\$/d;}' | sort -u > \"$prefix/${projectName}.txt\"
                                                echo \$buildlist | sed '\${/^\$/d;}' >> \"$prefix/${projectName}.txt\"
                                            else
                                                echo \$buildlist | sed '\${/^\$/d;}' > \"$prefix/${projectName}.txt\"


### PR DESCRIPTION
Set toolchain modules default on systems with Lmod that use the EasyBuild hierarchical module naming scheme in order to avoid the issue experienced in #2964.