### PR TITLE
[pilatus] Update CP2K architecture file on Pilatus

### DIFF
--- a/easybuild/easyconfigs/c/CP2K/CP2K-9.1-cpeGNU-23.12.eb
+++ b/easybuild/easyconfigs/c/CP2K/CP2K-9.1-cpeGNU-23.12.eb
@@ -1,0 +1,62 @@
+# contributed by Luca Marsella (CSCS)
+easyblock = 'MakeCp'
+
+name = 'CP2K'
+version = '9.1'
+
+homepage = 'http://www.cp2k.org/'
+description = """
+    CP2K is a freely available (GPL) program, written in Fortran 95, to
+    perform atomistic and molecular simulations of solid state, liquid,
+    molecular and biological systems. It provides a general framework for
+    different methods such as e.g. density functional theory (DFT) using a
+    mixed Gaussian and plane waves approach (GPW), and classical pair and
+    many-body potentials.
+"""
+
+toolchain = {'name': 'cpeGNU', 'version': '23.12'}
+toolchainopts = {'openmp': True, 'usempi': True}
+
+source_urls = ['https://github.com/%(namelower)s/%(namelower)s/releases/download/v%(version)s.0']
+sources = [SOURCELOWER_TAR_BZ2]
+patches = [
+    ('%(name)s-%(version_major_minor)s-%(toolchain_name)s.psmp', '%(builddir)s/%(namelower)s-%(version)s/arch'),
+]
+
+builddependencies = [
+    ('Bison', '3.8.2'),
+    ('cray-fftw', EXTERNAL_MODULE),
+    ('cray-libsci', EXTERNAL_MODULE),
+    ('flex', '2.6.4'),
+]
+dependencies = [
+    ('ELPA', '2021.11.001'),
+    ('Libint-CP2K', '2.6.0'),
+    ('libvori', '210412'),
+    ('libxc', '5.1.7'),
+    ('libxsmm', '1.17'),
+    ('PLUMED', '2.7.3'),
+    ('SIRIUS', '7.3.1'),
+    ('spglib', '1.16.3'),
+]
+
+# build type
+buildopts = "ARCH=%(name)s-%(version_major_minor)s-%(toolchain_name)s VERSION=psmp"
+
+files_to_copy = [
+    (['./arch/%(name)s-%(version_major_minor)s-%(toolchain_name)s.psmp'], 'arch'),
+    (['./exe/%(name)s-%(version_major_minor)s-%(toolchain_name)s/*'], 'bin'),
+    (['./data'], '.'),
+    (['./tests'], '.'),
+    (['./tools'], '.'),
+]
+
+sanity_check_paths = {
+    'files': ['arch/%(name)s-%(version_major_minor)s-%(toolchain_name)s.psmp', 'bin/%(namelower)s.psmp'],
+    'dirs': ['data', 'tests'],
+}
+
+# set custom CP2K_DATA_DIR
+modextravars = {'CP2K_DATA_DIR': '%(installdir)s/data'}
+
+moduleclass = 'chem'

--- a/easybuild/easyconfigs/c/CP2K/CP2K-9.1-cpeGNU.psmp
+++ b/easybuild/easyconfigs/c/CP2K/CP2K-9.1-cpeGNU.psmp
@@ -10,7 +10,7 @@ AR             = ar -r
 
 DFLAGS   = -D__GFORTRAN -D__MAX_CONTR=4 -D__MPI_VERSION=3 -D__parallel -D__SCALAPACK
 DFLAGS  += -D__ELPA -D__FFTW3 -D__GSL -D__LIBINT -D__LIBXSMM -D__LIBVORI -D__LIBXC -D__PLUMED2 -D__SIRIUS -D__SPGLIB
-CFLAGS  = -O2 -fopenmp -fopenmp-simd -ftree-vectorize -funroll-loops -g $(DFLAGS)
+CFLAGS  = -O2 -fopenmp -funroll-loops -g $(DFLAGS)
 CFLAGS  += -I$(ELPA_OPENMP_INCLUDE_DIR)/elpa -I$(ELPA_OPENMP_INCLUDE_DIR)/modules 
 CFLAGS  += -I$(EBROOTFFTW)/include
 CFLAGS  += -I$(EBROOTGSL)/include
@@ -20,11 +20,8 @@ CFLAGS  += -I$(EBROOTLIBXSMM)/include
 CFLAGS  += -I$(EBROOTSIRIUS)/include/sirius
 CFLAGS  += -I$(EBROOTSPGLIB)/include
 CXXFLAGS = $(CFLAGS) -std=c++11
-FCFLAGS  = $(CFLAGS)
-ifeq ($(shell (( $(shell gcc -dumpversion | cut -d. -f1) > 9 )) && echo yes), yes)
- FCFLAGS += -fallow-argument-mismatch
-endif
-FCFLAGS  += -fbacktrace -ffree-form -ffree-line-length-none -fno-omit-frame-pointer -std=f2008 
+FCFLAGS  = $(CFLAGS) -ffree-form -ffree-line-length-512 -fallow-argument-mismatch 
+CFLAGS  += -fopenmp-simd -ftree-vectorize
 LDFLAGS  = $(FCFLAGS)
 LIBS     += -L$(EBROOTELPA)/lib -lelpa_openmp
 LIBS   	 += -L$(EBROOTFFTW)/lib -lfftw3 -lfftw3_threads

--- a/easybuild/easyconfigs/e/ELPA/ELPA-2021.11.001-cpeGNU-23.12.eb
+++ b/easybuild/easyconfigs/e/ELPA/ELPA-2021.11.001-cpeGNU-23.12.eb
@@ -1,0 +1,38 @@
+# Contributed by Luca Marsella (CSCS)
+easyblock = 'ConfigureMake'
+
+name = 'ELPA'
+version = '2021.11.001'
+
+homepage = 'http://elpa.rzg.mpg.de'
+description = "Eigenvalue SoLvers for Petaflop-Applications."
+
+toolchain = {'name': 'cpeGNU', 'version': '23.12'}
+toolchainopts = {'usempi': True, 'openmp': True}
+
+# WARNING: download from http://elpa.mpcdf.mpg.de often fails
+source_urls = ['https://%(namelower)s.mpcdf.mpg.de/software/tarball-archive/Releases/%(version)s']
+sources = [SOURCELOWER_TAR_GZ]
+
+preconfigopts = " CC=cc CXX=CC FC=ftn && "
+configopts = [
+    ' FCFLAGS="$FCFLAGS" -disable-avx512 --enable-static ',
+    ' FCFLAGS="$FCFLAGS" -disable-avx512 --enable-static  --enable-runtime-threading-support-checks --enable-allow-thread-limiting --without-threading-support-check-during-build --enable-openmp ',
+]
+
+prebuildopts = " make clean && "
+
+
+sanity_check_paths = {
+    'files': ['lib/libelpa.a', 'lib/libelpa.so', 'lib/libelpa_openmp.a', 'lib/libelpa_openmp.so'],
+    'dirs': ['bin', 'lib/pkgconfig', 'include/%(namelower)s-%(version)s/%(namelower)s', 'include/%(namelower)s-%(version)s/modules', 'include/%(namelower)s_openmp-%(version)s/%(namelower)s', 'include/%(namelower)s_openmp-%(version)s/modules'],
+}
+
+modextrapaths = {'CPATH': ['include/elpa_openmp-%(version)s', 'include/%(namelower)s-%(version)s']}
+
+modextravars = {
+    'ELPA_INCLUDE_DIR': '%(installdir)s/include/%(namelower)s-%(version)s',
+    'ELPA_OPENMP_INCLUDE_DIR': '%(installdir)s/include/elpa_openmp-%(version)s',
+}
+
+moduleclass = 'math'

--- a/easybuild/easyconfigs/g/GMP/GMP-6.2.1-cpeGNU-23.12.eb
+++ b/easybuild/easyconfigs/g/GMP/GMP-6.2.1-cpeGNU-23.12.eb
@@ -1,0 +1,27 @@
+# contributed by Guilherme Peretti Pezzi and Luca Marsella (CSCS)
+easyblock = 'ConfigureMake'
+
+name = 'GMP'
+version = '6.2.1'
+
+homepage = 'http://gmplib.org/'
+description = """GMP is a free library for arbitrary precision arithmetic,
+operating on signed integers, rational numbers, and floating point numbers. """
+
+toolchain = {'name': 'cpeGNU', 'version': '23.12'}
+toolchainopts = {'lowopt': True}
+
+source_urls = [GNU_SOURCE]
+sources = [SOURCELOWER_TAR_BZ2]
+
+preconfigopts = 'export CFLAGS="$CFLAGS -mcmodel=large" && '
+
+
+# the output of config.guess is used by default and can be changed with --build
+# E.g.: configopts = ' --build=haswell-pc-linux-gnu'
+sanity_check_paths = {
+    'files': ['lib/libgmp.so', 'include/%(namelower)s.h'],
+    'dirs': [],
+}
+
+moduleclass = 'math'

--- a/easybuild/easyconfigs/l/Libint-CP2K/Libint-CP2K-2.6.0-cpeGNU-23.12.eb
+++ b/easybuild/easyconfigs/l/Libint-CP2K/Libint-CP2K-2.6.0-cpeGNU-23.12.eb
@@ -1,0 +1,39 @@
+# contributed by Luca Marsella (CSCS)
+easyblock = 'ConfigureMake'
+
+name = 'Libint-CP2K'
+version = '2.6.0'
+
+homepage = 'https://github.com/cp2k/libint-cp2k'
+description = """Provides tarballs of CP2K-configured libint releases for different maximum angular momenta. 
+Libint library is used to evaluate the traditional (electron repulsion) and certain novel two-body
+ matrix elements (integrals) over Cartesian Gaussian functions used in modern atomic and molecular theory."""
+
+toolchain = {'name': 'cpeGNU', 'version': '23.12'}
+toolchainopts = {'opt': True, 'pic': True}
+
+source_urls = ['https://github.com/cp2k/%(namelower)s/releases/download/v%(version)s']
+sources = ['libint-v%(version)s-cp2k-lmax-5.tgz']
+
+builddependencies = [
+    ('Boost', '1.78.0', '-python3'),
+    ('GMP', '6.2.1'),
+]
+
+osdependencies = [('autoconf', 'automake')]
+
+preconfigopts = " module unload cray-libsci && "
+configopts = " --enable-fortran --enable-shared "
+
+prebuildopts = " module unload cray-libsci && "
+
+# https://github.com/evaleev/libint/issues/173 and https://gcc.gnu.org/onlinedocs/gcc-10.1.0/cpp/_005f_005fhas_005finclude.html
+preinstallopts = ' sed -i "s/__has_include(<libint2_params.h>)/defined(__COMPILING_LIBINT2)/" ./include/libint2/util/generated/libint2_params.h && '
+
+
+sanity_check_paths = {
+    'files': ['include/libint2.h', 'include/libint2.hpp', 'lib/libint2.a', 'lib/libint2.so'],
+    'dirs': ['include/libint2'],
+}
+
+moduleclass = 'chem'

--- a/easybuild/easyconfigs/l/libvori/libvori-210412-cpeGNU-23.12.eb
+++ b/easybuild/easyconfigs/l/libvori/libvori-210412-cpeGNU-23.12.eb
@@ -1,0 +1,26 @@
+# Contributed by Luca Marsella (CSCS)
+easyblock = 'CMakeMake'
+
+name = 'libvori'
+version = '210412'
+
+homepage = 'https://brehm-research.de/libvori.php'
+description = "libvori stands for 'Library for Voronoi Integration': currently libvori is working with the CP2K program package"
+
+toolchain = {'name': 'cpeGNU', 'version': '23.12'}
+toolchainopts = {'usempi': False, 'openmp': False}
+
+source_urls = ['https://brehm-research.de/files']
+sources = [SOURCE_TAR_GZ]
+
+builddependencies = [
+    ('CMake', '3.22.1', '', SYSTEM),
+]
+
+
+sanity_check_paths = {
+    'files': ['lib/%(name)s.a'],
+    'dirs': ['lib'],
+}
+
+moduleclass = 'chem'

--- a/easybuild/easyconfigs/l/libxc/libxc-5.1.7-cpeGNU-23.12.eb
+++ b/easybuild/easyconfigs/l/libxc/libxc-5.1.7-cpeGNU-23.12.eb
@@ -1,0 +1,33 @@
+# contributed by Luca Marsella (CSCS)
+easyblock = 'CMakeMake'
+
+name = 'libxc'
+version = '5.1.7'
+
+homepage = 'http://www.tddft.org/programs/octopus/wiki/index.php/Libxc'
+description = """Libxc is a library of exchange-correlation functionals for density-functional theory.
+ The aim is to provide a portable, well tested and reliable set of exchange and correlation functionals."""
+
+toolchain = {'name': 'cpeGNU', 'version': '23.12'}
+toolchainopts = {'opt': True}
+
+source_urls = ['https://gitlab.com/%(name)s/%(name)s/-/archive/%(version)s']
+sources = [SOURCE_TAR_BZ2]
+
+builddependencies = [
+    ('bzip2', '1.0.8'),
+    ('CMake', '3.22.1', '', SYSTEM),
+]
+
+configopts = [
+    " -DENABLE_FORTRAN=ON -DCMAKE_INSTALL_LIBDIR=lib ",
+    " -DENABLE_FORTRAN=ON -DCMAKE_INSTALL_LIBDIR=lib  -DBUILD_SHARED_LIBS=ON ",
+]
+
+
+sanity_check_paths = {
+    'files': ['lib/%(name)s.a', 'lib/%(name)s.so', 'lib/%(name)sf90.a', 'lib/%(name)sf90.so', 'lib/%(name)sf03.a', 'lib/%(name)sf03.so'],
+    'dirs': ['include'],
+}
+
+moduleclass = 'chem'

--- a/easybuild/easyconfigs/l/libxsmm/libxsmm-1.17-cpeGNU-23.12.eb
+++ b/easybuild/easyconfigs/l/libxsmm/libxsmm-1.17-cpeGNU-23.12.eb
@@ -1,0 +1,31 @@
+# contributed by Luca Marsella (CSCS)
+easyblock = 'MakeCp'
+
+name = 'libxsmm'
+version = '1.17'
+
+homepage = 'https://readthedocs.org/projects/libxsmm'
+description = """
+Library targeting Intel Architecture for specialized dense and sparse matrix operations, and deep learning primitives.
+"""
+
+toolchain = {'name': 'cpeGNU', 'version': '23.12'}
+toolchainopts = {'usempi': True, 'openmp': True}
+
+source_urls = ['https://github.com/hfp/%(name)s/archive/']
+sources = ['%(version)s.tar.gz']
+
+buildopts = "PREFIX=%(installdir)s CXX=g++ CC=gcc FC=ftn AVX=2 DBG=0 JIT=1 MALLOC=0 MIC=0 OPT=3 OMP=1 PREFETCH=1 STATIC=0 install"
+
+skipsteps = [
+    'configure',
+    'install',
+]
+files_to_copy = []
+
+sanity_check_paths = {
+    'files': ['include/%(name)s.f', 'include/%(name)s.h', 'lib/%(name)s.so'],
+    'dirs': ['include', 'include/%(name)s', 'lib'],
+}
+
+moduleclass = 'chem'

--- a/easybuild/easyconfigs/p/PLUMED/PLUMED-2.7.3-cpeGNU-23.12.eb
+++ b/easybuild/easyconfigs/p/PLUMED/PLUMED-2.7.3-cpeGNU-23.12.eb
@@ -1,0 +1,49 @@
+# by Ward Poelmans <wpoely86@gmail.com>
+# Modified by Luca Marsella (CSCS)
+easyblock = 'ConfigureMake'
+
+name = 'PLUMED'
+version = '2.7.3'
+
+homepage = 'https://www.plumed.org'
+description = """PLUMED is an open source library for free energy calculations in molecular systems which
+ works together with some of the most popular molecular dynamics engines. Free energy calculations can be
+ performed as a function of many order parameters with a particular  focus on biological problems, using
+ state of the art methods such as metadynamics, umbrella sampling and Jarzynski-equation based steered MD.
+ The software, written in C++, can be easily interfaced with both fortran and C/C++ codes.
+"""
+
+toolchain = {'name': 'cpeGNU', 'version': '23.12'}
+toolchainopts = {'openmp': 'True', 'usempi': 'True', 'verbose': 'True'}
+
+source_urls = ['https://github.com/%(namelower)s/plumed2/archive/']
+sources = ['v%(version)s.tar.gz']
+
+builddependencies = [
+    ('cray-fftw', EXTERNAL_MODULE),
+    ('cray-python', EXTERNAL_MODULE),
+]
+dependencies = [
+    ('zlib', '1.2.11'),
+    ('GSL', '2.7'),
+]
+
+# The following search options are activated by default in configure:
+# --enable-external-blas --enable-external-lapack --enable-fftw --enable-gsl --enable-mpi --enable-python
+preconfigopts = " module unload cray-libsci &&  CC=cc CXX=CC MPIEXEC=srun "
+configopts = " --disable-xdrfile --enable-shared --enable-modules=all --exec-prefix=%(installdir)s "
+
+prebuildopts = " module unload cray-libsci && "
+
+
+sanity_check_paths = {
+    'files': ['bin/%(namelower)s', 'lib/libplumedKernel.so', 'lib/libplumed.so'],
+    'dirs': ['lib/%(namelower)s'],
+}
+
+modextrapaths = {
+    'PLUMED_KERNEL': 'lib/libplumedKernel.so',
+    'PLUMED_ROOT': 'lib/%(namelower)s',
+}
+
+moduleclass = 'chem'

--- a/easybuild/easyconfigs/s/SIRIUS/SIRIUS-7.3.1-cpeGNU-23.12.eb
+++ b/easybuild/easyconfigs/s/SIRIUS/SIRIUS-7.3.1-cpeGNU-23.12.eb
@@ -1,0 +1,35 @@
+# contributed by Anton Kozhevnikov (CSCS)
+easyblock = 'CMakeMake'
+
+name = 'SIRIUS'
+version = '7.3.1'
+
+homepage = 'https://electronic-structure.github.io/SIRIUS/'
+description = "Domain specific library for electronic structure calculations."
+
+toolchain = {'name': 'cpeGNU', 'version': '23.12'}
+toolchainopts = {'openmp': True, 'opt': True, 'pic': True, 'usempi': True, 'verbose': True}
+
+source_urls = ['https://github.com/electronic-structure/%(name)s/archive/']
+sources = ['v%(version)s.tar.gz']
+
+builddependencies = [
+    ('CMake', '3.22.1', '', SYSTEM),
+]
+dependencies = [
+    ('cray-hdf5', EXTERNAL_MODULE),
+    ('ELPA', '2021.11.001'),
+    ('GSL', '2.7'),
+    ('libxc', '5.1.7'),
+    ('SpFFT', '1.0.5'),
+    ('spglib', '1.16.3'),
+    ('SPLA', '1.5.2'),
+]
+
+preconfigopts = " CXX=CC CC=cc FC=ftn && "
+configopts = "-DUSE_CUDA=0 -DBUILD_TESTS=0 -DUSE_CRAY_LIBSCI=1 -DUSE_MAGMA=0 -DUSE_MKL=0 -DUSE_SCALAPACK=1 -DUSE_ELPA=1 -DSpFFT_DIR=$EBROOTSPFFT/lib64/cmake/SpFFT"
+
+
+modextrapaths = {'CPATH': ['include/%(namelower)s']}
+
+moduleclass = 'chem'

--- a/easybuild/easyconfigs/s/SPLA/SPLA-1.5.2-cpeGNU-23.12.eb
+++ b/easybuild/easyconfigs/s/SPLA/SPLA-1.5.2-cpeGNU-23.12.eb
@@ -1,0 +1,28 @@
+# contributed by Luca Marsella (CSCS)
+easyblock = 'CMakeMake'
+
+name = 'SPLA'
+version = '1.5.2'
+
+homepage = 'https://github.com/eth-cscs/spla'
+description = "Specialized Parallel Linear Algebra"
+
+toolchain = {'name': 'cpeGNU', 'version': '23.12'}
+toolchainopts = {'openmp': True, 'opt': True, 'pic': True, 'usempi': True, 'verbose': True}
+
+source_urls = ['https://github.com/eth-cscs/%(namelower)s/archive']
+sources = ['v%(version)s.tar.gz']
+
+builddependencies = [
+    ('CMake', '3.22.1', '', SYSTEM),
+]
+
+configopts = "-DCMAKE_BUILD_TYPE=RELEASE -DSPLA_HOST_BLAS=CRAY_LIBSCI -DSPLA_OMP=ON"
+
+
+sanity_check_paths = {
+    'files': ['lib/libspla.so', 'include/%(namelower)s/config.h', 'include/%(namelower)s/%(namelower)s.hpp'],
+    'dirs': [],
+}
+
+moduleclass = 'lib'

--- a/easybuild/easyconfigs/s/SpFFT/SpFFT-1.0.5-cpeGNU-23.12.eb
+++ b/easybuild/easyconfigs/s/SpFFT/SpFFT-1.0.5-cpeGNU-23.12.eb
@@ -1,0 +1,30 @@
+# contributed by Luca Marsella (CSCS)
+easyblock = 'CMakeMake'
+
+name = 'SpFFT'
+version = '1.0.5'
+
+homepage = 'https://github.com/eth-cscs/SpFFT'
+description = "Sparse 3D FFT library with MPI, OpenMP, CUDA and ROCm support"
+
+toolchain = {'name': 'cpeGNU', 'version': '23.12'}
+toolchainopts = {'openmp': True, 'opt': True, 'pic': True, 'verbose': True}
+
+source_urls = ['https://github.com/eth-cscs/%(name)s/archive']
+sources = ['v%(version)s.tar.gz']
+
+builddependencies = [
+    ('CMake', '3.22.1', '', SYSTEM),
+    ('cray-fftw', EXTERNAL_MODULE),
+]
+
+preconfigopts = " CXX=CC CC=cc FC=ftn && "
+configopts = " -DCMAKE_BUILD_TYPE=RELEASE -DSPFFT_FFTW_LIB=FFTW -DSPFFT_SINGLE_PRECISION=ON  -DSPFFT_MPI=ON -DSPFFT_OMP=ON "
+
+
+sanity_check_paths = {
+    'files': ['lib/libspfft.so', 'include/%(namelower)s/config.h', 'include/%(namelower)s/%(namelower)s.hpp'],
+    'dirs': [],
+}
+
+moduleclass = 'lib'

--- a/easybuild/easyconfigs/s/spglib/spglib-1.16.3-cpeGNU-23.12.eb
+++ b/easybuild/easyconfigs/s/spglib/spglib-1.16.3-cpeGNU-23.12.eb
@@ -1,0 +1,30 @@
+# contributed by Anton Kozhevnikov and Simon Pintarelli (CSCS)
+easyblock = 'CMakeMake'
+
+name = 'spglib'
+version = '1.16.3'
+
+homepage = 'https://atztogo.github.io/spglib/'
+description = "Spglib is a library for finding and handling crystal symmetries written in C."
+
+toolchain = {'name': 'cpeGNU', 'version': '23.12'}
+toolchainopts = {'openmp': True, 'usempi': False}
+
+source_urls = ['https://github.com/atztogo/%(name)s/archive/']
+sources = ['v%(version)s.tar.gz']
+
+builddependencies = [
+    ('CMake', '3.22.1', '', SYSTEM),
+]
+
+postinstallcmds = [
+    "mkdir %(installdir)s/include/%(name)s",
+    "cp %(installdir)s/include/%(name)s.h %(installdir)s/include/%(name)s/",
+]
+
+sanity_check_paths = {
+    'files': ['lib/libsymspg.a', 'lib/libsymspg.so'],
+    'dirs': ['include', 'lib', 'include/%(name)s'],
+}
+
+moduleclass = 'chem'

--- a/jenkins-builds/23.12-pilatus
+++ b/jenkins-builds/23.12-pilatus
@@ -13,6 +13,7 @@
  Boost-1.78.0-cpeGNU-23.12.eb
  Boost-1.78.0-cpeGNU-23.12-python3.eb --set-default-module
  CDO-1.9.10-cpeGNU-23.12.eb
+ CP2K-9.1-cpeGNU-23.12.eb
  CubeLib-4.5-cpeGNU-23.12.eb
  FFmpeg-5.0-cpeGNU-23.12.eb 
  GREASY-19.03-cscs-cpeGNU-23.12.eb


### PR DESCRIPTION
I provide an updated architecture file for CP2K 9.1 on Pilatus and the recipes of the dependencies (see [SPCI-265](https://jira.cscs.ch/browse/SPCI-265)).