### PR TITLE
[eiger pilatus] Update reframe-cscs-tests

### DIFF
--- a/jenkins-builds/23.12-eiger
+++ b/jenkins-builds/23.12-eiger
@@ -5,7 +5,7 @@
  NCL-6.6.2.eb                         --set-default-module
  OOOPS-1.0.eb                         --set-default-module
  reframe-4.6.0.eb                     --set-default-module
- reframe-cscs-tests-24.07.eb          --set-default-module
+ reframe-cscs-tests-24.08.eb          --set-default-module
  singularity-3.6.4-eiger.eb
  GSL-2.7-cpeAMD-23.12.eb
  GSL-2.7-cpeCray-23.12.eb


### PR DESCRIPTION
Latest release 24.08 will be deployed as default modulefile on Eiger and Pilatus.