### PR TITLE
[pilatus] Add missing cpeGNU-23.09.eb

### DIFF
--- a/easybuild/easyconfigs/c/cpeGNU/cpeGNU-23.09.eb
+++ b/easybuild/easyconfigs/c/cpeGNU/cpeGNU-23.09.eb
@@ -1,0 +1,38 @@
+# Compiler toolchain for Cray EX Programming Environment GNU compiler
+easyblock = 'cpeToolchain'
+
+name = 'cpeGNU'
+version = "23.09"
+
+homepage = 'https://pubs.cray.com'
+description = """Toolchain using Cray compiler wrapper with gcc module (CPE release: %s).\n""" % version
+
+toolchain = SYSTEM
+
+dependencies = [
+   ("cpe/%(version)s", EXTERNAL_MODULE),
+   ('PrgEnv-gnu', EXTERNAL_MODULE),
+]
+
+modluafooter = '''
+if not ( isloaded("craype") ) then
+    load("craype")
+end
+if not ( isloaded("craype-network-ofi") ) then
+    load("craype-network-ofi")
+end
+if not ( isloaded("craype-x86-rome") ) then
+    load("craype-x86-rome")
+end
+if not ( isloaded("cray-mpich") ) then
+    load("cray-mpich")
+end
+if not ( isloaded("perftools-base") ) then
+    load("perftools-base")
+end
+if not ( isloaded("xpmem") ) then
+    load("xpmem")
+end
+'''
+
+moduleclass = 'toolchain'


### PR DESCRIPTION
I provide the missing recipe for the toolchain `cpeGNU`, release `23.09`.