### PR TITLE
[daint, dom] Update adios-2.9.2-CrayGNU-21.09.eb

### DIFF
--- a/easybuild/easyconfigs/a/adios/adios-2.9.2-CrayGNU-21.09.eb
+++ b/easybuild/easyconfigs/a/adios/adios-2.9.2-CrayGNU-21.09.eb
@@ -27,7 +27,7 @@ dependencies = [
     ('sz', '2.1.12.2'),
     ('libpng', '1.6.37'),
     ('blosc2', '2.9.2'),
-    ('Catalyst', '2.0.0', '-rc4'),
+    ('Catalyst', '2.0.0'),
 ]
 
 configopts  = '-DCMAKE_BUILD_TYPE=Release '


### PR DESCRIPTION
use the production version of Catalyst, instead of "rc4" version