### PR TITLE
[eiger] tweaks to enable h5part, run-time python, and hdf5_HL

### DIFF
--- a/easybuild/easyconfigs/v/Visit/Visit-3.4.1-cpeGNU-23.12.eb
+++ b/easybuild/easyconfigs/v/Visit/Visit-3.4.1-cpeGNU-23.12.eb
@@ -19,6 +19,8 @@ sources = [
 
 builddependencies = [
     ('CMake', '3.26.5', '', SYSTEM),
+]
+dependencies = [
     ('cray-python', EXTERNAL_MODULE),
 ]
 
@@ -26,7 +28,8 @@ preconfigopts = 'export PAR_COMPILER_CXX=mpicxx; ' # required to build Conduit
 preconfigopts += 'pushd ../%(namelower)s%(version)s; mkdir -p third_party; '
 preconfigopts += "sed -i 's/== \"gcc/!= \"gcc/g' ./src/tools/dev/scripts/bv_support/bv_xdmf.sh; " # required to build xdmf
 
-preconfigopts += './src/tools/dev/scripts/build_visit --cc /usr/bin/gcc-12 --cxx /usr/bin/g++-12 --no-%(namelower)s --parallel --llvm --mesagl --vtk --vtk9 --makeflags -j32 --system-python --qwt --qt --silo --hdf5 --system-cmake --icet --ospray --ispc --embree --tbb --mfem --conduit --xdmf <<< "yes" && cp `hostname`.cmake ./src/config-site; mkdir build; cd build; '
+preconfigopts += './src/tools/dev/scripts/build_visit --cc /usr/bin/gcc-12 --cxx /usr/bin/g++-12 --no-%(namelower)s --parallel --llvm --mesagl --vtk --vtk9 --makeflags -j32 --system-python --qwt --qt --silo --hdf5 --h5part --system-cmake --icet --ospray --ispc --embree --tbb --mfem --conduit --xdmf <<< "yes" && cp `hostname`.cmake ./src/config-site; mkdir build; cd build; '
+
 configopts = "-DMPI_CXX_COMPILER=CC -DCMAKE_BUILD_TYPE=RelWithDebInfo -DVISIT_ENABLE_MANUALS=FALSE -DVISIT_ENABLE_DATA_MANUAL_EXAMPLES:BOOL=ON -DVISIT_INSTALL_THIRD_PARTY:BOOL=ON -DVISIT_SLIVR:BOOL=OFF -DVISIT_ENABLE_XDB:BOOL=OFF "
 
 prebuildopts = " pushd ../%(namelower)s%(version)s/build; "
@@ -40,6 +43,10 @@ parallel = 24
 runtest = False
 install_cmd = "make install "
 srcdir = '../%(namelower)s%(version)s/src'
+
+postinstallcmds = [
+    "cp %(builddir)s/%(namelower)s%(version)s/third_party/hdf5/1.8.14/linux-x86_64_*/lib/libhdf5_hl* %(installdir)s/current/linux-x86_64/lib"
+]
 
 modluafooter = 'prepend_path("LD_LIBRARY_PATH",pathJoin(os.getenv("CRAY_PYTHON_PREFIX"), "lib"))'
 

--- a/easybuild/easyconfigs/v/Visit/Visit-3.4.1-cpeGNU-23.12.eb
+++ b/easybuild/easyconfigs/v/Visit/Visit-3.4.1-cpeGNU-23.12.eb
@@ -28,7 +28,7 @@ preconfigopts = 'export PAR_COMPILER_CXX=mpicxx; ' # required to build Conduit
 preconfigopts += 'pushd ../%(namelower)s%(version)s; mkdir -p third_party; '
 preconfigopts += "sed -i 's/== \"gcc/!= \"gcc/g' ./src/tools/dev/scripts/bv_support/bv_xdmf.sh; " # required to build xdmf
 
-preconfigopts += './src/tools/dev/scripts/build_visit --cc /usr/bin/gcc-12 --cxx /usr/bin/g++-12 --no-%(namelower)s --parallel --llvm --mesagl --vtk --vtk9 --makeflags -j32 --system-python --qwt --qt --silo --hdf5 --h5part --system-cmake --icet --ospray --ispc --embree --tbb --mfem --conduit --xdmf <<< "yes" && cp `hostname`.cmake ./src/config-site; mkdir build; cd build; '
+preconfigopts += './src/tools/dev/scripts/build_visit --cc /usr/bin/gcc-12 --cxx /usr/bin/g++-12 --no-%(namelower)s --parallel --llvm --mesagl --vtk --vtk9 --makeflags -j32 --system-python --qwt --qt --silo --hdf5 --system-cmake --icet --ospray --ispc --embree --tbb --mfem --conduit --xdmf <<< "yes" && cp `hostname`.cmake ./src/config-site; mkdir build; cd build; '
 
 configopts = "-DMPI_CXX_COMPILER=CC -DCMAKE_BUILD_TYPE=RelWithDebInfo -DVISIT_ENABLE_MANUALS=FALSE -DVISIT_ENABLE_DATA_MANUAL_EXAMPLES:BOOL=ON -DVISIT_INSTALL_THIRD_PARTY:BOOL=ON -DVISIT_SLIVR:BOOL=OFF -DVISIT_ENABLE_XDB:BOOL=OFF "
 


### PR DESCRIPTION
this fixes 3 things:

HDF5_HL libs are not getting installed
cray-python module is not loaded for run-time
H5part was missing