### PR TITLE
[daint-mc] Remove versionsuffix from Catalyst dependency

### DIFF
--- a/easybuild/easyconfigs/p/ParaView/ParaView-5.11.2-CrayGNU-21.09-OSMesa.eb
+++ b/easybuild/easyconfigs/p/ParaView/ParaView-5.11.2-CrayGNU-21.09-OSMesa.eb
@@ -24,9 +24,9 @@ dependencies = [
     ('h5py', '3.6.0', '-serial'),
     ('Boost', '1.78.0', '-python%(pymajver)s'),
     ('CDI', '2.1.0'),
-    ('Catalyst', '2.0.0', '-rc4'),
+    ('Catalyst', '2.0.0'),
     ('Mesa', '21.3.1'),
-    ('ospray', '2.10.0'),
+    ('ospray', '2.10.0')
 ]
 
 configopts = '-DPARAVIEW_USE_MPI:BOOL=ON '

--- a/easybuild/easyconfigs/p/ParaView/ParaView-5.12.0-CrayGNU-21.09-OSMesa.eb
+++ b/easybuild/easyconfigs/p/ParaView/ParaView-5.12.0-CrayGNU-21.09-OSMesa.eb
@@ -17,16 +17,16 @@ sources = ['%(name)s-v%(version)s.tar.gz']
 
 dependencies = [
     ('Boost', '1.78.0', '-python%(pymajver)s'),
-    ('Catalyst', '2.0.0', '-rc4'),
+    ('Catalyst', '2.0.0'),
     ('CDI', '2.2.4', '-parallel'),
     ('Mesa', '23.0.1'),
     ('adios', '2.9.2'),
     ('cray-python', EXTERNAL_MODULE),
-    ('ospray', '2.12.0'),
+    ('ospray', '2.12.0')
 ]
 
 builddependencies = [
-    ('CMake', '3.26.5','', True),
+    ('CMake', '3.26.5','', True)
 ]
 
 separate_build_dir = True


### PR DESCRIPTION
Remove version suffix `-rc4` from `Catalyst` dependency of `ParaView` (see #2999): the [regression tests](https://jenkins.cscs.ch/blue/organizations/jenkins/reframe-daint-production-daily/detail/reframe-daint-production-daily/2879/pipeline) are successful (after the manual change of the corresponding modules on the system).