### PR TITLE
[pilatus] Add adios as dependency to be loaded at runtime

### DIFF
--- a/easybuild/easyconfigs/p/ParaView/ParaView-5.12.0-cpeGNU-23.09-OSMesa.eb
+++ b/easybuild/easyconfigs/p/ParaView/ParaView-5.12.0-cpeGNU-23.09-OSMesa.eb
@@ -13,8 +13,11 @@ toolchainopts = {'pic': True, 'usempi': True, 'verbose': False}
 
 builddependencies = [
     ('CMake', '3.26.5', '', SYSTEM),
-    ('adios', '2.9.2'),
-    ('patchelf', '0.18.0', '', SYSTEM),
+    ('patchelf', '0.18.0', '', SYSTEM)
+]
+
+dependencies = [
+    ('adios', '2.9.2')
 ]
 
 preconfigopts = "git clone --recursive https://gitlab.kitware.com/%(namelower)s/%(namelower)s-superbuild.git && cd %(namelower)s-superbuild && git fetch origin && git checkout v%(version)s && git submodule update && mkdir ../build; cd ../build; "


### PR DESCRIPTION
I provide a recipe with `adios` in the `dependecies` in order to load the module at runtime and fix the [failure of the regression test suite](https://jenkins.cscs.ch/blue/organizations/jenkins/reframe-pilatus-production-daily/detail/reframe-pilatus-production-daily/936/pipeline/).