### PR TITLE
[daint dom eiger pilatus] Files for CPE 23.05

### DIFF
--- a/easybuild/cpe_external_modules_metadata-23.05.cfg
+++ b/easybuild/cpe_external_modules_metadata-23.05.cfg
@@ -1,0 +1,72 @@
+# metadata useful to EasyBuild (hpcugent.github.io/easybuild) for modules provided by Cray on Cray systems
+# authors: Guilherme Peretti-Pezzi (CSCS), Petar Forai (IMP/IMBA), Kenneth Hoste (HPC-UGent), Eirini Koutsaniti (CSCS)
+
+[aocc]
+name = AOCC
+prefix = CRAY_AOCC_PREFIX
+version = 4.0.0
+
+[cray-fftw]
+name = FFTW
+prefix = FFTW_DIR/..
+version = 3.3.10.4
+
+[cray-hdf5]
+name = HDF5
+prefix = CRAY_HDF5_PREFIX
+version = 1.12.2.3
+
+[cray-hdf5-parallel]
+name = HDF5
+prefix = CRAY_HDF5_PARALLEL_PREFIX
+version = 1.12.2.3
+
+[cray-libsci]
+name = LibSci
+prefix = CRAY_LIBSCI_PREFIX_DIR
+version = 23.05.1.4
+
+[cray-netcdf]
+name = netCDF, netCDF-Fortran
+prefix = CRAY_NETCDF_PREFIX
+version = 4.9.0.3, 4.9.0.3
+
+[cray-netcdf-hdf5parallel]
+name = netCDF, netCDF-Fortran
+prefix = CRAY_NETCDF_HDF5PARALLEL_PREFIX
+version = 4.9.0.3, 4.9.0.3
+
+[cray-parallel-netcdf]
+name = netCDF
+prefix = CRAY_PARALLEL_NETCDF_PREFIX
+version = 1.12.2.3
+
+[cray-python]
+name = Python
+prefix = CRAY_PYTHON_PREFIX
+version = 3.10.10
+
+[cray-R]
+name = R
+prefix = CRAY_R_PREFIX
+version = 4.2.1.2
+
+[gcc]
+name = GCC
+prefix = GCC_PREFIX
+version = GCC_VERSION
+
+[papi]
+name = PAPI
+prefix = CRAY_PAPI_PREFIX
+version = 7.0.0.2
+
+[pmi]
+name = pmi
+prefix = CRAY_PMI_PREFIX
+version = 6.1.11
+
+[slurm/.default]
+name = slurm
+prefix = SLURMDIR
+version = .default

--- a/jenkins-builds/21.12-pilatus
+++ b/jenkins-builds/21.12-pilatus
@@ -1,1 +1,36 @@
-21.12-eiger
+ CMake-3.26.5.eb                      --set-default-module
+ ddt-22.1.3-linux-x86_64.eb           --set-default-module
+ hub-2.14.2.eb                        --set-default-module
+ hwloc-2.4.1.eb                       --set-default-module
+ jupyter-utils-0.1.eb                 --set-default-module
+ NCL-6.6.2.eb                         --set-default-module
+ OOOPS-1.0.eb                         --set-default-module
+ reframe-4.5.1.eb                     --set-default-module
+ reframe-cscs-tests-24.03.eb          --set-default-module
+ singularity-3.6.4-eiger.eb
+ GSL-2.7-cpeAMD-21.12.eb
+ GSL-2.7-cpeCray-21.12.eb
+ Ascent-0.8.0-cpeGNU-21.12.eb
+ Boost-1.78.0-cpeGNU-21.12.eb
+ Boost-1.78.0-cpeGNU-21.12-python3.eb --set-default-module
+ CDO-1.9.10-cpeGNU-21.12.eb
+ CP2K-9.1-cpeGNU-21.12.eb
+ CubeLib-4.5-cpeGNU-21.12.eb
+ FFmpeg-5.0-cpeGNU-21.12.eb           --set-default-module
+ GREASY-19.03-cscs-cpeGNU-21.12.eb
+ GROMACS-2021.5-cpeGNU-21.12.eb
+ GSL-2.7-cpeGNU-21.12.eb
+ Julia-1.6.3-cpeGNU-21.12.eb
+ JuliaExtensions-1.6.3-cpeGNU-21.12.eb
+ jupyterlab-2.2.10-cpeGNU-21.12.eb
+ LAMMPS-20Sep21-cpeGNU-21.12.eb
+ matplotlib-3.4.3-cpeGNU-21.12.eb
+ NAMD-2.14-cpeGNU-21.12.eb
+ NCO-5.0.1-cpeGNU-21.12.eb
+ ParaView-5.11.2-cpeGNU-21.12-OSMesa.eb --set-default-module
+ ParaView-5.12.0-cpeGNU-21.12-OSMesa.eb
+ Visit-3.3.1-cpeGNU-21.12.eb
+ VTK-9.2.6-cpeGNU-21.12-OSMesa.eb
+ GSL-2.7-cpeIntel-21.12.eb
+ QuantumESPRESSO-7.2-cpeIntel-21.12.eb
+ VASP-6.3.0-cpeIntel-21.12.eb

--- a/jenkins-builds/production.sh
+++ b/jenkins-builds/production.sh
@@ -75,7 +75,7 @@ done
 # checks force_list
 if [ -n "${force_list}" ] && [ -n "${eb_lists}" ]; then
 # match force_list items with production lists: only matching items will be built using the EasyBuild flag '-f'
- echo -e "Items matching production list and system filtered forcelist (\"${force_list}\")"
+ echo -e "\n Items matching production list and system filtered forcelist (\"${force_list}\")"
  for item in ${force_list}; do
      force_match=$(grep $item ${eb_lists[@]})
      if [ -n "${force_match}" ]; then
@@ -124,27 +124,27 @@ if [[ "$system" =~ "daint" || "$system" =~ "dom" ]]; then
     ebtoolsmodulepath_suffix="/tools/modules/all/"
 # set production repository folder
     if [ -z "$EB_CUSTOM_REPOSITORY" ]; then
-    	export EB_CUSTOM_REPOSITORY=/apps/common/UES/jenkins/production/easybuild
+    	export EB_CUSTOM_REPOSITORY="/apps/common/UES/jenkins/production/easybuild"
     fi
 elif [[ "$system" =~ "eiger" || "$system" =~ "pilatus" ]]; then
 # load cray module on Alps vClusters
     module load cray
 # system specific EasyBuild paths
-    ebcustompath="/users/jenscscs/production/easybuild/module/EasyBuild-custom/"
+    ebcustompath="/capstor/apps/cscs/common/production/easybuild/module/EasyBuild-custom/"
     ebmodulepath_suffix="/modules/all/Core/"
     ebtoolsmodulepath_suffix=$ebmodulepath_suffix
 # set production repository folder
     if [ -z "$EB_CUSTOM_REPOSITORY" ]; then
-    	export EB_CUSTOM_REPOSITORY=/users/jenscscs/production/easybuild
+    	export EB_CUSTOM_REPOSITORY="/capstor/apps/cscs/common/production/easybuild"
     fi
 fi
 ######################
 # --- COMMON SETUP ---
 # module unuse PATH before loading EasyBuild module and building
 if [ -n "$unuse_path" ]; then
- echo -e " Unuse path: $unuse_path "
+ echo -e "\n Unuse path: $unuse_path "
  module unuse $unuse_path
- echo -e " Updated MODULEPATH: $MODULEPATH "
+ echo -e "\n Updated MODULEPATH: $MODULEPATH "
 fi
 # check prefix folder
 if [ -z "$PREFIX" ]; then
@@ -167,9 +167,9 @@ else
 # check if PREFIX is already in MODULEPATH after unuse command
  statuspath=$(echo $MODULEPATH | grep -c $EASYBUILD_PREFIX)
  if [ $statuspath -eq 0 ]; then
-  echo -e " Use path (EASYBUILD_PREFIX): $ebmodulepath "
+  echo -e "\n Use path (EASYBUILD_PREFIX): $ebmodulepath "
   module use $ebmodulepath
-  echo -e " Updated MODULEPATH: $MODULEPATH "
+  echo -e "\n Updated MODULEPATH: $MODULEPATH "
  fi
 fi
 ###############
@@ -183,7 +183,7 @@ if [ -n "${eb_lists}" ] && [ -n "${hidden_deps}" ]; then
   IFS=', ' read -r -a hidden_deps <<< ${__eb_list}
 
 # match  items with hide deps list: matching items will be built using the EasyBuild flag '--hidden'
- echo -e "Items matching hidden list and easybuild recipes to install (\"${eb_lists}\")"
+ echo -e "\n Items matching hidden list and easybuild recipes to install (\"${eb_lists}\")"
  for item in ${hidden_deps[@]}; do
      hidden_match=$(grep $item ${eb_lists[@]})
      if [ -n "${hidden_match}" ]; then


### PR DESCRIPTION
I provide the configuration files required for CPE 23.05 currently installed on Pilatus, in view of the software stack update. 
Therefore, I need to detach the production list of Pilatus from Eiger, removing some builds that currently are not working (e.g.: `Scalasca`, due to the `PDT` dependency of `Score-P`). 
I also provide an updated `production.sh` to use a more recent EasyBuild release on Eiger and Pilatus.