### PR TITLE
 [pilatus eiger] jupyterlab-4.2.3-cpeGNU-23.12 paths fix - lua

### DIFF
--- a/easybuild/easyconfigs/j/jupyterlab/jupyterlab-4.2.3-cpeGNU-23.12.eb
+++ b/easybuild/easyconfigs/j/jupyterlab/jupyterlab-4.2.3-cpeGNU-23.12.eb
@@ -77,7 +77,7 @@ modextrapaths = {
 }
 
 modluafooter = """
-append_path("JULIA_LOAD_PATH", "%(installdir)s/share/IJulia/environments/" .. os.getenv(EBJULIA_ENV_NAME))
+append_path("JULIA_LOAD_PATH", "%(installdir)s/share/IJulia/environments/" .. os.getenv("EBJULIA_ENV_NAME"))
 append_path("JULIA_DEPOT_PATH", "%(installdir)s/share/IJulia")
 """
 

--- a/easybuild/easyconfigs/j/jupyterlab/jupyterlab-4.2.3-cpeGNU-23.12.eb
+++ b/easybuild/easyconfigs/j/jupyterlab/jupyterlab-4.2.3-cpeGNU-23.12.eb
@@ -76,11 +76,9 @@ modextrapaths = {
     'JUPYTER_PATH': 'share/jupyter'
 }
 
-modtclfooter = """
-if { [ info exists ::env(EBJULIA_ENV_NAME) ] } {
-    append-path JULIA_LOAD_PATH "%(installdir)s/share/IJulia/environments/$::env(EBJULIA_ENV_NAME)"
-    append-path JULIA_DEPOT_PATH "%(installdir)s/share/IJulia"
-}
+modluafooter = """
+append_path("JULIA_LOAD_PATH", "%(installdir)s/share/IJulia/environments/" .. os.getenv(EBJULIA_ENV_NAME))
+append_path("JULIA_DEPOT_PATH", "%(installdir)s/share/IJulia")
 """
 
 modextravars = {


### PR DESCRIPTION
This pull request fixes Julia paths, appending IJulia paths rather than prepending:

eiger:
![image](https://github.com/user-attachments/assets/eab9680f-4411-4e05-b6da-4e873bfcb207)

pilatus:
![image](https://github.com/user-attachments/assets/6d395a46-6947-426d-b51d-fd78edf8f7d1)

