### PR TITLE
[daint-gpu] adding ParaView 5.12.1 as default for EGL-rendering

### DIFF
--- a/easybuild/easyconfigs/p/ParaView/ParaView-5.12.1-CrayGNU-21.09-EGL.eb
+++ b/easybuild/easyconfigs/p/ParaView/ParaView-5.12.1-CrayGNU-21.09-EGL.eb
@@ -1,0 +1,112 @@
+# CrayGNU version by Jean Favre (CSCS)
+easyblock = 'CMakeMake'
+
+name = 'ParaView'
+version = '5.12.1'
+versionsuffix = '-EGL'
+
+homepage = 'http://www.paraview.org'
+description = "ParaView is a scientific parallel visualizer."
+
+toolchain = {'name': 'CrayGNU', 'version': '21.09'}
+toolchainopts = {'pic': True, 'usempi': True, 'verbose': False}
+
+local_download_suffix = 'download.php?submit=Download&version=v%(version_major_minor)s&type=source&os=all&downloadFile='
+source_urls = ['http://www.paraview.org/paraview-downloads/%s' % local_download_suffix]
+sources = ['%(name)s-v%(version)s.tar.gz']
+
+dependencies = [
+    ('intel', EXTERNAL_MODULE),
+    ('Boost', '1.78.0', '-python%(pymajver)s'),
+    ('Catalyst', '2.0.0'),
+    ('CDI', '2.2.4', '-parallel'),
+    ('VisRTX', '0.1.6', '-cuda'),
+    ('adios', '2.10.0'),
+    ('cray-python', EXTERNAL_MODULE),
+#    ('cray-hdf5-parallel', EXTERNAL_MODULE),
+    ('ospray', '2.12.0'),
+]
+
+builddependencies = [
+    ('CMake', '3.26.5','', True),
+]
+
+separate_build_dir = True
+
+maxparallel = 32
+
+configopts  = '-DPARAVIEW_USE_MPI:BOOL=ON '
+configopts += '-DCMAKE_C_COMPILER=gcc -DCMAKE_CXX_COMPILER=g++ '
+configopts += '-DMPI_C_COMPILER=cc -DMPI_CXX_COMPILER=CC '
+configopts += '-DPARAVIEW_BUILD_TESTING:BOOL=OFF -DPARAVIEW_ENABLE_EXAMPLES:BOOL=OFF -DPARAVIEW_BUILD_EDITION=CANONICAL '
+configopts += '-DPARAVIEW_USE_PYTHON:BOOL=ON '
+configopts += '-DCMAKE_BUILD_TYPE=Release -DPARAVIEW_BUILD_SHARED_LIBS:BOOL=ON '
+
+# use TBB for on-the-node parallelism
+configopts += '-DVTK_SMP_IMPLEMENTATION_TYPE=TBB '
+configopts += '-DTBB_DIR:PATH=$INTEL_PATH/../../tbb/latest/lib/cmake/tbb '
+#
+configopts += '-DOPENGL_opengl_LIBRARY=/usr/lib64/libOpenGL.so '
+configopts += '-DOPENGL_egl_LIBRARY=/usr/lib64/libEGL.so '
+configopts += '-DOPENGL_INCLUDE_DIR=/usr/include '
+configopts += '-DPARAVIEW_USE_VTKM:BO0L=ON '
+configopts += '-DPARAVIEW_USE_QT:BOOL=OFF -DPARAVIEW_ENABLE_WEB:BOOL=ON '
+configopts += '-DPARAVIEW_ENABLE_XDMF3:BOOL=ON '
+# CSCS specific for EGL
+configopts += '-DVTK_OPENGL_HAS_EGL:BOOL=ON -DVTK_USE_X:BOOL=OFF '
+# CSCS specific for Raytracing (OSPRAY and/or OptiX)
+configopts += '-DPARAVIEW_ENABLE_RAYTRACING:BOOL=ON '
+configopts += '-DVTK_ENABLE_VISRTX:BOOL=ON '
+configopts += '-DVTKOSPRAY_ENABLE_DENOISER:BOOL=ON '
+#
+configopts += '-DVisRTX_DIR="$EBROOTVISRTX/lib64/cmake/VisRTX-$EBVERSIONVISRTX" '
+# Using Cray HDF5
+configopts += '-DVTK_MODULE_USE_EXTERNAL_VTK_hdf5:BOOL=ON '
+configopts += '-DHDF5_PREFER_PARALLEL:BOOL=ON '
+configopts += '-DHDF5_NO_FIND_PACKAGE_CONFIG_FILE:BOOL=TRUE '
+configopts += '-DHDF5_C_COMPILER_EXECUTABLE=cc '
+configopts += '-DHDF5_C_COMPILER_EXECUTABLE_NO_INTERROGATE=cc '
+configopts += '-DHDF5_DIR=$CRAY_HDF5_PARALLEL_PREFIX '
+configopts += '-DHDF5_C_INCLUDE_DIRS=$CRAY_HDF5_PARALLEL_PREFIX/include '
+configopts += '-DHDF5_C_HL_LIBRARIES=$CRAY_HDF5_PARALLEL_PREFIX/lib/libhdf5_hl_parallel.so '
+configopts += '-DHDF5_C_LIBRARIES=$CRAY_HDF5_PARALLEL_PREFIX/lib/libhdf5_parallel.so '
+# Using Cray NETCDF
+#configopts += '-DVTK_MODULE_USE_EXTERNAL_VTK_netcdf:BOOL=ON -DnetCDF_DIR=$NETCDF_DIR '
+#configopts += '-DNetCDF_INCLUDE_DIR="$NETCDF_DIR"/include '
+#configopts += '-DNetCDF_LIBRARY="$NETCDF_DIR"/lib/libnetcdf.so '
+# Using CSCS NVIDIA IndeX lib. Auto-load cannot be turned on. See https://jira.cscs.ch/browse/SD-51595
+#configopts += '-DPARAVIEW_PLUGIN_ENABLE_pvNVIDIAIndeX:BOOL=ON '
+#configopts += '-DPARAVIEW_PLUGIN_AUTOLOAD_pvNVIDIAIndeX:BOOL=ON '
+#
+#configopts += '-DPARAVIEW_INITIALIZE_MPI_ON_CLIENT=ON '
+configopts += '-DPARAVIEW_INSTALL_DEVELOPMENT_FILES=ON '
+#
+configopts += "-DVTK_MODULE_ENABLE_VTK_GeovisCore:STRING=YES "
+configopts += '-DPARAVIEW_ENABLE_VISITBRIDGE:BOOL=ON '
+#
+configopts += '-DPARAVIEW_ENABLE_CATALYST:BOOL=ON -Dcatalyst_DIR="$EBROOTCATALYST/lib64/cmake/catalyst-2.0" '
+configopts += '-DPARAVIEW_PLUGIN_ENABLE_CDIReader:BOOL=ON -DCDI_DIR="$EBROOTCDI/lib/cmake/libcdi" '
+#
+configopts += '-DADIOS2_DIR="$EBROOTADIOS/lib64/cmake/adios2" -DPARAVIEW_ENABLE_ADIOS2:BOOL=ON '
+configopts += '-DPARAVIEW_ENABLE_FIDES:BOOL=ON '
+
+
+modextravars = { 'LD_LIBRARY_PATH':'/opt/intel/oneapi/tbb/latest/lib/intel64/gcc4.8:/apps/common/UES/easybuild/sources/p/ParaView/nvindex_default/linux-x86-64/lib:/opt/python/%(pyver)s/lib:$::env(LD_LIBRARY_PATH)', 
+                 'NVINDEX_PVPLUGIN_HOME':'/apps/common/UES/easybuild/sources/p/ParaView',
+#                 'TBB_ROOT': '/opt/intel/compilers_and_libraries/linux/tbb',
+               }
+
+
+modextrapaths = {'PYTHONPATH': 'lib64/python%(pyshortver)s/site-packages'}
+
+sanity_check_paths = {
+    'files': ['bin/pvbatch', 'bin/pvserver'],
+    'dirs': ['lib64/python%(pyshortver)s/site-packages', 'lib64/paraview-%(version_major_minor)s/plugins'],
+}
+
+#postinstallcmds = [
+#    "tar xf /apps/common/UES/easybuild/sources/%(nameletterlower)s/%(name)s/materials.tar.bz2 -C %(installdir)s/share/%(namelower)s-%(version_major_minor)s"
+#]
+
+
+moduleclass = 'vis'

--- a/jenkins-builds/7.0.UP03-21.09-daint-gpu
+++ b/jenkins-builds/7.0.UP03-21.09-daint-gpu
@@ -48,8 +48,8 @@
  OOOPS-1.0.eb
  ovito-3.7.7-CrayGNU-21.09.eb                           --set-default-module
  ovito-3.9.4-CrayGNU-21.09.eb
- ParaView-5.11.2-CrayGNU-21.09-EGL.eb                   --set-default-module
- ParaView-5.12.0-CrayGNU-21.09-EGL.eb                   
+ ParaView-5.11.2-CrayGNU-21.09-EGL.eb
+ ParaView-5.12.1-CrayGNU-21.09-EGL.eb                   --set-default-module
  PLUMED-2.7.3-CrayGNU-21.09.eb                          --set-default-module
  PLUMED-2.8.0-CrayGNU-21.09.eb
  pycuda-2021.1-CrayGNU-21.09-cuda.eb                    --set-default-module


### PR DESCRIPTION
synching with the HDF5 provided by adios2 dependencies
removing NVIndeX no longer supported
making it the default